### PR TITLE
Add tray icon context menu for deactivating tunnel

### DIFF
--- a/WireSockUI/Forms/frmMain.Designer.cs
+++ b/WireSockUI/Forms/frmMain.Designer.cs
@@ -37,6 +37,7 @@ namespace WireSockUI.Forms
             this.cmiStatus = new System.Windows.Forms.ToolStripMenuItem();
             this.cmiAddresses = new System.Windows.Forms.ToolStripMenuItem();
             this.cmiSepTunnels = new System.Windows.Forms.ToolStripSeparator();
+            this.cmiDeactivateTunnel = new System.Windows.Forms.ToolStripMenuItem();
             this.cmiManageTunnels = new System.Windows.Forms.ToolStripMenuItem();
             this.cmiOpenTunnel = new System.Windows.Forms.ToolStripMenuItem();
             this.cmiSepBottom = new System.Windows.Forms.ToolStripSeparator();
@@ -101,6 +102,7 @@ namespace WireSockUI.Forms
             this.cmiStatus,
             this.cmiAddresses,
             this.cmiSepTunnels,
+            this.cmiDeactivateTunnel,
             this.cmiManageTunnels,
             this.cmiOpenTunnel,
             this.cmiSepBottom,
@@ -131,6 +133,15 @@ namespace WireSockUI.Forms
             this.cmiSepTunnels.Name = "cmiSepTunnels";
             this.resMenu.SetResourceKey(this.cmiSepTunnels, null);
             this.cmiSepTunnels.Size = new System.Drawing.Size(207, 6);
+            // 
+            // cmiDeactivateTunnel
+            // 
+            this.cmiDeactivateTunnel.Enabled = false;
+            this.cmiDeactivateTunnel.Name = "cmiDeactivateTunnel";
+            this.resMenu.SetResourceKey(this.cmiDeactivateTunnel, null);
+            this.cmiDeactivateTunnel.Size = new System.Drawing.Size(210, 22);
+            this.cmiDeactivateTunnel.Text = "Deactivate tunnel";
+            this.cmiDeactivateTunnel.Click += new System.EventHandler(this.OnDisconnectClick);
             // 
             // cmiManageTunnels
             // 
@@ -555,6 +566,7 @@ namespace WireSockUI.Forms
         private TableLayoutPanel layoutState;
         private ContextMenuStrip mnuContext;
         private ToolStripMenuItem cmiExit;
+        private ToolStripMenuItem cmiDeactivateTunnel;
         private ToolStripMenuItem cmiManageTunnels;
         private ToolStripSeparator cmiSepBottom;
         private ToolStripMenuItem cmiOpenTunnel;

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -489,8 +489,7 @@ namespace WireSockUI.Forms
             if (e != EventArgs.Empty)
             {
                 // Check if the current state is connected or connecting.
-                if ((_currentState == ConnectionState.Connected || _currentState == ConnectionState.Connecting) &&
-                    e != EventArgs.Empty)
+                if (_currentState == ConnectionState.Connected || _currentState == ConnectionState.Connecting)
                 {
                     var reconnect = false;
 
@@ -505,50 +504,25 @@ namespace WireSockUI.Forms
                     // Proceed with reconnecting if the reconnect flag is set.
                     if (!reconnect) return;
 
-                    // Set the tunnel mode based on the application settings.
-                    _wiresock.TunnelMode = Settings.Default.UseAdapter
-                        ? WireSockManager.Mode.VirtualAdapter
-                        : WireSockManager.Mode.Transparent;
-
-                    // Get the selected profile.
-                    var profile = lstProfiles.SelectedItems[0].Text;
-
-                    // Connect to the selected profile and update the state to connecting if successful.
-                    if (_wiresock.Connect(profile))
-                        UpdateState(ConnectionState.Connecting);
-                }
-                else
-                {
-                    // Set the tunnel mode based on the application settings.
-                    _wiresock.TunnelMode = Settings.Default.UseAdapter
-                        ? WireSockManager.Mode.VirtualAdapter
-                        : WireSockManager.Mode.Transparent;
-
-                    // Get the selected profile.
-                    var profile = lstProfiles.SelectedItems[0].Text;
-
-                    // Connect to the selected profile and update the state to connecting if successful.
-                    if (_wiresock.Connect(profile))
-                        UpdateState(ConnectionState.Connecting);
                 }
             }
             else
             {
                 // Update the state to disconnected.
                 UpdateState(ConnectionState.Disconnected);
-
-                // Set the tunnel mode based on the application settings.
-                _wiresock.TunnelMode = Settings.Default.UseAdapter
-                    ? WireSockManager.Mode.VirtualAdapter
-                    : WireSockManager.Mode.Transparent;
-
-                // Get the selected profile.
-                var profile = lstProfiles.SelectedItems[0].Text;
-
-                // Connect to the selected profile and update the state to connecting if successful.
-                if (_wiresock.Connect(profile))
-                    UpdateState(ConnectionState.Connecting);
             }
+
+            // Set the tunnel mode based on the application settings.
+            _wiresock.TunnelMode = Settings.Default.UseAdapter
+                ? WireSockManager.Mode.VirtualAdapter
+                : WireSockManager.Mode.Transparent;
+
+            // Get the selected profile.
+            var profile = lstProfiles.SelectedItems[0].Text;
+
+            // Connect to the selected profile and update the state to connecting if successful.
+            if (_wiresock.Connect(profile))
+                UpdateState(ConnectionState.Connecting);
         }
 
         private void OnWireSockLogMessage(WireSockManager.LogMessage logMessage)

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -245,6 +245,8 @@ namespace WireSockUI.Forms
                     btnActivate.Enabled = true;
                     imgStatus.Focus();
 
+                    this.cmiDeactivateTunnel.Enabled = true;
+
                     lstProfiles.Items[_wiresock.ProfileName].ImageKey = ConnectionState.Connecting.ToString();
 
                     trayIcon.Text = Resources.TrayActivating;
@@ -267,6 +269,8 @@ namespace WireSockUI.Forms
 
                     cmiAddresses.Text = txtAddresses.Text;
                     cmiAddresses.Visible = true;
+
+                    this.cmiDeactivateTunnel.Enabled = true;
 
                     foreach (ToolStripItem item in mnuContext.Items)
                         if (item is ToolStripMenuItem menuItem && Equals(menuItem.Tag, "tunnel"))
@@ -301,6 +305,8 @@ namespace WireSockUI.Forms
 
                     cmiAddresses.Text = string.Empty;
                     cmiAddresses.Visible = false;
+
+                    this.cmiDeactivateTunnel.Enabled = false;
 
                     foreach (ToolStripItem item in mnuContext.Items)
                         if (item is ToolStripMenuItem menuItem && Equals(menuItem.Tag, "tunnel"))
@@ -345,6 +351,11 @@ namespace WireSockUI.Forms
             else
                 MessageBox.Show(Resources.LastProfileNotFound, Resources.DialogAutoConnect, MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
+        }
+
+        private void OnDisconnectClick(object sender, EventArgs e)
+        {
+            UpdateState(ConnectionState.Disconnected);
         }
 
         private void OnExitClick(object sender, EventArgs e)

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -509,7 +509,7 @@ namespace WireSockUI.Forms
             else
             {
                 // Update the state to disconnected.
-                UpdateState(ConnectionState.Disconnected);
+                UpdateState(ConnectionState.Disconnected, false);
             }
 
             // Set the tunnel mode based on the application settings.


### PR DESCRIPTION
Fixes #19 

### Change:
- added tray context menu button
   - is disabled when not connected to tunnel
- cleaned up some duplicated code
- disabled notification for when disconnecting when not connected already