### PR TITLE
Add wgbooster kill switch toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ WireSock-specific directives may use the current SDK comment-extension syntax:
 
 Plain WireGuard keys are still parsed normally. WireSockUI validates common SDK fields such as script hooks, masking parameters, SOCKS5 settings, `BypassLanTraffic`, and profile-level `VirtualAdapterMode` while preserving the file-based profile workflow.
 
+The Settings dialog includes an optional Kill Switch toggle. When enabled, WireSockUI calls the `wgbooster.dll` network-lock API before creating the tunnel and clears the lock through normal tunnel cleanup when disconnecting. The option is off by default so existing SDK/minimal installations keep their current behavior.
+
 ## Compatibility Notes
 
-- The native `wgbooster.dll` ABI is expected to match the current SDK headers, including log levels and `drop_tunnel(..., preserve_network_lock)`.
+- The native `wgbooster.dll` ABI is expected to match the current SDK headers, including log levels, network-lock exports, and `drop_tunnel(..., preserve_network_lock)`.
 - `Any CPU` builds disable 32-bit preference, and the solution includes x64 mappings for direct use with the common 64-bit SDK install.
 - WireSockUI uses the same global direct-client event name as the C++ CLI/service to avoid running side by side with another direct SDK tunnel owner.
 - The newer WireSock Secure Connect service stack is intentionally out of scope for this project.

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -20,7 +20,8 @@ namespace WireSockUI.Tests
                 { "Profile rejects empty address list items", ProfileRejectsEmptyAddressListItems },
                 { "Profile validates Windows-safe profile names", ProfileValidatesWindowsSafeNames },
                 { "Parser strips WireSock directive prefixes", ParserStripsWireSockDirectivePrefixes },
-                { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions }
+                { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
+                { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi }
             };
 
             var failures = 0;
@@ -126,6 +127,12 @@ namespace WireSockUI.Tests
             new Profile(path);
         }
 
+        private static void NetworkLockEnumMatchesWgboosterAbi()
+        {
+            AssertEqual(0, (int)WireguardBoosterExports.WgbNetworkLockMode.Disabled);
+            AssertEqual(1, (int)WireguardBoosterExports.WgbNetworkLockMode.Enabled);
+        }
+
         private static string WriteConfig(string contents)
         {
             var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests");
@@ -168,6 +175,12 @@ namespace WireSockUI.Tests
         private static void AssertEqual(string expected, string actual)
         {
             if (!string.Equals(expected, actual, StringComparison.Ordinal))
+                throw new Exception($"Expected '{expected}', got '{actual}'.");
+        }
+
+        private static void AssertEqual(int expected, int actual)
+        {
+            if (expected != actual)
                 throw new Exception($"Expected '{expected}', got '{actual}'.");
         }
     }

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -736,7 +736,7 @@ namespace WireSockUI.Forms
                 if (!Settings.Default.EnableKillSwitch && WireSockManager.IsNetworkLockActive() &&
                     !WireSockManager.ResetNetworkLock())
                     MessageBox.Show(
-                        "Kill Switch network lock is active, but WireSockUI could not reset it. Disconnect or restart WireSock UI and try again.",
+                        Resources.KillSwitchResetError,
                         Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             catch (Exception ex)

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -716,7 +716,32 @@ namespace WireSockUI.Forms
                 form.Owner = this;
 
                 if (form.ShowDialog() == DialogResult.OK)
+                {
                     _wiresock.LogLevel = _wiresock.LogLevelSetting;
+                    ApplyKillSwitchSetting();
+                }
+            }
+        }
+
+        private void ApplyKillSwitchSetting()
+        {
+            try
+            {
+                if (_wiresock.HasTunnelHandle)
+                {
+                    _wiresock.KillSwitchEnabled = Settings.Default.EnableKillSwitch;
+                    return;
+                }
+
+                if (!Settings.Default.EnableKillSwitch && WireSockManager.IsNetworkLockActive() &&
+                    !WireSockManager.ResetNetworkLock())
+                    MessageBox.Show(
+                        "Kill Switch network lock is active, but WireSockUI could not reset it. Disconnect or restart WireSock UI and try again.",
+                        Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -729,7 +729,9 @@ namespace WireSockUI.Forms
             {
                 if (_wiresock.HasTunnelHandle)
                 {
-                    _wiresock.KillSwitchEnabled = Settings.Default.EnableKillSwitch;
+                    if (Settings.Default.EnableKillSwitch || _wiresock.KillSwitchEnabled)
+                        _wiresock.KillSwitchEnabled = Settings.Default.EnableKillSwitch;
+
                     return;
                 }
 

--- a/WireSockUI/Forms/frmSettings.Designer.cs
+++ b/WireSockUI/Forms/frmSettings.Designer.cs
@@ -177,7 +177,7 @@
             this.chkEnableKillSwitch.AutoSize = true;
             this.chkEnableKillSwitch.Location = new System.Drawing.Point(12, 194);
             this.chkEnableKillSwitch.Name = "chkEnableKillSwitch";
-            this.resControls.SetResourceKey(this.chkEnableKillSwitch, null);
+            this.resControls.SetResourceKey(this.chkEnableKillSwitch, "SettingsEnableKillSwitch");
             this.chkEnableKillSwitch.Size = new System.Drawing.Size(185, 17);
             this.chkEnableKillSwitch.TabIndex = 12;
             this.chkEnableKillSwitch.Text = "Enable Kill Switch (network lock)";

--- a/WireSockUI/Forms/frmSettings.Designer.cs
+++ b/WireSockUI/Forms/frmSettings.Designer.cs
@@ -40,6 +40,7 @@
             this.chkNotify = new System.Windows.Forms.CheckBox();
             this.resControls = new WireSockUI.Extensions.ControlTextExtender();
             this.chkDisableAutoAdmin = new System.Windows.Forms.CheckBox();
+            this.chkEnableKillSwitch = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.resControls)).BeginInit();
             this.SuspendLayout();
             // 
@@ -78,7 +79,7 @@
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(12, 254);
+            this.btnSave.Location = new System.Drawing.Point(12, 280);
             this.btnSave.Name = "btnSave";
             this.resControls.SetResourceKey(this.btnSave, "SettingsSave");
             this.btnSave.Size = new System.Drawing.Size(75, 25);
@@ -89,7 +90,7 @@
             // 
             // btnOpenFolder
             // 
-            this.btnOpenFolder.Location = new System.Drawing.Point(89, 254);
+            this.btnOpenFolder.Location = new System.Drawing.Point(89, 280);
             this.btnOpenFolder.Name = "btnOpenFolder";
             this.resControls.SetResourceKey(this.btnOpenFolder, "SettingsProfiles");
             this.btnOpenFolder.Size = new System.Drawing.Size(121, 25);
@@ -108,7 +109,7 @@
             "Info",
             "Debug",
             "All"});
-            this.ddlLogLevel.Location = new System.Drawing.Point(12, 217);
+            this.ddlLogLevel.Location = new System.Drawing.Point(12, 243);
             this.ddlLogLevel.Name = "ddlLogLevel";
             this.resControls.SetResourceKey(this.ddlLogLevel, null);
             this.ddlLogLevel.Size = new System.Drawing.Size(121, 21);
@@ -117,7 +118,7 @@
             // lblLogLevel
             // 
             this.lblLogLevel.AutoSize = true;
-            this.lblLogLevel.Location = new System.Drawing.Point(12, 201);
+            this.lblLogLevel.Location = new System.Drawing.Point(12, 227);
             this.lblLogLevel.Name = "lblLogLevel";
             this.resControls.SetResourceKey(this.lblLogLevel, "SettingsLogLevel");
             this.lblLogLevel.Size = new System.Drawing.Size(70, 13);
@@ -170,12 +171,23 @@
             this.chkDisableAutoAdmin.Size = new System.Drawing.Size(165, 17);
             this.chkDisableAutoAdmin.TabIndex = 11;
             this.chkDisableAutoAdmin.Text = "Disable Auto-Admin Elevation";
+            //
+            // chkEnableKillSwitch
+            //
+            this.chkEnableKillSwitch.AutoSize = true;
+            this.chkEnableKillSwitch.Location = new System.Drawing.Point(12, 194);
+            this.chkEnableKillSwitch.Name = "chkEnableKillSwitch";
+            this.resControls.SetResourceKey(this.chkEnableKillSwitch, null);
+            this.chkEnableKillSwitch.Size = new System.Drawing.Size(185, 17);
+            this.chkEnableKillSwitch.TabIndex = 12;
+            this.chkEnableKillSwitch.Text = "Enable Kill Switch (network lock)";
             // 
             // FrmSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(222, 291);
+            this.ClientSize = new System.Drawing.Size(222, 317);
+            this.Controls.Add(this.chkEnableKillSwitch);
             this.Controls.Add(this.chkDisableAutoAdmin);
             this.Controls.Add(this.chkNotify);
             this.Controls.Add(this.chkAutoUpdate);
@@ -214,5 +226,6 @@
         private System.Windows.Forms.CheckBox chkAutoUpdate;
         private System.Windows.Forms.CheckBox chkNotify;
         private System.Windows.Forms.CheckBox chkDisableAutoAdmin;
+        private System.Windows.Forms.CheckBox chkEnableKillSwitch;
     }
 }

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -25,6 +25,7 @@ namespace WireSockUI.Forms
             chkUseAdapter.Checked = Settings.Default.UseAdapter;
             chkNotify.Checked = Settings.Default.EnableNotifications;
             chkDisableAutoAdmin.Checked = Settings.Default.DisableAutoAdmin;
+            chkEnableKillSwitch.Checked = Settings.Default.EnableKillSwitch;
             ddlLogLevel.SelectedItem = Settings.Default.LogLevel;
             if (ddlLogLevel.SelectedItem == null)
                 ddlLogLevel.SelectedItem = "Error";
@@ -33,6 +34,8 @@ namespace WireSockUI.Forms
             {
                 chkUseAdapter.Enabled = false;
                 chkUseAdapter.Checked = false;
+                chkEnableKillSwitch.Enabled = false;
+                chkEnableKillSwitch.Checked = false;
 
                 // If autorun is enabled for admin users while we are not an admin, disable the checkbox
                 if (chkAutorun.Checked && !IsAutoRunForNonAdminEnabled())
@@ -292,6 +295,7 @@ namespace WireSockUI.Forms
             Settings.Default.UseAdapter = chkUseAdapter.Checked;
             Settings.Default.EnableNotifications = chkNotify.Checked;
             Settings.Default.DisableAutoAdmin = chkDisableAutoAdmin.Checked;
+            Settings.Default.EnableKillSwitch = chkEnableKillSwitch.Checked;
             Settings.Default.LogLevel = ddlLogLevel.SelectedItem as string;
 
             Settings.Default.Save();

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -34,7 +34,9 @@ namespace WireSockUI.Forms
             {
                 chkUseAdapter.Enabled = false;
                 chkUseAdapter.Checked = false;
-                chkEnableKillSwitch.Enabled = false;
+
+                // Non-elevated users may turn an already-enabled Kill Switch off, but cannot enable it.
+                chkEnableKillSwitch.Enabled = chkEnableKillSwitch.Checked;
 
                 // If autorun is enabled for admin users while we are not an admin, disable the checkbox
                 if (chkAutorun.Checked && !IsAutoRunForNonAdminEnabled())

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -35,7 +35,6 @@ namespace WireSockUI.Forms
                 chkUseAdapter.Enabled = false;
                 chkUseAdapter.Checked = false;
                 chkEnableKillSwitch.Enabled = false;
-                chkEnableKillSwitch.Checked = false;
 
                 // If autorun is enabled for admin users while we are not an admin, disable the checkbox
                 if (chkAutorun.Checked && !IsAutoRunForNonAdminEnabled())

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -37,6 +37,8 @@ namespace WireSockUI.Forms
 
                 // Non-elevated users may turn an already-enabled Kill Switch off, but cannot enable it.
                 chkEnableKillSwitch.Enabled = chkEnableKillSwitch.Checked;
+                if (chkEnableKillSwitch.Enabled)
+                    chkEnableKillSwitch.CheckedChanged += OnKillSwitchCheckedChanged;
 
                 // If autorun is enabled for admin users while we are not an admin, disable the checkbox
                 if (chkAutorun.Checked && !IsAutoRunForNonAdminEnabled())
@@ -49,6 +51,12 @@ namespace WireSockUI.Forms
             chkAutorun.Checked =
                 IsCurrentProcessElevated() ? IsAutoRunForAdminEnabled() : IsAutoRunForNonAdminEnabled();
             Settings.Default.AutoRun = chkAutorun.Checked;
+        }
+
+        private void OnKillSwitchCheckedChanged(object sender, EventArgs e)
+        {
+            if (!chkEnableKillSwitch.Checked)
+                chkEnableKillSwitch.Enabled = false;
         }
 
         private static bool IsCurrentProcessElevated()

--- a/WireSockUI/Native/WireguardBoosterExports.cs
+++ b/WireSockUI/Native/WireguardBoosterExports.cs
@@ -17,6 +17,12 @@ namespace WireSockUI.Native
             All = 255
         }
 
+        public enum WgbNetworkLockMode
+        {
+            Disabled = 0,
+            Enabled = 1
+        }
+
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern IntPtr wgb_get_handle(LogPrinter logPrinter, WgbLogLevel level, bool enableTrafficCapture);
 
@@ -54,6 +60,13 @@ namespace WireSockUI.Native
         public static extern bool wgb_get_tunnel_active(IntPtr wgboosterHandle);
 
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool wgb_set_network_lock_mode(IntPtr wgboosterHandle, WgbNetworkLockMode mode);
+
+        [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        public static extern WgbNetworkLockMode wgb_get_network_lock_mode(IntPtr wgboosterHandle);
+
+        [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern IntPtr
             wgbp_get_handle(LogPrinter logPrinter, WgbLogLevel level, bool enableTrafficCapture);
 
@@ -89,6 +102,21 @@ namespace WireSockUI.Native
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgbp_get_tunnel_active(IntPtr wgboosterHandle);
+
+        [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool wgbp_set_network_lock_mode(IntPtr wgboosterHandle, WgbNetworkLockMode mode);
+
+        [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        public static extern WgbNetworkLockMode wgbp_get_network_lock_mode(IntPtr wgboosterHandle);
+
+        [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool wg_reset_network_lock();
+
+        [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool wg_is_network_lock_active();
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         public struct WgbStats

--- a/WireSockUI/Properties/Resources.Designer.cs
+++ b/WireSockUI/Properties/Resources.Designer.cs
@@ -458,6 +458,15 @@ namespace WireSockUI.Properties {
                 return ResourceManager.GetString("LastProfileNotFound", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Kill Switch network lock is active, but WireSockUI could not reset it. Disconnect or restart WireSock UI and try again..
+        /// </summary>
+        internal static string KillSwitchResetError {
+            get {
+                return ResourceManager.GetString("KillSwitchResetError", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to yyyy-MM-dd HH:mm:ss.fff.
@@ -708,6 +717,15 @@ namespace WireSockUI.Properties {
         internal static string SettingsAutoUpdate {
             get {
                 return ResourceManager.GetString("SettingsAutoUpdate", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Kill Switch (network lock).
+        /// </summary>
+        internal static string SettingsEnableKillSwitch {
+            get {
+                return ResourceManager.GetString("SettingsEnableKillSwitch", resourceCulture);
             }
         }
         

--- a/WireSockUI/Properties/Resources.Designer.cs
+++ b/WireSockUI/Properties/Resources.Designer.cs
@@ -460,7 +460,7 @@ namespace WireSockUI.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Kill Switch network lock is active, but WireSockUI could not reset it. Disconnect or restart WireSock UI and try again..
+        ///   Looks up a localized string similar to Kill Switch network lock is active, but WireSock UI could not reset it. Disconnect or restart WireSock UI and try again..
         /// </summary>
         internal static string KillSwitchResetError {
             get {

--- a/WireSockUI/Properties/Resources.resx
+++ b/WireSockUI/Properties/Resources.resx
@@ -256,6 +256,9 @@
   <data name="LastProfileNotFound" xml:space="preserve">
     <value>Last saved config not found.</value>
   </data>
+  <data name="KillSwitchResetError" xml:space="preserve">
+    <value>Kill Switch network lock is active, but WireSockUI could not reset it. Disconnect or restart WireSock UI and try again.</value>
+  </data>
   <data name="LogTimestampFormat" xml:space="preserve">
     <value>yyyy-MM-dd HH:mm:ss.fff</value>
   </data>
@@ -339,6 +342,9 @@
   </data>
   <data name="SettingsAutoUpdate" xml:space="preserve">
     <value>Check online for updates</value>
+  </data>
+  <data name="SettingsEnableKillSwitch" xml:space="preserve">
+    <value>Enable Kill Switch (network lock)</value>
   </data>
   <data name="SettingsLogLevel" xml:space="preserve">
     <value>Log level</value>

--- a/WireSockUI/Properties/Resources.resx
+++ b/WireSockUI/Properties/Resources.resx
@@ -257,7 +257,7 @@
     <value>Last saved config not found.</value>
   </data>
   <data name="KillSwitchResetError" xml:space="preserve">
-    <value>Kill Switch network lock is active, but WireSockUI could not reset it. Disconnect or restart WireSock UI and try again.</value>
+    <value>Kill Switch network lock is active, but WireSock UI could not reset it. Disconnect or restart WireSock UI and try again.</value>
   </data>
   <data name="LogTimestampFormat" xml:space="preserve">
     <value>yyyy-MM-dd HH:mm:ss.fff</value>

--- a/WireSockUI/Properties/Settings.Designer.cs
+++ b/WireSockUI/Properties/Settings.Designer.cs
@@ -136,5 +136,20 @@ namespace WireSockUI.Properties {
                 this["DisableAutoAdmin"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool EnableKillSwitch
+        {
+            get
+            {
+                return ((bool)(this["EnableKillSwitch"]));
+            }
+            set
+            {
+                this["EnableKillSwitch"] = value;
+            }
+        }
     }
 }

--- a/WireSockUI/Properties/Settings.settings
+++ b/WireSockUI/Properties/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="DisableAutoAdmin" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="EnableKillSwitch" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -106,6 +106,8 @@ namespace WireSockUI
                             _dropTunnel = wgbp_drop_tunnel;
                             _tunnelActive = wgbp_get_tunnel_active;
                             _tunnelState = wgbp_get_tunnel_state;
+                            _setNetworkLockMode = wgbp_set_network_lock_mode;
+                            _getNetworkLockMode = wgbp_get_network_lock_mode;
                             break;
                         default:
                             _getHandle = wgb_get_handle;
@@ -116,6 +118,8 @@ namespace WireSockUI
                             _dropTunnel = wgb_drop_tunnel;
                             _tunnelActive = wgb_get_tunnel_active;
                             _tunnelState = wgb_get_tunnel_state;
+                            _setNetworkLockMode = wgb_set_network_lock_mode;
+                            _getNetworkLockMode = wgb_get_network_lock_mode;
                             break;
                     }
 
@@ -208,6 +212,42 @@ namespace WireSockUI
         public string ProfileName { get; private set; }
 
         public string LastError { get; private set; }
+
+        public bool KillSwitchEnabled
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    if (_handle == IntPtr.Zero || _getNetworkLockMode == null)
+                        return false;
+
+                    try
+                    {
+                        return _getNetworkLockMode(_handle) == WgbNetworkLockMode.Enabled;
+                    }
+                    catch (Exception ex)
+                    {
+                        PrintLog($"Failed to query kill switch network lock mode: {ex.Message}");
+                        return false;
+                    }
+                }
+            }
+            set
+            {
+                lock (_syncRoot)
+                {
+                    ThrowIfDisposed();
+
+                    if (_handle == IntPtr.Zero)
+                        throw new InvalidOperationException("Kill Switch mode cannot be changed before a tunnel handle is allocated.");
+
+                    if (!SetNetworkLockMode(value))
+                        throw new InvalidOperationException(
+                            LastError ?? "Failed to update Kill Switch network lock mode.");
+                }
+            }
+        }
 
         /// <summary>
         ///     Disposes the GCHandle for the log printer delegate.
@@ -380,6 +420,12 @@ namespace WireSockUI
                     if (_handle == IntPtr.Zero)
                         return ShowTunnelError(Resources.TunnelErrorManager);
 
+                    if (Settings.Default.EnableKillSwitch && !SetNetworkLockMode(true))
+                    {
+                        DropCurrentHandle(true);
+                        return false;
+                    }
+
                     if (!_createTunnelFromFile(_handle, profilePath))
                     {
                         ShowTunnelError(Resources.TunnelErrorCreate);
@@ -537,6 +583,60 @@ namespace WireSockUI
                 throw new ObjectDisposedException(nameof(WireSockManager));
         }
 
+        private bool SetNetworkLockMode(bool enabled)
+        {
+            try
+            {
+                if (_setNetworkLockMode == null)
+                    return ShowTunnelError("Failed to update Kill Switch network lock mode.",
+                        "The loaded wgbooster.dll does not expose network lock support.");
+
+                var mode = enabled ? WgbNetworkLockMode.Enabled : WgbNetworkLockMode.Disabled;
+                if (_setNetworkLockMode(_handle, mode))
+                    return true;
+
+                return ShowTunnelError("Failed to update Kill Switch network lock mode.",
+                    GetLastNativeErrorOrDefault("native set_network_lock_mode returned false."));
+            }
+            catch (EntryPointNotFoundException ex)
+            {
+                return ShowTunnelError("Failed to update Kill Switch network lock mode.",
+                    $"The loaded wgbooster.dll does not expose network lock support. {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                return ShowTunnelError("Failed to update Kill Switch network lock mode.", ex.Message);
+            }
+        }
+
+        public static bool ResetNetworkLock()
+        {
+            try
+            {
+                return wg_reset_network_lock();
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static bool IsNetworkLockActive()
+        {
+            try
+            {
+                return wg_is_network_lock_active();
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         private bool DropCurrentHandle(bool logFailure, bool clearOnFailure = false)
         {
             if (_handle == IntPtr.Zero)
@@ -587,6 +687,10 @@ namespace WireSockUI
 
         private delegate WgbStats TunnelState(IntPtr handle);
 
+        private delegate bool SetNetworkLockModeAction(IntPtr handle, WgbNetworkLockMode mode);
+
+        private delegate WgbNetworkLockMode GetNetworkLockModeAction(IntPtr handle);
+
         private GetHandle _getHandle;
         private SetLogLevel _setLogLevel;
         private CreateTunnelFromFile _createTunnelFromFile;
@@ -595,6 +699,8 @@ namespace WireSockUI
         private DropTunnelAction _dropTunnel;
         private TunnelAction _tunnelActive;
         private TunnelState _tunnelState;
+        private SetNetworkLockModeAction _setNetworkLockMode;
+        private GetNetworkLockModeAction _getNetworkLockMode;
 
         private Mode _adapterMode;
 

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -422,7 +422,7 @@ namespace WireSockUI
 
                     if (Settings.Default.EnableKillSwitch && !SetNetworkLockMode(true))
                     {
-                        DropCurrentHandle(true);
+                        DropCurrentHandle(true, true);
                         return false;
                     }
 
@@ -617,7 +617,7 @@ namespace WireSockUI
             }
             catch (EntryPointNotFoundException)
             {
-                return true;
+                return false;
             }
             catch
             {

--- a/WireSockUI/app.config
+++ b/WireSockUI/app.config
@@ -38,6 +38,9 @@
 			<setting name="DisableAutoAdmin" serializeAs="String">
 				<value>False</value>
 			</setting>
+			<setting name="EnableKillSwitch" serializeAs="String">
+				<value>False</value>
+			</setting>
 		</WireSockUI.Properties.Settings>
 	</userSettings>
 </configuration>


### PR DESCRIPTION
Summary:
- Add a Settings toggle for wgbooster network-lock / Kill Switch, default off for existing installs.
- Bind the basic and Pro wgbooster network-lock exports and apply the setting before tunnel creation or immediately to an active handle after Settings save.
- Reset an active global network lock when the toggle is disabled without an active handle, document the behavior, and add an ABI enum test.

Validation:
- git diff --check
- dotnet build WireSockUI.sln (clean temp copy; direct workspace build hit stale obj ACLs)
- WireSockUI.Tests.exe (Debug, clean temp copy)
- dotnet build WireSockUI.sln -c Release -p:Platform=x64 (clean temp copy)
- WireSockUI.Tests.exe (Release, clean temp copy)