### PR TITLE
Harden profile storage and tunnel activation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ WireSock-specific directives may use the current SDK comment-extension syntax:
 
 Plain WireGuard keys are still parsed normally. WireSockUI validates common SDK fields such as script hooks, masking parameters, SOCKS5 settings, `BypassLanTraffic`, and profile-level `VirtualAdapterMode` while preserving the file-based profile workflow.
 
-Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are copied into the secured folder on startup when no secured profile with the same name exists.
+Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are moved into the secured folder on startup when no secured profile with the same name exists. If a secured profile already exists, the legacy copy is deleted only when its content matches.
 
 Profiles containing `PreUp`, `PostUp`, `PreDown`, or `PostDown` script hooks require confirmation before import/save and again before activation. Treat script-hook profiles as privileged code.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ WireSockUI does not talk to the newer WireSock Secure Connect service API. Keep 
 
 At startup WireSockUI looks for `wgbooster.dll` in this order:
 
-1. The application directory.
+1. The application directory, unless that directory is writable by non-administrative users.
 2. WireSock Secure Connect SDK registry install locations under `HKLM\Software\WireSock Foundation\WireSock Secure Connect`.
 3. WireSock Secure Connect Pro SDK registry install locations under `HKLM\Software\WireSock Foundation\WireSock Secure Connect Pro`.
 4. The legacy WireSock VPN Client registry location under `HKLM\SOFTWARE\NTKernelResources\WinpkFilterForVPNClient`.
@@ -33,6 +33,10 @@ WireSock-specific directives may use the current SDK comment-extension syntax:
 ```
 
 Plain WireGuard keys are still parsed normally. WireSockUI validates common SDK fields such as script hooks, masking parameters, SOCKS5 settings, `BypassLanTraffic`, and profile-level `VirtualAdapterMode` while preserving the file-based profile workflow.
+
+Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are copied into the secured folder on startup when no secured profile with the same name exists.
+
+Profiles containing `PreUp`, `PostUp`, `PreDown`, or `PostDown` script hooks require confirmation before import/save and again before activation. Treat script-hook profiles as privileged code.
 
 The Settings dialog includes an optional Kill Switch toggle. When enabled, WireSockUI calls the `wgbooster.dll` network-lock API before creating the tunnel and clears the lock through normal tunnel cleanup when disconnecting. The option is off by default so existing SDK/minimal installations keep their current behavior.
 

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -28,6 +28,7 @@ namespace WireSockUI.Tests
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
                 { "Stats formatting handles extreme values", StatsFormattingHandlesExtremeValues },
                 { "Time formatting uses plural hours", TimeFormattingUsesPluralHours },
+                { "Time formatting uses singular hour for partial second hour", TimeFormattingUsesSingularHourForPartialSecondHour },
                 { "Time formatting handles future values", TimeFormattingHandlesFutureValues },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi }
             };
@@ -220,6 +221,14 @@ namespace WireSockUI.Tests
             AssertTrue(value.Contains("2"), "Expected two-hour durations to include the hour count.");
             AssertTrue(value.IndexOf("hours", StringComparison.OrdinalIgnoreCase) >= 0,
                 $"Expected two-hour durations to use a plural hour label, got '{value}'.");
+        }
+
+        private static void TimeFormattingUsesSingularHourForPartialSecondHour()
+        {
+            var value = TimeSpan.FromMinutes(90).AsTimeAgo();
+
+            AssertTrue(value.IndexOf("an hour", StringComparison.OrdinalIgnoreCase) >= 0,
+                $"Expected 90-minute durations to use the singular hour label, got '{value}'.");
         }
 
         private static void TimeFormattingHandlesFutureValues()

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -28,6 +28,7 @@ namespace WireSockUI.Tests
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
                 { "Stats formatting handles extreme values", StatsFormattingHandlesExtremeValues },
                 { "Time formatting uses plural hours", TimeFormattingUsesPluralHours },
+                { "Time formatting handles future values", TimeFormattingHandlesFutureValues },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi }
             };
 
@@ -219,6 +220,16 @@ namespace WireSockUI.Tests
             AssertTrue(value.Contains("2"), "Expected two-hour durations to include the hour count.");
             AssertTrue(value.IndexOf("hours", StringComparison.OrdinalIgnoreCase) >= 0,
                 $"Expected two-hour durations to use a plural hour label, got '{value}'.");
+        }
+
+        private static void TimeFormattingHandlesFutureValues()
+        {
+            var value = TimeSpan.FromHours(-2).AsTimeAgo();
+
+            AssertTrue(!value.Contains("-"), $"Expected future durations to format without a negative sign, got '{value}'.");
+            AssertTrue(value.Contains("2"), "Expected future two-hour durations to include the absolute hour count.");
+            AssertTrue(value.IndexOf("hours", StringComparison.OrdinalIgnoreCase) >= 0,
+                $"Expected future two-hour durations to use a plural hour label, got '{value}'.");
         }
 
         private static void NetworkLockEnumMatchesWgboosterAbi()

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using WireSockUI.Config;
 using WireSockUI.Extensions;
 using WireSockUI.Native;
@@ -30,6 +31,7 @@ namespace WireSockUI.Tests
                 { "Time formatting uses plural hours", TimeFormattingUsesPluralHours },
                 { "Time formatting uses singular hour for partial second hour", TimeFormattingUsesSingularHourForPartialSecondHour },
                 { "Time formatting handles future values", TimeFormattingHandlesFutureValues },
+                { "Program path normalization preserves drive roots", ProgramPathNormalizationPreservesDriveRoots },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi }
             };
 
@@ -239,6 +241,23 @@ namespace WireSockUI.Tests
             AssertTrue(value.Contains("2"), "Expected future two-hour durations to include the absolute hour count.");
             AssertTrue(value.IndexOf("hours", StringComparison.OrdinalIgnoreCase) >= 0,
                 $"Expected future two-hour durations to use a plural hour label, got '{value}'.");
+        }
+
+        private static void ProgramPathNormalizationPreservesDriveRoots()
+        {
+            var normalize = typeof(WireSockUI.Program).GetMethod("NormalizePathDirectory",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (normalize == null)
+                throw new InvalidOperationException("NormalizePathDirectory helper was not found.");
+
+            var root = Path.GetPathRoot(Environment.SystemDirectory);
+            var normalizedRoot = (string)normalize.Invoke(null, new object[] { root });
+            var normalizedWithQuotes = (string)normalize.Invoke(null, new object[] { $"\"{root}\"" });
+            var normalizedChild = (string)normalize.Invoke(null, new object[] { Path.Combine(root, "Windows") + "\\" });
+
+            AssertEqual(root, normalizedRoot);
+            AssertEqual(root, normalizedWithQuotes);
+            AssertEqual(Path.Combine(root, "Windows"), normalizedChild);
         }
 
         private static void NetworkLockEnumMatchesWgboosterAbi()

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -27,6 +27,7 @@ namespace WireSockUI.Tests
                 { "Parser rejects duplicate sections", ParserRejectsDuplicateSections },
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
                 { "Stats formatting handles extreme values", StatsFormattingHandlesExtremeValues },
+                { "Time formatting uses plural hours", TimeFormattingUsesPluralHours },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi }
             };
 
@@ -209,6 +210,15 @@ namespace WireSockUI.Tests
                 "Expected large byte counters to format without overflowing the suffix list.");
             AssertFalse(string.IsNullOrWhiteSpace(long.MaxValue.AsTimeAgo()),
                 "Expected large handshake ages to format without narrowing to Int32.");
+        }
+
+        private static void TimeFormattingUsesPluralHours()
+        {
+            var value = TimeSpan.FromHours(2).AsTimeAgo();
+
+            AssertTrue(value.Contains("2"), "Expected two-hour durations to include the hour count.");
+            AssertTrue(value.IndexOf("hours", StringComparison.OrdinalIgnoreCase) >= 0,
+                $"Expected two-hour durations to use a plural hour label, got '{value}'.");
         }
 
         private static void NetworkLockEnumMatchesWgboosterAbi()

--- a/WireSockUI/Extensions/TimeExtensions.cs
+++ b/WireSockUI/Extensions/TimeExtensions.cs
@@ -37,7 +37,7 @@ namespace WireSockUI.Extensions
                 return Resources.TimeLapseHour;
 
             if (delta < 24 * hour)
-                return value.Hours + Resources.TimeLapseHour;
+                return value.Hours + Resources.TimeLapseHours;
 
             if (delta < 48 * hour)
                 return "yesterday";

--- a/WireSockUI/Extensions/TimeExtensions.cs
+++ b/WireSockUI/Extensions/TimeExtensions.cs
@@ -39,7 +39,10 @@ namespace WireSockUI.Extensions
                 return Resources.TimeLapseHour;
 
             if (delta < 24 * hour)
-                return Math.Abs(value.Hours) + Resources.TimeLapseHours;
+            {
+                var hours = Convert.ToInt32(Math.Floor(delta / hour));
+                return hours <= 1 ? Resources.TimeLapseHour : hours + Resources.TimeLapseHours;
+            }
 
             if (delta < 48 * hour)
                 return "yesterday";

--- a/WireSockUI/Extensions/TimeExtensions.cs
+++ b/WireSockUI/Extensions/TimeExtensions.cs
@@ -25,33 +25,35 @@ namespace WireSockUI.Extensions
             var delta = Math.Abs(value.TotalSeconds);
 
             if (delta < 1 * minute)
-                return value.Seconds == 1 ? Resources.TimeLapseSecond : value.Seconds + Resources.TimeLapseSeconds;
+                return Math.Abs(value.Seconds) == 1
+                    ? Resources.TimeLapseSecond
+                    : Math.Abs(value.Seconds) + Resources.TimeLapseSeconds;
 
             if (delta < 2 * minute)
                 return Resources.TimeLapseMinute;
 
             if (delta < 45 * minute)
-                return value.Minutes + Resources.TimeLapseMinutes;
+                return Math.Abs(value.Minutes) + Resources.TimeLapseMinutes;
 
             if (delta < 90 * minute)
                 return Resources.TimeLapseHour;
 
             if (delta < 24 * hour)
-                return value.Hours + Resources.TimeLapseHours;
+                return Math.Abs(value.Hours) + Resources.TimeLapseHours;
 
             if (delta < 48 * hour)
                 return "yesterday";
 
             if (delta < 30 * day)
-                return value.Days + Resources.TimeLapseDays;
+                return Math.Abs(value.Days) + Resources.TimeLapseDays;
 
             if (delta < 12 * month)
             {
-                var months = Convert.ToInt32(Math.Floor((double)value.Days / 30));
+                var months = Math.Abs(value.Days) / 30;
                 return months <= 1 ? Resources.TimeLapseMonth : months + Resources.TimeLapseMonths;
             }
 
-            var years = Convert.ToInt32(Math.Floor((double)value.Days / 365));
+            var years = Math.Abs(value.Days) / 365;
             return years <= 1 ? Resources.TimeLapseYear : years + Resources.TimeLapseYears;
         }
     }

--- a/WireSockUI/Forms/frmEdit.cs
+++ b/WireSockUI/Forms/frmEdit.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
@@ -25,6 +26,7 @@ namespace WireSockUI.Forms
         private Font _editorBoldFont;
         private Font _editorItalicFont;
         private Font _editorRegularFont;
+        private readonly string _originalProfileName;
         private string _targetConfigurationKeyName;
 
         public FrmEdit() : this(null)
@@ -36,6 +38,7 @@ namespace WireSockUI.Forms
             Initialize();
 
             ShowInTaskbar = false;
+            _originalProfileName = config;
 
             if (string.IsNullOrEmpty(config))
             {
@@ -542,10 +545,28 @@ namespace WireSockUI.Forms
                 return;
             }
 
-            if (!Profile.IsValidProfileName(txtProfileName.Text))
+            var requestedProfileName = txtProfileName.Text;
+            if (!Profile.IsValidProfileName(requestedProfileName))
             {
                 MessageBox.Show(Resources.EditProfileNameError, Resources.EditProfileError, MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
+                TryDeleteTemporaryProfile(tmpProfile);
+
+                DialogResult = DialogResult.None;
+                return;
+            }
+
+            var profilePath = Profile.GetProfilePath(requestedProfileName);
+            var isExistingProfile = !string.IsNullOrEmpty(_originalProfileName);
+            var isRename = isExistingProfile &&
+                           !string.Equals(_originalProfileName, requestedProfileName,
+                               StringComparison.OrdinalIgnoreCase);
+
+            if (File.Exists(profilePath) && (!isExistingProfile || isRename))
+            {
+                MessageBox.Show(string.Format(Resources.AddProfileExistsMsg, requestedProfileName),
+                    Resources.EditProfileError,
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
                 TryDeleteTemporaryProfile(tmpProfile);
 
                 DialogResult = DialogResult.None;
@@ -560,14 +581,15 @@ namespace WireSockUI.Forms
                 return;
             }
 
-            var profilePath = Profile.GetProfilePath(txtProfileName.Text);
-
             try
             {
                 if (File.Exists(profilePath))
                     File.Replace(tmpProfile, profilePath, null);
                 else
                     File.Move(tmpProfile, profilePath);
+
+                if (isRename)
+                    TryDeleteOriginalProfile(_originalProfileName, profilePath);
             }
             catch (Exception ex)
             {
@@ -578,9 +600,25 @@ namespace WireSockUI.Forms
                 return;
             }
 
-            ReturnValue = txtProfileName.Text;
+            ReturnValue = requestedProfileName;
 
             Close();
+        }
+
+        private static void TryDeleteOriginalProfile(string originalProfileName, string newProfilePath)
+        {
+            try
+            {
+                var originalProfilePath = Profile.GetProfilePath(originalProfileName);
+                if (!string.Equals(Path.GetFullPath(originalProfilePath), Path.GetFullPath(newProfilePath),
+                        StringComparison.OrdinalIgnoreCase) &&
+                    File.Exists(originalProfilePath))
+                    File.Delete(originalProfilePath);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to delete renamed profile '{originalProfileName}': {ex.Message}");
+            }
         }
 
         private static void TryDeleteTemporaryProfile(string tmpProfile)

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -380,7 +380,7 @@ namespace WireSockUI.Forms
 
                 if (progress.TimedOut)
                 {
-                    HandleTunnelConnectionTimeout(progress.Generation);
+                    _ = HandleTunnelConnectionTimeoutAsync(progress.Generation);
                     return;
                 }
 
@@ -400,7 +400,7 @@ namespace WireSockUI.Forms
             return worker;
         }
 
-        private async void HandleTunnelConnectionTimeout(int generation)
+        private async Task HandleTunnelConnectionTimeoutAsync(int generation)
         {
             if (!RequestTunnelConnectionTimeout(generation) || !TryBeginTunnelOperation())
                 return;

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -30,6 +30,7 @@ namespace WireSockUI.Forms
 
         private readonly BackgroundWorker _tunnelConnectionWorker;
         private readonly BackgroundWorker _tunnelStateWorker;
+        private const int TunnelConnectionTimeoutMilliseconds = 30000;
 
         /**
          * @brief The manager that handles the Wireguard connections.
@@ -47,6 +48,7 @@ namespace WireSockUI.Forms
         {
             public int Generation { get; set; }
             public bool Connected { get; set; }
+            public bool TimedOut { get; set; }
         }
 
         private sealed class TunnelStateProgress
@@ -333,6 +335,7 @@ namespace WireSockUI.Forms
             {
                 var generation = (int)e.Argument;
                 var connected = false;
+                var timeoutAt = DateTime.UtcNow.AddMilliseconds(TunnelConnectionTimeoutMilliseconds);
 
                 do
                 {
@@ -349,6 +352,17 @@ namespace WireSockUI.Forms
                     }
 
                     connected = _wiresock.Connected;
+                    if (!connected && DateTime.UtcNow >= timeoutAt)
+                    {
+                        worker.ReportProgress(0, new TunnelConnectionProgress
+                        {
+                            Generation = generation,
+                            TimedOut = true
+                        });
+                        e.Cancel = true;
+                        return;
+                    }
+
                     worker.ReportProgress(0, new TunnelConnectionProgress
                     {
                         Generation = generation,
@@ -362,6 +376,12 @@ namespace WireSockUI.Forms
                 if (_shutdownComplete || !(e.UserState is TunnelConnectionProgress progress) ||
                     progress.Generation != CurrentTunnelGeneration())
                     return;
+
+                if (progress.TimedOut)
+                {
+                    HandleTunnelConnectionTimeout(progress.Generation);
+                    return;
+                }
 
                 if (_currentState == ConnectionState.Connecting && progress.Connected)
                     UpdateState(ConnectionState.Connected);
@@ -377,6 +397,27 @@ namespace WireSockUI.Forms
             };
 
             return worker;
+        }
+
+        private async void HandleTunnelConnectionTimeout(int generation)
+        {
+            if (!TryBeginTunnelOperation())
+                return;
+
+            try
+            {
+                if (_shutdownComplete || generation != CurrentTunnelGeneration() ||
+                    _currentState != ConnectionState.Connecting)
+                    return;
+
+                await DisconnectCurrentTunnelAsync(false);
+                MessageBox.Show(Resources.TunnelConnectTimeout, Resources.TunnelErrorTitle, MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
+            finally
+            {
+                EndTunnelOperation();
+            }
         }
 
         /// <summary>
@@ -541,13 +582,13 @@ namespace WireSockUI.Forms
                 case ConnectionState.Connecting:
                     if (btnActivate != null)
                     {
-                        btnActivate.Text = Resources.ButtonActivating;
-                        btnActivate.Enabled = false;
+                        btnActivate.Text = Resources.ButtonActive;
+                        btnActivate.Enabled = true;
                     }
 
                     imgStatus?.Focus();
 
-                    cmiDeactivateTunnel.Enabled = false;
+                    cmiDeactivateTunnel.Enabled = true;
 
                     if (TryGetProfileItem(activeProfileName, out var connectingProfile))
                         connectingProfile.ImageKey = ConnectionState.Connecting.ToString();
@@ -590,8 +631,15 @@ namespace WireSockUI.Forms
 
                     if (!string.IsNullOrWhiteSpace(activeProfileName))
                     {
-                        Settings.Default.LastProfile = activeProfileName;
-                        Settings.Default.Save();
+                        try
+                        {
+                            Settings.Default.LastProfile = activeProfileName;
+                            Settings.Default.Save();
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.TraceWarning($"Failed to save last active profile setting: {ex.Message}");
+                        }
                     }
 
                     gbxState.Visible = true;
@@ -926,51 +974,52 @@ namespace WireSockUI.Forms
                 // Return if no profile is selected in the list.
                 if (lstProfiles.SelectedItems.Count == 0) return;
 
-                // Check if the event arguments are not empty.
-                if (e != EventArgs.Empty)
+                // Get the selected profile.
+                var profile = lstProfiles.SelectedItems[0].Text;
+                var disconnectOnly = false;
+
+                if (e != EventArgs.Empty &&
+                    (_currentState == ConnectionState.Connected || _currentState == ConnectionState.Connecting))
                 {
-                    // Check if the current state is connected or connecting.
-                    if (_currentState == ConnectionState.Connected || _currentState == ConnectionState.Connecting)
-                    {
-                        var reconnect = false;
-
-                        // Check if the sender is a Button, and if its text is equal to ButtonInactive.
-                        if (sender is Button senderButton)
-                            if (senderButton.Text == Resources.ButtonInactive)
-                                reconnect = true;
-
-                        // Update the state to disconnected.
-                        if (!await DisconnectCurrentTunnelAsync())
-                            return;
-
-                        // Proceed with reconnecting if the reconnect flag is set.
-                        if (!reconnect) return;
-                    }
+                    var reconnect = sender is Button senderButton && senderButton.Text == Resources.ButtonInactive;
+                    disconnectOnly = !reconnect;
                 }
-                else
+
+                Profile profileSettings = null;
+                var useAdapter = Settings.Default.UseAdapter;
+
+                if (!disconnectOnly)
                 {
-                    // Update the state to disconnected.
+                    try
+                    {
+                        profileSettings = Profile.LoadProfile(profile);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show(ex.Message, Resources.ProfileError, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+
+                    if (!ProfileScriptWarning.ConfirmIfProfileHasScriptHooks(this, profileSettings))
+                        return;
+
+                    if (bool.TryParse(profileSettings.VirtualAdapterMode, out var profileUseAdapter))
+                        useAdapter = profileUseAdapter;
+                }
+
+                if (_currentState == ConnectionState.Connected || _currentState == ConnectionState.Connecting)
+                {
+                    if (!await DisconnectCurrentTunnelAsync(e != EventArgs.Empty))
+                        return;
+
+                    if (disconnectOnly)
+                        return;
+                }
+                else if (e == EventArgs.Empty && _wiresock.HasTunnelHandle)
+                {
                     if (!await DisconnectCurrentTunnelAsync(false))
                         return;
                 }
-
-                // Get the selected profile.
-                var profile = lstProfiles.SelectedItems[0].Text;
-                Profile profileSettings;
-
-                try
-                {
-                    profileSettings = Profile.LoadProfile(profile);
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show(ex.Message, Resources.ProfileError, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return;
-                }
-
-                var useAdapter = Settings.Default.UseAdapter;
-                if (bool.TryParse(profileSettings.VirtualAdapterMode, out var profileUseAdapter))
-                    useAdapter = profileUseAdapter;
 
                 try
                 {

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -42,6 +42,7 @@ namespace WireSockUI.Forms
         private bool _shutdownComplete;
         private int _tunnelOperationInProgress;
         private int _tunnelGeneration;
+        private int _tunnelConnectionTimeoutGeneration;
         private Icon _ownedTrayIcon;
 
         private sealed class TunnelConnectionProgress
@@ -401,23 +402,45 @@ namespace WireSockUI.Forms
 
         private async void HandleTunnelConnectionTimeout(int generation)
         {
-            if (!TryBeginTunnelOperation())
+            if (!RequestTunnelConnectionTimeout(generation) || !TryBeginTunnelOperation())
                 return;
 
             try
             {
-                if (_shutdownComplete || generation != CurrentTunnelGeneration() ||
-                    _currentState != ConnectionState.Connecting)
-                    return;
-
-                await DisconnectCurrentTunnelAsync(false);
-                MessageBox.Show(Resources.TunnelConnectTimeout, Resources.TunnelErrorTitle, MessageBoxButtons.OK,
-                    MessageBoxIcon.Warning);
+                await DisconnectTimedOutTunnelAsync(generation);
             }
             finally
             {
                 EndTunnelOperation();
             }
+        }
+
+        private bool RequestTunnelConnectionTimeout(int generation)
+        {
+            if (_shutdownComplete || generation != CurrentTunnelGeneration() ||
+                _currentState != ConnectionState.Connecting)
+                return false;
+
+            Volatile.Write(ref _tunnelConnectionTimeoutGeneration, generation);
+            return true;
+        }
+
+        private bool IsTunnelConnectionTimedOut(int generation)
+        {
+            return Volatile.Read(ref _tunnelConnectionTimeoutGeneration) == generation;
+        }
+
+        private async Task DisconnectTimedOutTunnelAsync(int generation)
+        {
+            if (_shutdownComplete || generation != CurrentTunnelGeneration() ||
+                _currentState != ConnectionState.Connecting || !IsTunnelConnectionTimedOut(generation))
+                return;
+
+            await DisconnectCurrentTunnelAsync(false);
+
+            if (!_shutdownComplete)
+                MessageBox.Show(Resources.TunnelConnectTimeout, Resources.TunnelErrorTitle, MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
         }
 
         /// <summary>
@@ -1046,6 +1069,20 @@ namespace WireSockUI.Forms
                     UpdateState(ConnectionState.Connecting, true, profile);
                     var connected = await Task.Run(() => _wiresock.Connect(profile));
                     var connectionSequence = connected ? _wiresock.ConnectionSequence : 0;
+
+                    if (!_shutdownComplete && connectGeneration == CurrentTunnelGeneration() &&
+                        IsTunnelConnectionTimedOut(connectGeneration))
+                    {
+                        if (connected)
+                            await DisconnectNativeTunnelAsync(connectionSequence, false);
+                        else if (_wiresock.HasTunnelHandle)
+                            await DisconnectNativeTunnelAsync(null, false);
+
+                        UpdateState(ConnectionState.Disconnected, false, profile);
+                        MessageBox.Show(Resources.TunnelConnectTimeout, Resources.TunnelErrorTitle,
+                            MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        return;
+                    }
 
                     if (connectGeneration != CurrentTunnelGeneration() || _shutdownComplete)
                     {

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -407,7 +407,14 @@ namespace WireSockUI.Forms
 
             try
             {
-                await DisconnectTimedOutTunnelAsync(generation);
+                try
+                {
+                    await DisconnectTimedOutTunnelAsync(generation);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning($"Failed to handle tunnel connection timeout: {ex.Message}");
+                }
             }
             finally
             {

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -582,13 +582,13 @@ namespace WireSockUI.Forms
                 case ConnectionState.Connecting:
                     if (btnActivate != null)
                     {
-                        btnActivate.Text = Resources.ButtonActive;
-                        btnActivate.Enabled = true;
+                        btnActivate.Text = Resources.ButtonActivating;
+                        btnActivate.Enabled = false;
                     }
 
                     imgStatus?.Focus();
 
-                    cmiDeactivateTunnel.Enabled = true;
+                    cmiDeactivateTunnel.Enabled = false;
 
                     if (TryGetProfileItem(activeProfileName, out var connectingProfile))
                         connectingProfile.ImageKey = ConnectionState.Connecting.ToString();

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -336,7 +336,7 @@ namespace WireSockUI.Forms
             {
                 var generation = (int)e.Argument;
                 var connected = false;
-                var timeoutAt = DateTime.UtcNow.AddMilliseconds(TunnelConnectionTimeoutMilliseconds);
+                var timeout = Stopwatch.StartNew();
 
                 do
                 {
@@ -353,7 +353,7 @@ namespace WireSockUI.Forms
                     }
 
                     connected = _wiresock.Connected;
-                    if (!connected && DateTime.UtcNow >= timeoutAt)
+                    if (!connected && timeout.ElapsedMilliseconds >= TunnelConnectionTimeoutMilliseconds)
                     {
                         worker.ReportProgress(0, new TunnelConnectionProgress
                         {

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -35,7 +35,7 @@ namespace WireSockUI.Forms
         {
             try
             {
-                Process.Start("explorer.exe", Global.MainFolder);
+                Process.Start("explorer.exe", Global.ConfigsFolder);
             }
             catch (Exception ex)
             {
@@ -198,7 +198,16 @@ namespace WireSockUI.Forms
             Settings.Default.EnableKillSwitch = chkEnableKillSwitch.Checked;
             Settings.Default.LogLevel = ddlLogLevel.SelectedItem as string;
 
-            Settings.Default.Save();
+            try
+            {
+                Settings.Default.Save();
+            }
+            catch (Exception ex)
+            {
+                ShowSettingsError(Resources.SettingsSaveError, ex);
+                DialogResult = DialogResult.None;
+                return;
+            }
 
             DialogResult = DialogResult.OK;
             Close();

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -1,14 +1,97 @@
 ﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Threading;
 
 namespace WireSockUI
 {
     internal static class Global
     {
-        public static string MainFolder =
-            $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\WireSockUI";
+        private const string ApplicationFolderName = "WireSockUI";
 
-        public static string ConfigsFolder = MainFolder + "\\Configs";
+        public static string MainFolder =
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ApplicationFolderName);
+
+        public static string SecureMainFolder =
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), ApplicationFolderName);
+
+        public static string ConfigsFolder = Path.Combine(SecureMainFolder, "Configs");
+
+        public static string LegacyConfigsFolder = Path.Combine(MainFolder, "Configs");
+
         public static EventWaitHandle AlreadyRunning;
+
+        public static void EnsureApplicationFolders()
+        {
+            Directory.CreateDirectory(MainFolder);
+            EnsureAdministratorsOnlyDirectory(SecureMainFolder);
+            EnsureAdministratorsOnlyDirectory(ConfigsFolder);
+        }
+
+        private static void EnsureAdministratorsOnlyDirectory(string path)
+        {
+            Directory.CreateDirectory(path);
+
+            try
+            {
+                Directory.SetAccessControl(path, CreateAdministratorsOnlyDirectorySecurity());
+                SecureExistingChildren(path);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to secure WireSock UI directory '{path}': {ex.Message}");
+                throw;
+            }
+        }
+
+        private static DirectorySecurity CreateAdministratorsOnlyDirectorySecurity()
+        {
+            var inheritanceFlags = InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit;
+            var security = new DirectorySecurity();
+
+            security.SetAccessRuleProtection(true, false);
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+                FileSystemRights.FullControl,
+                inheritanceFlags,
+                PropagationFlags.None,
+                AccessControlType.Allow));
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                FileSystemRights.FullControl,
+                inheritanceFlags,
+                PropagationFlags.None,
+                AccessControlType.Allow));
+
+            return security;
+        }
+
+        private static FileSecurity CreateAdministratorsOnlyFileSecurity()
+        {
+            var security = new FileSecurity();
+
+            security.SetAccessRuleProtection(true, false);
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+                FileSystemRights.FullControl,
+                AccessControlType.Allow));
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                FileSystemRights.FullControl,
+                AccessControlType.Allow));
+
+            return security;
+        }
+
+        private static void SecureExistingChildren(string path)
+        {
+            foreach (var directory in Directory.GetDirectories(path, "*", SearchOption.AllDirectories))
+                Directory.SetAccessControl(directory, CreateAdministratorsOnlyDirectorySecurity());
+
+            foreach (var file in Directory.GetFiles(path, "*", SearchOption.AllDirectories))
+                File.SetAccessControl(file, CreateAdministratorsOnlyFileSecurity());
+        }
     }
 }

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -32,11 +32,11 @@ namespace WireSockUI
 
         private static void EnsureAdministratorsOnlyDirectory(string path)
         {
-            Directory.CreateDirectory(path);
-
             try
             {
-                Directory.SetAccessControl(path, CreateAdministratorsOnlyDirectorySecurity());
+                var security = CreateAdministratorsOnlyDirectorySecurity();
+                Directory.CreateDirectory(path, security);
+                Directory.SetAccessControl(path, security);
                 SecureExistingChildren(path);
             }
             catch (Exception ex)

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -103,8 +103,19 @@ namespace WireSockUI
             while (directories.Count > 0)
             {
                 var directory = directories.Pop();
+                string[] files;
 
-                foreach (var file in Directory.GetFiles(directory))
+                try
+                {
+                    files = Directory.GetFiles(directory);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning($"Unable to enumerate WireSock UI configuration files in '{directory}': {ex.Message}");
+                    files = Array.Empty<string>();
+                }
+
+                foreach (var file in files)
                 {
                     if (IsReparsePoint(file))
                     {
@@ -112,10 +123,29 @@ namespace WireSockUI
                         continue;
                     }
 
-                    File.SetAccessControl(file, CreateAdministratorsOnlyFileSecurity());
+                    try
+                    {
+                        File.SetAccessControl(file, CreateAdministratorsOnlyFileSecurity());
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceWarning($"Failed to secure WireSock UI configuration file '{file}': {ex.Message}");
+                    }
                 }
 
-                foreach (var childDirectory in Directory.GetDirectories(directory))
+                string[] childDirectories;
+                try
+                {
+                    childDirectories = Directory.GetDirectories(directory);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning(
+                        $"Unable to enumerate WireSock UI configuration directories in '{directory}': {ex.Message}");
+                    continue;
+                }
+
+                foreach (var childDirectory in childDirectories)
                 {
                     if (IsReparsePoint(childDirectory))
                     {
@@ -123,15 +153,31 @@ namespace WireSockUI
                         continue;
                     }
 
-                    Directory.SetAccessControl(childDirectory, CreateAdministratorsOnlyDirectorySecurity());
-                    directories.Push(childDirectory);
+                    try
+                    {
+                        Directory.SetAccessControl(childDirectory, CreateAdministratorsOnlyDirectorySecurity());
+                        directories.Push(childDirectory);
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceWarning(
+                            $"Failed to secure WireSock UI configuration directory '{childDirectory}': {ex.Message}");
+                    }
                 }
             }
         }
 
         private static bool IsReparsePoint(string path)
         {
-            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
+            try
+            {
+                return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Unable to inspect reparse point attributes for '{path}': {ex.Message}");
+                return true;
+            }
         }
     }
 }

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -53,17 +53,20 @@ namespace WireSockUI
         private static DirectorySecurity CreateAdministratorsOnlyDirectorySecurity()
         {
             var inheritanceFlags = InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit;
+            var administratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+            var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
             var security = new DirectorySecurity();
 
             security.SetAccessRuleProtection(true, false);
+            security.SetOwner(administratorsSid);
             security.AddAccessRule(new FileSystemAccessRule(
-                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+                systemSid,
                 FileSystemRights.FullControl,
                 inheritanceFlags,
                 PropagationFlags.None,
                 AccessControlType.Allow));
             security.AddAccessRule(new FileSystemAccessRule(
-                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                administratorsSid,
                 FileSystemRights.FullControl,
                 inheritanceFlags,
                 PropagationFlags.None,
@@ -74,15 +77,18 @@ namespace WireSockUI
 
         private static FileSecurity CreateAdministratorsOnlyFileSecurity()
         {
+            var administratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+            var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
             var security = new FileSecurity();
 
             security.SetAccessRuleProtection(true, false);
+            security.SetOwner(administratorsSid);
             security.AddAccessRule(new FileSystemAccessRule(
-                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+                systemSid,
                 FileSystemRights.FullControl,
                 AccessControlType.Allow));
             security.AddAccessRule(new FileSystemAccessRule(
-                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                administratorsSid,
                 FileSystemRights.FullControl,
                 AccessControlType.Allow));
 

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Security.AccessControl;
@@ -36,6 +37,9 @@ namespace WireSockUI
             {
                 var security = CreateAdministratorsOnlyDirectorySecurity();
                 Directory.CreateDirectory(path, security);
+                if (IsReparsePoint(path))
+                    throw new IOException($"Refusing to secure WireSock UI directory reparse point '{path}'.");
+
                 Directory.SetAccessControl(path, security);
                 SecureExistingChildren(path);
             }
@@ -87,11 +91,41 @@ namespace WireSockUI
 
         private static void SecureExistingChildren(string path)
         {
-            foreach (var directory in Directory.GetDirectories(path, "*", SearchOption.AllDirectories))
-                Directory.SetAccessControl(directory, CreateAdministratorsOnlyDirectorySecurity());
+            var directories = new Stack<string>();
+            directories.Push(path);
 
-            foreach (var file in Directory.GetFiles(path, "*", SearchOption.AllDirectories))
-                File.SetAccessControl(file, CreateAdministratorsOnlyFileSecurity());
+            while (directories.Count > 0)
+            {
+                var directory = directories.Pop();
+
+                foreach (var file in Directory.GetFiles(directory))
+                {
+                    if (IsReparsePoint(file))
+                    {
+                        Trace.TraceWarning($"Skipping WireSock UI configuration file reparse point '{file}'.");
+                        continue;
+                    }
+
+                    File.SetAccessControl(file, CreateAdministratorsOnlyFileSecurity());
+                }
+
+                foreach (var childDirectory in Directory.GetDirectories(directory))
+                {
+                    if (IsReparsePoint(childDirectory))
+                    {
+                        Trace.TraceWarning($"Skipping WireSock UI configuration directory reparse point '{childDirectory}'.");
+                        continue;
+                    }
+
+                    Directory.SetAccessControl(childDirectory, CreateAdministratorsOnlyDirectorySecurity());
+                    directories.Push(childDirectory);
+                }
+            }
+        }
+
+        private static bool IsReparsePoint(string path)
+        {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
         }
     }
 }

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -155,7 +155,7 @@ namespace WireSockUI
                 }
 
                 Trace.TraceWarning(
-                    $"Skipping app-local wgbooster.dll in user-writable directory '{localDirectory}' while running elevated.");
+                    $"Skipping app-local wgbooster.dll in user-writable directory '{localDirectory}'.");
             }
 
             foreach (var installLocation in GetInstallLocations())

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -390,10 +390,18 @@ namespace WireSockUI
                 {
                     if (rule.AccessControlType != AccessControlType.Allow ||
                         !(rule.IdentityReference is SecurityIdentifier sid) ||
-                        IsAdministrativeOrServiceSid(sid))
+                        (rule.FileSystemRights & writeRights) == 0)
                         continue;
 
-                    if ((rule.FileSystemRights & writeRights) != 0)
+                    if (sid.IsWellKnown(WellKnownSidType.CreatorOwnerSid))
+                    {
+                        if ((rule.PropagationFlags & PropagationFlags.InheritOnly) != 0)
+                            continue;
+
+                        return true;
+                    }
+
+                    if (!IsAdministrativeOrServiceSid(sid))
                         return true;
                 }
 
@@ -410,7 +418,6 @@ namespace WireSockUI
         {
             return sid.IsWellKnown(WellKnownSidType.LocalSystemSid) ||
                    sid.IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid) ||
-                   sid.IsWellKnown(WellKnownSidType.CreatorOwnerSid) ||
                    sid.IsWellKnown(WellKnownSidType.LocalServiceSid) ||
                    sid.IsWellKnown(WellKnownSidType.NetworkServiceSid) ||
                    sid.Value.StartsWith("S-1-5-80-", StringComparison.OrdinalIgnoreCase) ||

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -378,15 +378,25 @@ namespace WireSockUI
                 using (var first = File.OpenRead(firstPath))
                 using (var second = File.OpenRead(secondPath))
                 {
-                    int firstByte;
-                    do
-                    {
-                        firstByte = first.ReadByte();
-                        if (firstByte != second.ReadByte())
-                            return false;
-                    } while (firstByte != -1);
+                    var firstBuffer = new byte[81920];
+                    var secondBuffer = new byte[81920];
 
-                    return true;
+                    while (true)
+                    {
+                        var firstBytesRead = ReadBlock(first, firstBuffer);
+                        var secondBytesRead = ReadBlock(second, secondBuffer);
+                        if (firstBytesRead != secondBytesRead)
+                            return false;
+
+                        if (firstBytesRead == 0)
+                            return true;
+
+                        for (var i = 0; i < firstBytesRead; i++)
+                        {
+                            if (firstBuffer[i] != secondBuffer[i])
+                                return false;
+                        }
+                    }
                 }
             }
             catch (Exception ex)
@@ -394,6 +404,21 @@ namespace WireSockUI
                 Trace.TraceWarning($"Failed to compare migrated profile files: {ex.Message}");
                 return false;
             }
+        }
+
+        private static int ReadBlock(Stream stream, byte[] buffer)
+        {
+            var totalRead = 0;
+            while (totalRead < buffer.Length)
+            {
+                var bytesRead = stream.Read(buffer, totalRead, buffer.Length - totalRead);
+                if (bytesRead == 0)
+                    break;
+
+                totalRead += bytesRead;
+            }
+
+            return totalRead;
         }
 
         private static void TryDeleteLegacyProfile(string legacyProfilePath, string profileName)

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -3,10 +3,14 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Windows.Forms;
 using Microsoft.Win32;
+using WireSockUI.Config;
 using WireSockUI.Extensions;
 using WireSockUI.Forms;
 using WireSockUI.Properties;
@@ -26,8 +30,8 @@ namespace WireSockUI
 
             try
             {
-                Directory.CreateDirectory(Global.MainFolder);
-                Directory.CreateDirectory(Global.ConfigsFolder);
+                Global.EnsureApplicationFolders();
+                MigrateLegacyProfiles();
             }
             catch (Exception ex)
             {
@@ -145,8 +149,14 @@ namespace WireSockUI
             var localDirectory = AppDomain.CurrentDomain.BaseDirectory;
             if (ContainsWireSockLibrary(localDirectory))
             {
-                libraryDirectory = localDirectory;
-                return true;
+                if (!IsPotentiallyUserWritableDirectory(localDirectory))
+                {
+                    libraryDirectory = localDirectory;
+                    return true;
+                }
+
+                Trace.TraceWarning(
+                    $"Skipping app-local wgbooster.dll in user-writable directory '{localDirectory}' while running elevated.");
             }
 
             foreach (var installLocation in GetInstallLocations())
@@ -274,6 +284,85 @@ namespace WireSockUI
             }
 
             return isAppLocalDirectory;
+        }
+
+        private static void MigrateLegacyProfiles()
+        {
+            if (!Directory.Exists(Global.LegacyConfigsFolder))
+                return;
+
+            foreach (var legacyProfilePath in Directory.GetFiles(Global.LegacyConfigsFolder, "*.conf"))
+            {
+                var profileName = Path.GetFileNameWithoutExtension(legacyProfilePath);
+                if (!Profile.IsValidProfileName(profileName))
+                {
+                    Trace.TraceWarning($"Skipping legacy profile with unsafe name '{Path.GetFileName(legacyProfilePath)}'.");
+                    continue;
+                }
+
+                var destinationPath = Profile.GetProfilePath(profileName);
+                if (File.Exists(destinationPath))
+                    continue;
+
+                try
+                {
+                    File.Copy(legacyProfilePath, destinationPath, false);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning($"Failed to migrate legacy profile '{profileName}': {ex.Message}");
+                }
+            }
+        }
+
+        private static bool IsPotentiallyUserWritableDirectory(string directory)
+        {
+            var normalizedDirectory = NormalizePathDirectory(directory);
+            if (normalizedDirectory == null)
+                return true;
+
+            try
+            {
+                var security = Directory.GetAccessControl(normalizedDirectory);
+                var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
+                var currentUser = WindowsIdentity.GetCurrent().User;
+                var writableSids = new[]
+                {
+                    new SecurityIdentifier(WellKnownSidType.WorldSid, null),
+                    new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null),
+                    new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null),
+                    new SecurityIdentifier(WellKnownSidType.InteractiveSid, null),
+                    currentUser
+                };
+                const FileSystemRights writeRights =
+                    FileSystemRights.FullControl |
+                    FileSystemRights.Modify |
+                    FileSystemRights.Write |
+                    FileSystemRights.WriteData |
+                    FileSystemRights.CreateFiles |
+                    FileSystemRights.AppendData |
+                    FileSystemRights.CreateDirectories |
+                    FileSystemRights.WriteAttributes |
+                    FileSystemRights.WriteExtendedAttributes;
+
+                foreach (FileSystemAccessRule rule in rules)
+                {
+                    if (rule.AccessControlType != AccessControlType.Allow ||
+                        !(rule.IdentityReference is SecurityIdentifier sid) ||
+                        !writableSids.Contains(sid))
+                        continue;
+
+                    if ((rule.FileSystemRights & writeRights) != 0)
+                        return true;
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Unable to inspect ACL for '{normalizedDirectory}': {ex.Message}");
+                return true;
+            }
         }
 
         private static string NormalizePathDirectory(string directory)

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -474,14 +474,23 @@ namespace WireSockUI
 
             try
             {
-                return Path.GetFullPath(directory.Trim().Trim('"'))
-                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                return NormalizePathRoot(Path.GetFullPath(directory.Trim().Trim('"')));
             }
             catch (Exception ex)
             {
                 Trace.TraceWarning($"Skipping invalid PATH directory '{directory}': {ex.Message}");
                 return null;
             }
+        }
+
+        private static string NormalizePathRoot(string fullPath)
+        {
+            var root = Path.GetPathRoot(fullPath);
+            if (!string.IsNullOrEmpty(root) &&
+                string.Equals(fullPath, root, StringComparison.OrdinalIgnoreCase))
+                return fullPath;
+
+            return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
 
         /// <summary>

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -290,8 +290,35 @@ namespace WireSockUI
             if (!Directory.Exists(Global.LegacyConfigsFolder))
                 return;
 
-            foreach (var legacyProfilePath in Directory.GetFiles(Global.LegacyConfigsFolder, "*.conf"))
+            if (!TryIsReparsePoint(Global.LegacyConfigsFolder, out var legacyConfigsIsReparsePoint) ||
+                legacyConfigsIsReparsePoint)
             {
+                Trace.TraceWarning(
+                    $"Skipping legacy profile migration because '{Global.LegacyConfigsFolder}' is a reparse point or cannot be inspected.");
+                return;
+            }
+
+            string[] legacyProfilePaths;
+            try
+            {
+                legacyProfilePaths = Directory.GetFiles(Global.LegacyConfigsFolder, "*.conf");
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Unable to enumerate legacy WireSock UI profiles: {ex.Message}");
+                return;
+            }
+
+            foreach (var legacyProfilePath in legacyProfilePaths)
+            {
+                if (!TryIsReparsePoint(legacyProfilePath, out var legacyProfileIsReparsePoint) ||
+                    legacyProfileIsReparsePoint)
+                {
+                    Trace.TraceWarning(
+                        $"Skipping legacy profile '{Path.GetFileName(legacyProfilePath)}' because it is a reparse point or cannot be inspected.");
+                    continue;
+                }
+
                 var profileName = Path.GetFileNameWithoutExtension(legacyProfilePath);
                 if (!Profile.IsValidProfileName(profileName))
                 {
@@ -320,6 +347,22 @@ namespace WireSockUI
                 {
                     Trace.TraceWarning($"Failed to migrate legacy profile '{profileName}': {ex.Message}");
                 }
+            }
+        }
+
+        private static bool TryIsReparsePoint(string path, out bool isReparsePoint)
+        {
+            isReparsePoint = false;
+
+            try
+            {
+                isReparsePoint = (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Unable to inspect reparse point attributes for '{path}': {ex.Message}");
+                return false;
             }
         }
 

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
@@ -302,16 +301,67 @@ namespace WireSockUI
 
                 var destinationPath = Profile.GetProfilePath(profileName);
                 if (File.Exists(destinationPath))
+                {
+                    if (FilesHaveSameContent(legacyProfilePath, destinationPath))
+                        TryDeleteLegacyProfile(legacyProfilePath, profileName);
+                    else
+                        Trace.TraceWarning(
+                            $"Skipping legacy profile '{profileName}' because a secured profile with different content already exists.");
+
                     continue;
+                }
 
                 try
                 {
                     File.Copy(legacyProfilePath, destinationPath, false);
+                    TryDeleteLegacyProfile(legacyProfilePath, profileName);
                 }
                 catch (Exception ex)
                 {
                     Trace.TraceWarning($"Failed to migrate legacy profile '{profileName}': {ex.Message}");
                 }
+            }
+        }
+
+        private static bool FilesHaveSameContent(string firstPath, string secondPath)
+        {
+            try
+            {
+                var firstInfo = new FileInfo(firstPath);
+                var secondInfo = new FileInfo(secondPath);
+                if (firstInfo.Length != secondInfo.Length)
+                    return false;
+
+                using (var first = File.OpenRead(firstPath))
+                using (var second = File.OpenRead(secondPath))
+                {
+                    int firstByte;
+                    do
+                    {
+                        firstByte = first.ReadByte();
+                        if (firstByte != second.ReadByte())
+                            return false;
+                    } while (firstByte != -1);
+
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to compare migrated profile files: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static void TryDeleteLegacyProfile(string legacyProfilePath, string profileName)
+        {
+            try
+            {
+                File.Delete(legacyProfilePath);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Migrated legacy profile '{profileName}', but could not delete the old copy: {ex.Message}");
             }
         }
 
@@ -325,15 +375,6 @@ namespace WireSockUI
             {
                 var security = Directory.GetAccessControl(normalizedDirectory);
                 var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
-                var currentUser = WindowsIdentity.GetCurrent().User;
-                var writableSids = new[]
-                {
-                    new SecurityIdentifier(WellKnownSidType.WorldSid, null),
-                    new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null),
-                    new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null),
-                    new SecurityIdentifier(WellKnownSidType.InteractiveSid, null),
-                    currentUser
-                };
                 const FileSystemRights writeRights =
                     FileSystemRights.FullControl |
                     FileSystemRights.Modify |
@@ -349,7 +390,7 @@ namespace WireSockUI
                 {
                     if (rule.AccessControlType != AccessControlType.Allow ||
                         !(rule.IdentityReference is SecurityIdentifier sid) ||
-                        !writableSids.Contains(sid))
+                        IsAdministrativeOrServiceSid(sid))
                         continue;
 
                     if ((rule.FileSystemRights & writeRights) != 0)
@@ -363,6 +404,17 @@ namespace WireSockUI
                 Trace.TraceWarning($"Unable to inspect ACL for '{normalizedDirectory}': {ex.Message}");
                 return true;
             }
+        }
+
+        private static bool IsAdministrativeOrServiceSid(SecurityIdentifier sid)
+        {
+            return sid.IsWellKnown(WellKnownSidType.LocalSystemSid) ||
+                   sid.IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid) ||
+                   sid.IsWellKnown(WellKnownSidType.CreatorOwnerSid) ||
+                   sid.IsWellKnown(WellKnownSidType.LocalServiceSid) ||
+                   sid.IsWellKnown(WellKnownSidType.NetworkServiceSid) ||
+                   sid.Value.StartsWith("S-1-5-80-", StringComparison.OrdinalIgnoreCase) ||
+                   sid.Value.StartsWith("S-1-5-83-", StringComparison.OrdinalIgnoreCase);
         }
 
         private static string NormalizePathDirectory(string directory)

--- a/WireSockUI/Properties/Resources.Designer.cs
+++ b/WireSockUI/Properties/Resources.Designer.cs
@@ -820,6 +820,15 @@ namespace WireSockUI.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Error saving settings: {0}.
+        /// </summary>
+        internal static string SettingsSaveError {
+            get {
+                return ResourceManager.GetString("SettingsSaveError", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Bytes.
         /// </summary>
         internal static string SizeBytes {
@@ -1205,6 +1214,15 @@ namespace WireSockUI.Properties {
         internal static string TunnelKillSwitchStateError {
             get {
                 return ResourceManager.GetString("TunnelKillSwitchStateError", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The tunnel did not report an active connection in time. WireSock UI stopped the pending tunnel; try again or check the log..
+        /// </summary>
+        internal static string TunnelConnectTimeout {
+            get {
+                return ResourceManager.GetString("TunnelConnectTimeout", resourceCulture);
             }
         }
 

--- a/WireSockUI/Properties/Resources.resx
+++ b/WireSockUI/Properties/Resources.resx
@@ -376,6 +376,9 @@
   <data name="SettingsSave" xml:space="preserve">
     <value>Save</value>
   </data>
+  <data name="SettingsSaveError" xml:space="preserve">
+    <value>Error saving settings: {0}</value>
+  </data>
   <data name="SizeBytes" xml:space="preserve">
     <value>Bytes</value>
   </data>
@@ -498,6 +501,9 @@
   </data>
   <data name="TunnelKillSwitchStateError" xml:space="preserve">
     <value>Unable to confirm the current Kill Switch state.</value>
+  </data>
+  <data name="TunnelConnectTimeout" xml:space="preserve">
+    <value>The tunnel did not report an active connection in time. WireSock UI stopped the pending tunnel; try again or check the log.</value>
   </data>
   <data name="TunnelErrorStart" xml:space="preserve">
     <value>Tunnel has failed to start. Please check log.</value>

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -43,6 +43,7 @@ namespace WireSockUI
         private readonly LogPrinter _logPrinter;
 
         private readonly BlockingCollection<LogMessage> _logQueue;
+        private readonly BackgroundWorker _logWorker;
         private readonly object _syncRoot = new object();
 
         private volatile IntPtr _handle = IntPtr.Zero;
@@ -60,7 +61,8 @@ namespace WireSockUI
         public WireSockManager(LogMessageCallback logMessageCallback = null)
         {
             _logQueue = new BlockingCollection<LogMessage>(new ConcurrentQueue<LogMessage>());
-            InitializeLogWorker(logMessageCallback).RunWorkerAsync();
+            _logWorker = InitializeLogWorker(logMessageCallback);
+            _logWorker.RunWorkerAsync();
 
             TunnelMode = Mode.Transparent;
 
@@ -315,12 +317,13 @@ namespace WireSockUI
                     }
                 }
 
+                _disposed = true;
                 CompleteLogQueue();
+                if (!_logWorker.IsBusy)
+                    _logWorker.Dispose();
 
                 if (_logPrinterHandle.IsAllocated)
                     _logPrinterHandle.Free();
-
-                _disposed = true;
             }
         }
 
@@ -368,6 +371,12 @@ namespace WireSockUI
             {
                 if (e.UserState is LogMessage message)
                     logMessageCallback?.Invoke(message);
+            };
+
+            worker.RunWorkerCompleted += (s, e) =>
+            {
+                if (_disposed)
+                    worker.Dispose();
             };
 
             return worker;
@@ -476,15 +485,24 @@ namespace WireSockUI
                         return false;
                     }
 
-                    if (_adapterMode == Mode.VirtualAdapter)
-                        ChangeNetConnectionIdByAdapterName("Wiresock Virtual Adapter", profile);
-
                     if (!_startTunnel(_handle))
                     {
                         ShowTunnelError(Resources.TunnelErrorStart);
 
                         DropFailedConnectHandle();
                         return false;
+                    }
+
+                    if (_adapterMode == Mode.VirtualAdapter)
+                    {
+                        try
+                        {
+                            ChangeNetConnectionIdByAdapterName("Wiresock Virtual Adapter", profile);
+                        }
+                        catch (Exception ex)
+                        {
+                            PrintLog($"Tunnel is active, but WireSock UI could not rename the virtual adapter: {ex.Message}");
+                        }
                     }
                 }
                 catch (DllNotFoundException ex)

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -318,9 +318,13 @@ namespace WireSockUI
                 }
 
                 _disposed = true;
-                CompleteLogQueue();
-                if (!_logWorker.IsBusy)
-                    _logWorker.Dispose();
+
+                if (disposing)
+                {
+                    CompleteLogQueue();
+                    if (!_logWorker.IsBusy)
+                        _logWorker.Dispose();
+                }
 
                 if (_logPrinterHandle.IsAllocated)
                     _logPrinterHandle.Free();
@@ -369,7 +373,7 @@ namespace WireSockUI
 
             worker.ProgressChanged += (s, e) =>
             {
-                if (e.UserState is LogMessage message)
+                if (!_disposed && e.UserState is LogMessage message)
                     logMessageCallback?.Invoke(message);
             };
 

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -367,8 +367,24 @@ namespace WireSockUI
 
             worker.DoWork += (s, e) =>
             {
-                foreach (var message in logQueue.GetConsumingEnumerable())
-                    worker.ReportProgress(0, message);
+                while (!_disposed)
+                {
+                    try
+                    {
+                        if (logQueue.TryTake(out var message, 500))
+                            worker.ReportProgress(0, message);
+                        else if (logQueue.IsCompleted)
+                            break;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        break;
+                    }
+                }
             };
 
             worker.ProgressChanged += (s, e) =>


### PR DESCRIPTION
**Summary**
- Move profile storage to `%ProgramData%\WireSockUI\Configs` with administrators-only ACLs and migrate legacy per-user profiles into the secured location.
- Reject app-local `wgbooster.dll` loading from directories writable by non-administrative/service identities.
- Add script-hook confirmation on import/save and activation, handle profile rename safely, and surface settings-save failures.
- Improve tunnel activation reliability with a 30-second connection timeout, non-fatal virtual adapter rename failures, and safer log worker cleanup.
- Fix time-ago formatting for plural and future/negative values and document profile storage/script-hook migration notes.

**Review comment follow-up**
- Created secured directories with ACLs at creation time, then reapplied ACLs to existing children.
- Broadened app-local DLL ACL checks to treat any writable non-admin/service SID as unsafe.
- Removed migrated legacy profile copies after successful migration, and delete duplicate legacy files only when the secured copy has matching content.
- Avoided managed log queue/worker cleanup from the finalizer path and suppressed queued log callbacks after disposal.
- Restored the disabled `Activating...` UI during native connect attempts instead of presenting a Deactivate button that cannot cancel the in-flight native call.
- Kept the elevated-only DLL lookup policy; non-elevated app-local loading was not restored because WireSock driver access is elevated-only.

**Testing**
- `git diff --check`
- `dotnet run --project WireSockUI.Tests\WireSockUI.Tests.csproj --configuration Release --framework net472-windows` passed all 13 tests from a clean temp copy.
- `dotnet build WireSockUI.sln --configuration Release -p:Platform=x64 -p:UseSharedCompilation=false -m:1` passed with 0 warnings and 0 errors from a clean temp copy.

**Note**
- The local checkout has stale `obj` directory permission issues, so full verification was run from a clean temp copy excluding generated `bin`/`obj` artifacts.
