### PR TITLE
Require elevation for WireSock driver access

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ WireSockUI does not talk to the newer WireSock Secure Connect service API. Keep 
 - Windows with a matching-architecture WireSock SDK installation.
 - `wgbooster.dll` available next to `WireSockUI.exe` or installed through the WireSock SDK/minimal installer.
 - The WireSock driver installed and usable by the current system.
-- Administrator privileges when the selected tunnel mode or driver operations require elevation.
+- Administrator privileges. Starting with WireSock Secure Connect v3, the driver interface is available only to elevated users, so WireSockUI now always starts elevated.
 
 At startup WireSockUI looks for `wgbooster.dll` in this order:
 
@@ -55,7 +55,7 @@ The single-node `-m:1` solution build avoids a silent MSBuild failure that can h
 ## Remaining Runtime Risks
 
 - A clean build does not prove that the installed driver and SDK DLL are present or compatible on the target machine.
-- Tunnel start/stop still depends on driver state, Windows networking permissions, and elevation.
+- Tunnel start/stop still depends on driver state and Windows networking permissions after elevation succeeds.
 - The `WireSockUI.Tests` harness covers focused parser/profile validation scenarios, but native driver and `wgbooster.dll` lifecycle behavior still needs runtime validation on a machine with the SDK installed.
 
 ## License

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -63,27 +62,6 @@ namespace WireSockUI.Forms
         {
             InitializeComponent();
 
-            // Don't try to elevate when running under debugger
-            if (!Debugger.IsAttached)
-                if (!IsCurrentProcessElevated() && !Settings.Default.DisableAutoAdmin)
-                    try
-                    {
-                        var startInfo = new ProcessStartInfo
-                        {
-                            UseShellExecute = true,
-                            WorkingDirectory = Environment.CurrentDirectory,
-                            FileName = Application.ExecutablePath,
-                            Verb = "runas"
-                        };
-                        Process.Start(startInfo);
-                        Environment.Exit(1);
-                    }
-                    catch
-                    {
-                        // If the user refused the elevation, or an error occurred
-                        // MessageBox.Show("Unable to run as administrator. Continuing as normal user.");
-                    }
-
             if (IsApplicationAlreadyRunning())
             {
                 MessageBox.Show(Resources.AlreadyRunningMessage, Resources.AlreadyRunningTitle, MessageBoxButtons.OK,
@@ -123,15 +101,6 @@ namespace WireSockUI.Forms
 
             // Update the list of available configurations.
             LoadProfiles();
-        }
-
-        private static bool IsCurrentProcessElevated()
-        {
-            using (var identity = WindowsIdentity.GetCurrent())
-            {
-                var principal = new WindowsPrincipal(identity);
-                return principal.IsInRole(WindowsBuiltInRole.Administrator);
-            }
         }
 
         private static bool SleepUntilCancelled(BackgroundWorker worker, int milliseconds)
@@ -1010,13 +979,9 @@ namespace WireSockUI.Forms
                         return;
                     }
 
-                    if (IsCurrentProcessElevated())
-                        // Set the tunnel mode based on the application settings and profile override.
-                        _wiresock.TunnelMode = useAdapter
-                            ? WireSockManager.Mode.VirtualAdapter
-                            : WireSockManager.Mode.Transparent;
-                    else
-                        _wiresock.TunnelMode = WireSockManager.Mode.Transparent;
+                    _wiresock.TunnelMode = useAdapter
+                        ? WireSockManager.Mode.VirtualAdapter
+                        : WireSockManager.Mode.Transparent;
                 }
                 catch (Exception ex)
                 {

--- a/WireSockUI/Forms/frmSettings.Designer.cs
+++ b/WireSockUI/Forms/frmSettings.Designer.cs
@@ -39,7 +39,6 @@
             this.chkAutoUpdate = new System.Windows.Forms.CheckBox();
             this.chkNotify = new System.Windows.Forms.CheckBox();
             this.resControls = new WireSockUI.Extensions.ControlTextExtender();
-            this.chkDisableAutoAdmin = new System.Windows.Forms.CheckBox();
             this.chkEnableKillSwitch = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.resControls)).BeginInit();
             this.SuspendLayout();
@@ -79,7 +78,7 @@
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(12, 280);
+            this.btnSave.Location = new System.Drawing.Point(12, 254);
             this.btnSave.Name = "btnSave";
             this.resControls.SetResourceKey(this.btnSave, "SettingsSave");
             this.btnSave.Size = new System.Drawing.Size(75, 25);
@@ -90,7 +89,7 @@
             // 
             // btnOpenFolder
             // 
-            this.btnOpenFolder.Location = new System.Drawing.Point(89, 280);
+            this.btnOpenFolder.Location = new System.Drawing.Point(89, 254);
             this.btnOpenFolder.Name = "btnOpenFolder";
             this.resControls.SetResourceKey(this.btnOpenFolder, "SettingsProfiles");
             this.btnOpenFolder.Size = new System.Drawing.Size(121, 25);
@@ -109,7 +108,7 @@
             "Info",
             "Debug",
             "All"});
-            this.ddlLogLevel.Location = new System.Drawing.Point(12, 243);
+            this.ddlLogLevel.Location = new System.Drawing.Point(12, 217);
             this.ddlLogLevel.Name = "ddlLogLevel";
             this.resControls.SetResourceKey(this.ddlLogLevel, null);
             this.ddlLogLevel.Size = new System.Drawing.Size(121, 21);
@@ -118,7 +117,7 @@
             // lblLogLevel
             // 
             this.lblLogLevel.AutoSize = true;
-            this.lblLogLevel.Location = new System.Drawing.Point(12, 227);
+            this.lblLogLevel.Location = new System.Drawing.Point(12, 201);
             this.lblLogLevel.Name = "lblLogLevel";
             this.resControls.SetResourceKey(this.lblLogLevel, "SettingsLogLevel");
             this.lblLogLevel.Size = new System.Drawing.Size(70, 13);
@@ -162,33 +161,22 @@
             // 
             this.resControls.ResourceClassName = "WireSockUI.Properties.Resources";
             // 
-            // chkDisableAutoAdmin
-            // 
-            this.chkDisableAutoAdmin.AutoSize = true;
-            this.chkDisableAutoAdmin.Location = new System.Drawing.Point(12, 168);
-            this.chkDisableAutoAdmin.Name = "chkDisableAutoAdmin";
-            this.resControls.SetResourceKey(this.chkDisableAutoAdmin, null);
-            this.chkDisableAutoAdmin.Size = new System.Drawing.Size(165, 17);
-            this.chkDisableAutoAdmin.TabIndex = 11;
-            this.chkDisableAutoAdmin.Text = "Disable Auto-Admin Elevation";
-            //
             // chkEnableKillSwitch
             //
             this.chkEnableKillSwitch.AutoSize = true;
-            this.chkEnableKillSwitch.Location = new System.Drawing.Point(12, 194);
+            this.chkEnableKillSwitch.Location = new System.Drawing.Point(12, 168);
             this.chkEnableKillSwitch.Name = "chkEnableKillSwitch";
             this.resControls.SetResourceKey(this.chkEnableKillSwitch, "SettingsEnableKillSwitch");
             this.chkEnableKillSwitch.Size = new System.Drawing.Size(185, 17);
-            this.chkEnableKillSwitch.TabIndex = 12;
+            this.chkEnableKillSwitch.TabIndex = 11;
             this.chkEnableKillSwitch.Text = "Enable Kill Switch (network lock)";
             // 
             // FrmSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(222, 317);
+            this.ClientSize = new System.Drawing.Size(222, 291);
             this.Controls.Add(this.chkEnableKillSwitch);
-            this.Controls.Add(this.chkDisableAutoAdmin);
             this.Controls.Add(this.chkNotify);
             this.Controls.Add(this.chkAutoUpdate);
             this.Controls.Add(this.lblLogLevel);
@@ -225,7 +213,6 @@
         private Extensions.ControlTextExtender resControls;
         private System.Windows.Forms.CheckBox chkAutoUpdate;
         private System.Windows.Forms.CheckBox chkNotify;
-        private System.Windows.Forms.CheckBox chkDisableAutoAdmin;
         private System.Windows.Forms.CheckBox chkEnableKillSwitch;
     }
 }

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -10,13 +10,16 @@ namespace WireSockUI.Forms
 {
     public partial class FrmSettings : Form
     {
+        private readonly bool _initialAutoRun;
+
         public FrmSettings()
         {
             InitializeComponent();
 
             Icon = Resources.ico;
 
-            chkAutorun.Checked = IsAutoRunEnabled();
+            _initialAutoRun = IsAutoRunEnabled();
+            chkAutorun.Checked = _initialAutoRun;
             chkAutoMinimize.Checked = Settings.Default.AutoMinimize;
             chkAutoConnect.Checked = Settings.Default.AutoConnect;
             chkAutoUpdate.Checked = Settings.Default.AutoUpdate;
@@ -176,7 +179,7 @@ namespace WireSockUI.Forms
 
         private void OnSaveClick(object sender, EventArgs e)
         {
-            if (Settings.Default.AutoRun != chkAutorun.Checked)
+            if (_initialAutoRun != chkAutorun.Checked)
             {
                 var autoRunUpdated = chkAutorun.Checked ? EnableAutoRun() : DisableAutoRun();
                 if (!autoRunUpdated)
@@ -184,10 +187,9 @@ namespace WireSockUI.Forms
                     DialogResult = DialogResult.None;
                     return;
                 }
-
-                Settings.Default.AutoRun = chkAutorun.Checked;
             }
 
+            Settings.Default.AutoRun = chkAutorun.Checked;
             Settings.Default.AutoConnect = chkAutoConnect.Checked;
             Settings.Default.AutoMinimize = chkAutoMinimize.Checked;
             Settings.Default.AutoUpdate = chkAutoUpdate.Checked;

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -2,10 +2,8 @@
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Security.Principal;
 using System.Windows.Forms;
 using Microsoft.Win32.TaskScheduler;
-using WireSockUI.Native;
 using WireSockUI.Properties;
 
 namespace WireSockUI.Forms
@@ -18,53 +16,16 @@ namespace WireSockUI.Forms
 
             Icon = Resources.ico;
 
-            chkAutorun.Checked = Settings.Default.AutoRun;
+            chkAutorun.Checked = IsAutoRunEnabled();
             chkAutoMinimize.Checked = Settings.Default.AutoMinimize;
             chkAutoConnect.Checked = Settings.Default.AutoConnect;
             chkAutoUpdate.Checked = Settings.Default.AutoUpdate;
             chkUseAdapter.Checked = Settings.Default.UseAdapter;
             chkNotify.Checked = Settings.Default.EnableNotifications;
-            chkDisableAutoAdmin.Checked = Settings.Default.DisableAutoAdmin;
             chkEnableKillSwitch.Checked = Settings.Default.EnableKillSwitch;
             ddlLogLevel.SelectedItem = Settings.Default.LogLevel;
             if (ddlLogLevel.SelectedItem == null)
                 ddlLogLevel.SelectedItem = "Error";
-
-            if (!IsCurrentProcessElevated())
-            {
-                chkUseAdapter.Enabled = false;
-                chkUseAdapter.Checked = false;
-
-                // Non-elevated users may turn an already-enabled Kill Switch off, but cannot enable it.
-                chkEnableKillSwitch.Enabled = chkEnableKillSwitch.Checked;
-                if (chkEnableKillSwitch.Enabled)
-                    chkEnableKillSwitch.CheckedChanged += OnKillSwitchCheckedChanged;
-
-                // If autorun is enabled for admin users while we are not an admin, disable the checkbox
-                if (chkAutorun.Checked && !IsAutoRunForNonAdminEnabled())
-                {
-                    chkAutorun.Enabled = false;
-                    return;
-                }
-            }
-
-            chkAutorun.Checked =
-                IsCurrentProcessElevated() ? IsAutoRunForAdminEnabled() : IsAutoRunForNonAdminEnabled();
-        }
-
-        private void OnKillSwitchCheckedChanged(object sender, EventArgs e)
-        {
-            if (!chkEnableKillSwitch.Checked)
-                chkEnableKillSwitch.Enabled = false;
-        }
-
-        private static bool IsCurrentProcessElevated()
-        {
-            using (var identity = WindowsIdentity.GetCurrent())
-            {
-                var principal = new WindowsPrincipal(identity);
-                return principal.IsInRole(WindowsBuiltInRole.Administrator);
-            }
         }
 
         private void OnProfilesFolderClick(object sender, EventArgs e)
@@ -84,6 +45,26 @@ namespace WireSockUI.Forms
             return Assembly.GetExecutingAssembly().GetName().Name;
         }
 
+        private static string GetLegacyStartupShortcutPath()
+        {
+            var startupFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
+            return Path.Combine(startupFolderPath, $"{GetAppName()}.lnk");
+        }
+
+        private static void DeleteLegacyStartupShortcutIfPresent()
+        {
+            try
+            {
+                var shortcutPath = GetLegacyStartupShortcutPath();
+                if (File.Exists(shortcutPath))
+                    File.Delete(shortcutPath);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to delete legacy Startup shortcut: {ex.Message}");
+            }
+        }
+
         /// <summary>
         ///     Checks if the auto-run feature is enabled for the current application.
         /// </summary>
@@ -94,7 +75,7 @@ namespace WireSockUI.Forms
         ///     This method uses the TaskService to find a task with the same name as the current application.
         ///     If such a task is found, it means that the auto-run feature is enabled.
         /// </remarks>
-        private static bool IsAutoRunForAdminEnabled()
+        private static bool IsAutoRunEnabled()
         {
             try
             {
@@ -111,32 +92,6 @@ namespace WireSockUI.Forms
         }
 
         /// <summary>
-        ///     Checks if the auto-run feature is enabled for the current application for non-admin users.
-        /// </summary>
-        /// <returns>
-        ///     Returns true if the auto-run feature is enabled, otherwise false.
-        /// </returns>
-        /// <remarks>
-        ///     This method checks if a shortcut to the application exists in the Startup folder.
-        ///     If such a shortcut is found, it means that the auto-run feature is enabled for non-admin users.
-        /// </remarks>
-        private static bool IsAutoRunForNonAdminEnabled()
-        {
-            try
-            {
-                var startupFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
-                var shortcutPath = Path.Combine(startupFolderPath, $"{GetAppName()}.lnk");
-
-                return File.Exists(shortcutPath);
-            }
-            catch (Exception ex)
-            {
-                ShowSettingsError(Resources.SettingsAutoRunCheckError, ex);
-                return false;
-            }
-        }
-
-        /// <summary>
         ///     Enables the auto-run feature for the current application with administrative privileges.
         /// </summary>
         /// <remarks>
@@ -147,7 +102,7 @@ namespace WireSockUI.Forms
         ///     switches to battery power, to wake the computer if needed, and to not stop when the computer ceases to be idle.
         ///     If an error occurs while enabling auto-run, an error message is displayed.
         /// </remarks>
-        private static bool EnableAutoRunForAdmin()
+        private static bool EnableAutoRun()
         {
             try
             {
@@ -160,7 +115,7 @@ namespace WireSockUI.Forms
 
                     td.Triggers.Add(new LogonTrigger()); // Trigger on logon
 
-                    var appPath = Assembly.GetExecutingAssembly().Location;
+                    var appPath = Application.ExecutablePath;
                     td.Actions.Add(new ExecAction(appPath)); // Path to the executable
 
                     // Set power and idle options
@@ -175,6 +130,7 @@ namespace WireSockUI.Forms
                     ts.RootFolder.RegisterTaskDefinition(GetAppName(), td);
                 }
 
+                DeleteLegacyStartupShortcutIfPresent();
                 return true;
             }
             catch (Exception ex)
@@ -192,7 +148,7 @@ namespace WireSockUI.Forms
         ///     If such a task is found and deleted, it means that the auto-run feature is disabled.
         ///     If an error occurs while disabling auto-run, an error message is displayed.
         /// </remarks>
-        private static bool DisableAutoRunForAdmin()
+        private static bool DisableAutoRun()
         {
             try
             {
@@ -202,80 +158,12 @@ namespace WireSockUI.Forms
                         ts.RootFolder.DeleteTask(GetAppName(), false);
                 }
 
+                DeleteLegacyStartupShortcutIfPresent();
                 return true;
             }
             catch (Exception ex)
             {
                 ShowSettingsError(Resources.SettingsAutoRunDisableAdminError, ex);
-                return false;
-            }
-        }
-
-        /// <summary>
-        ///     Enables the auto-run feature for the current application for non-admin users.
-        /// </summary>
-        /// <remarks>
-        ///     This method creates a shortcut to the application in the Startup folder.
-        ///     The shortcut is created using the ShellLink class and is saved to the Startup folder.
-        ///     If the shortcut is created successfully, a success message is displayed.
-        ///     If an error occurs while enabling auto-run, an error message is displayed.
-        /// </remarks>
-        private static bool EnableAutoRunForNonAdmin()
-        {
-            try
-            {
-                var appPath = Application.ExecutablePath;
-                var startupFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
-                var shortcutPath = Path.Combine(startupFolderPath, GetAppName() + ".lnk");
-
-                using (var link = new ShellLink())
-                {
-                    link.TargetPath = appPath;
-                    link.WorkingDirectory = AppContext.BaseDirectory;
-
-                    link.Save(shortcutPath);
-                }
-
-                //MessageBox.Show("Auto-run enabled successfully.", "Success", MessageBoxButtons.OK,
-                //    MessageBoxIcon.Information);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                ShowSettingsError(Resources.SettingsAutoRunEnableUserError, ex);
-                return false;
-            }
-        }
-
-        /// <summary>
-        ///     Disables the auto-run feature for the current application for non-admin users.
-        /// </summary>
-        /// <remarks>
-        ///     This method deletes the shortcut to the application in the Startup folder.
-        ///     If the shortcut is found and deleted, it means that the auto-run feature is disabled for non-admin users.
-        ///     If the shortcut is not found, an info message is displayed.
-        ///     If an error occurs while disabling auto-run, an error message is displayed.
-        /// </remarks>
-        private static bool DisableAutoRunForNonAdmin()
-        {
-            try
-            {
-                var startupFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
-                var shortcutPath = Path.Combine(startupFolderPath, GetAppName() + ".lnk");
-
-                if (File.Exists(shortcutPath)) File.Delete(shortcutPath);
-                //MessageBox.Show("Auto-run disabled successfully.", "Success", MessageBoxButtons.OK,
-                //    MessageBoxIcon.Information);
-                //else
-                //{
-                //    MessageBox.Show("Auto-run shortcut not found.", "Info", MessageBoxButtons.OK,
-                //        MessageBoxIcon.Information);
-                //}
-                return true;
-            }
-            catch (Exception ex)
-            {
-                ShowSettingsError(Resources.SettingsAutoRunDisableUserError, ex);
                 return false;
             }
         }
@@ -286,42 +174,11 @@ namespace WireSockUI.Forms
                 MessageBoxIcon.Error);
         }
 
-        private static bool DisableAutoRunForNonAdminIfPresent()
-        {
-            return !IsAutoRunForNonAdminEnabled() || DisableAutoRunForNonAdmin();
-        }
-
         private void OnSaveClick(object sender, EventArgs e)
         {
             if (Settings.Default.AutoRun != chkAutorun.Checked)
             {
-                var autoRunUpdated = false;
-
-                if (!chkAutorun.Checked)
-                {
-                    if (IsCurrentProcessElevated())
-                    {
-                        // Under Administrator ensure that non-admin AutoRun is also disabled
-                        autoRunUpdated = DisableAutoRunForNonAdminIfPresent() && DisableAutoRunForAdmin();
-                    }
-                    else
-                    {
-                        autoRunUpdated = DisableAutoRunForNonAdmin();
-                    }
-                }
-                else
-                {
-                    if (IsCurrentProcessElevated())
-                    {
-                        // Under Administrator ensure that non-admin AutoRun is disabled
-                        autoRunUpdated = DisableAutoRunForNonAdminIfPresent() && EnableAutoRunForAdmin();
-                    }
-                    else
-                    {
-                        autoRunUpdated = EnableAutoRunForNonAdmin();
-                    }
-                }
-
+                var autoRunUpdated = chkAutorun.Checked ? EnableAutoRun() : DisableAutoRun();
                 if (!autoRunUpdated)
                 {
                     DialogResult = DialogResult.None;
@@ -334,10 +191,8 @@ namespace WireSockUI.Forms
             Settings.Default.AutoConnect = chkAutoConnect.Checked;
             Settings.Default.AutoMinimize = chkAutoMinimize.Checked;
             Settings.Default.AutoUpdate = chkAutoUpdate.Checked;
-            if (chkUseAdapter.Enabled)
-                Settings.Default.UseAdapter = chkUseAdapter.Checked;
+            Settings.Default.UseAdapter = chkUseAdapter.Checked;
             Settings.Default.EnableNotifications = chkNotify.Checked;
-            Settings.Default.DisableAutoAdmin = chkDisableAutoAdmin.Checked;
             Settings.Default.EnableKillSwitch = chkEnableKillSwitch.Checked;
             Settings.Default.LogLevel = ddlLogLevel.SelectedItem as string;
 

--- a/WireSockUI/Properties/Resources.Designer.cs
+++ b/WireSockUI/Properties/Resources.Designer.cs
@@ -748,15 +748,6 @@ namespace WireSockUI.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Error checking auto-run status: {0}.
-        /// </summary>
-        internal static string SettingsAutoRunCheckError {
-            get {
-                return ResourceManager.GetString("SettingsAutoRunCheckError", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Error disabling autorun: {0}.
         /// </summary>
         internal static string SettingsAutoRunDisableAdminError {
@@ -766,29 +757,11 @@ namespace WireSockUI.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Error disabling auto-run: {0}.
-        /// </summary>
-        internal static string SettingsAutoRunDisableUserError {
-            get {
-                return ResourceManager.GetString("SettingsAutoRunDisableUserError", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Error enabling autorun: {0}.
         /// </summary>
         internal static string SettingsAutoRunEnableAdminError {
             get {
                 return ResourceManager.GetString("SettingsAutoRunEnableAdminError", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Error enabling auto-run: {0}.
-        /// </summary>
-        internal static string SettingsAutoRunEnableUserError {
-            get {
-                return ResourceManager.GetString("SettingsAutoRunEnableUserError", resourceCulture);
             }
         }
 

--- a/WireSockUI/Properties/Resources.resx
+++ b/WireSockUI/Properties/Resources.resx
@@ -343,20 +343,11 @@
   <data name="SettingsAutoRunCheckAdminError" xml:space="preserve">
     <value>Error checking elevated autorun status: {0}</value>
   </data>
-  <data name="SettingsAutoRunCheckError" xml:space="preserve">
-    <value>Error checking auto-run status: {0}</value>
-  </data>
   <data name="SettingsAutoRunDisableAdminError" xml:space="preserve">
     <value>Error disabling autorun: {0}</value>
   </data>
-  <data name="SettingsAutoRunDisableUserError" xml:space="preserve">
-    <value>Error disabling auto-run: {0}</value>
-  </data>
   <data name="SettingsAutoRunEnableAdminError" xml:space="preserve">
     <value>Error enabling autorun: {0}</value>
-  </data>
-  <data name="SettingsAutoRunEnableUserError" xml:space="preserve">
-    <value>Error enabling auto-run: {0}</value>
   </data>
   <data name="SettingsAutoConnect" xml:space="preserve">
     <value>Automatically connect on start</value>

--- a/WireSockUI/Properties/Settings.Designer.cs
+++ b/WireSockUI/Properties/Settings.Designer.cs
@@ -125,21 +125,6 @@ namespace WireSockUI.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool DisableAutoAdmin
-        {
-            get
-            {
-                return ((bool)(this["DisableAutoAdmin"]));
-            }
-            set
-            {
-                this["DisableAutoAdmin"] = value;
-            }
-        }
-
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool EnableKillSwitch
         {
             get

--- a/WireSockUI/Properties/Settings.settings
+++ b/WireSockUI/Properties/Settings.settings
@@ -26,9 +26,6 @@
     <Setting Name="EnableNotifications" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="DisableAutoAdmin" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
-    </Setting>
     <Setting Name="EnableKillSwitch" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>

--- a/WireSockUI/Properties/app.manifest
+++ b/WireSockUI/Properties/app.manifest
@@ -16,6 +16,7 @@
             Remove this element if your application requires this virtualization for backwards
             compatibility.
         -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>

--- a/WireSockUI/app.config
+++ b/WireSockUI/app.config
@@ -35,9 +35,6 @@
 			<setting name="EnableNotifications" serializeAs="String">
 				<value>True</value>
 			</setting>
-			<setting name="DisableAutoAdmin" serializeAs="String">
-				<value>False</value>
-			</setting>
 			<setting name="EnableKillSwitch" serializeAs="String">
 				<value>False</value>
 			</setting>


### PR DESCRIPTION
## Summary
- require administrator execution through the application manifest for WireSock Secure Connect v3 driver access
- remove the non-elevated runtime variant, including the DisableAutoAdmin setting and per-user Startup shortcut autorun path
- keep elevated Task Scheduler autorun and clean up legacy Startup shortcuts on a best-effort basis
- document that WireSockUI now always starts elevated for the direct wgbooster.dll model

## Verification
- git diff --check HEAD~1..HEAD
- dotnet run --project WireSockUI.Tests\\WireSockUI.Tests.csproj --configuration Release --framework net472-windows
- dotnet build WireSockUI.sln --configuration Release -p:Platform=x64 -p:UseSharedCompilation=false -m:1

Note: verification was run from a fresh temp copy because the local workspace has an existing obj directory ACL issue.