### PR TITLE
Fix production review follow-up issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ At startup WireSockUI looks for `wgbooster.dll` in this order:
 3. WireSock Secure Connect Pro SDK registry install locations under `HKLM\Software\WireSock Foundation\WireSock Secure Connect Pro`.
 4. The legacy WireSock VPN Client registry location under `HKLM\SOFTWARE\NTKernelResources\WinpkFilterForVPNClient`.
 
-For each registered install location it checks `sdk`, `bin`, and the install root. The discovered directory is added to the process `PATH` so the native library can be loaded without changing the machine-wide environment.
+For each registered install location it checks `sdk`, `bin`, and the install root. The discovered directory is registered with the process through `SetDllDirectory` so the native library can be loaded without changing the machine-wide environment.
 
 ## Configuration Notes
 
@@ -34,7 +34,7 @@ WireSock-specific directives may use the current SDK comment-extension syntax:
 
 Plain WireGuard keys are still parsed normally. WireSockUI validates common SDK fields such as script hooks, masking parameters, SOCKS5 settings, `BypassLanTraffic`, and profile-level `VirtualAdapterMode` while preserving the file-based profile workflow.
 
-Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are moved into the secured folder on startup when no secured profile with the same name exists. If a secured profile already exists, the legacy copy is deleted only when its content matches.
+Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are moved into the secured folder on startup when no secured profile with the same name exists. If a secured profile already exists, the legacy copy is deleted only when its content matches. Profile files that are reparse points are not loaded, imported, saved over, or activated; app-owned reparse-point files in the secured profile tree are removed during startup hardening when possible.
 
 Profiles containing `PreUp`, `PostUp`, `PreDown`, or `PostDown` script hooks require confirmation before import/save and again before activation. Treat script-hook profiles as privileged code.
 

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -36,6 +36,7 @@ namespace WireSockUI.Tests
                 { "Profile enumeration accepts uppercase conf extension", ProfileEnumerationAcceptsUppercaseConfExtension },
                 { "Profile rejects directory profile paths", ProfileRejectsDirectoryProfilePaths },
                 { "Profile rejects reparse point profile files", ProfileRejectsReparsePointProfileFiles },
+                { "Profile reports missing profile paths clearly", ProfileReportsMissingProfilePathsClearly },
                 { "Parser strips WireSock directive prefixes", ParserStripsWireSockDirectivePrefixes },
                 { "Parser rejects duplicate sections", ParserRejectsDuplicateSections },
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
@@ -189,6 +190,19 @@ namespace WireSockUI.Tests
                     "Expected directory profile paths to be excluded from enumeration.");
                 AssertThrows<IOException>(() => Profile.EnsureRegularProfileFile(profileDirectory), "directory");
                 AssertThrows<IOException>(() => new Profile(profileDirectory), "directory");
+            });
+        }
+
+        private static void ProfileReportsMissingProfilePathsClearly()
+        {
+            WithTemporaryConfigFolder(() =>
+            {
+                var missingProfile = Path.Combine(Global.ConfigsFolder, "missing.conf");
+
+                AssertFalse(Profile.IsRegularProfileFile(missingProfile, out var diagnostic),
+                    "Expected missing profile paths to be rejected.");
+                AssertTrue(diagnostic.IndexOf("does not exist", StringComparison.OrdinalIgnoreCase) >= 0,
+                    $"Expected a clear missing-file diagnostic, got '{diagnostic}'.");
             });
         }
 

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using WireSockUI.Config;
 using WireSockUI.Extensions;
 using WireSockUI.Native;
@@ -13,6 +14,15 @@ namespace WireSockUI.Tests
     {
         private static readonly string PrivateKey = Convert.ToBase64String(Enumerable.Repeat((byte)1, 32).ToArray());
         private static readonly string PublicKey = Convert.ToBase64String(Enumerable.Repeat((byte)2, 32).ToArray());
+        private const int SymbolicLinkFlagFile = 0;
+        private const int SymbolicLinkFlagAllowUnprivilegedCreate = 2;
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        private static extern bool CreateSymbolicLink(
+            string lpSymlinkFileName,
+            string lpTargetFileName,
+            int dwFlags);
 
         private static int Main()
         {
@@ -24,6 +34,8 @@ namespace WireSockUI.Tests
                 { "Profile path rejects unsafe names", ProfilePathRejectsUnsafeNames },
                 { "Profile reports configured script hooks", ProfileReportsConfiguredScriptHooks },
                 { "Profile enumeration accepts uppercase conf extension", ProfileEnumerationAcceptsUppercaseConfExtension },
+                { "Profile rejects directory profile paths", ProfileRejectsDirectoryProfilePaths },
+                { "Profile rejects reparse point profile files", ProfileRejectsReparsePointProfileFiles },
                 { "Parser strips WireSock directive prefixes", ParserStripsWireSockDirectivePrefixes },
                 { "Parser rejects duplicate sections", ParserRejectsDuplicateSections },
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
@@ -139,6 +151,44 @@ namespace WireSockUI.Tests
 
                 var profiles = Profile.GetProfiles().ToList();
                 AssertTrue(profiles.Contains("Office"), "Expected .CONF profiles to be listed on Windows.");
+            });
+        }
+
+        private static void ProfileRejectsReparsePointProfileFiles()
+        {
+            WithTemporaryConfigFolder(() =>
+            {
+                var target = Path.Combine(Global.ConfigsFolder, "target.conf");
+                var link = Path.Combine(Global.ConfigsFolder, "linked.conf");
+                File.WriteAllText(target, ValidConfig());
+
+                if (!TryCreateFileSymbolicLink(link, target))
+                {
+                    Console.WriteLine("SKIP file symlink creation unavailable; reparse profile check not exercised.");
+                    return;
+                }
+
+                AssertTrue(Profile.ProfilePathExists(link),
+                    "Expected profile path existence checks to detect reparse point files.");
+                var profiles = Profile.GetProfiles().ToList();
+                AssertFalse(profiles.Contains("linked", StringComparer.OrdinalIgnoreCase),
+                    "Expected reparse point profiles to be excluded from enumeration.");
+                AssertThrows<IOException>(() => new Profile(link), "reparse point");
+            });
+        }
+
+        private static void ProfileRejectsDirectoryProfilePaths()
+        {
+            WithTemporaryConfigFolder(() =>
+            {
+                var profileDirectory = Path.Combine(Global.ConfigsFolder, "folder.conf");
+                Directory.CreateDirectory(profileDirectory);
+
+                var profiles = Profile.GetProfiles().ToList();
+                AssertFalse(profiles.Contains("folder", StringComparer.OrdinalIgnoreCase),
+                    "Expected directory profile paths to be excluded from enumeration.");
+                AssertThrows<IOException>(() => Profile.EnsureRegularProfileFile(profileDirectory), "directory");
+                AssertThrows<IOException>(() => new Profile(profileDirectory), "directory");
             });
         }
 
@@ -274,6 +324,27 @@ namespace WireSockUI.Tests
             var path = Path.Combine(directory, $"{Guid.NewGuid():N}.conf");
             File.WriteAllText(path, contents);
             return path;
+        }
+
+        private static string ValidConfig()
+        {
+            return "[Interface]\n" +
+                   $"PrivateKey = {PrivateKey}\n" +
+                   "Address = 10.0.0.2/32\n" +
+                   "\n" +
+                   "[Peer]\n" +
+                   $"PublicKey = {PublicKey}\n" +
+                   "Endpoint = example.com:51820\n" +
+                   "AllowedIPs = 0.0.0.0/0\n";
+        }
+
+        private static bool TryCreateFileSymbolicLink(string linkPath, string targetPath)
+        {
+            if (CreateSymbolicLink(linkPath, targetPath,
+                    SymbolicLinkFlagFile | SymbolicLinkFlagAllowUnprivilegedCreate))
+                return true;
+
+            return CreateSymbolicLink(linkPath, targetPath, SymbolicLinkFlagFile);
         }
 
         private static void WithTemporaryConfigFolder(Action action)

--- a/WireSockUI/Config/Profile.cs
+++ b/WireSockUI/Config/Profile.cs
@@ -52,8 +52,10 @@ namespace WireSockUI.Config
         /// <param name="profilePath">Full filepath to a profile</param>
         public Profile(string profilePath)
         {
-            if (!File.Exists(profilePath))
+            if (!ProfilePathExists(profilePath))
                 throw new FileNotFoundException($"Profile {Path.GetFileName(profilePath)} does not exist.");
+
+            EnsureRegularProfileFile(profilePath);
 
             var parser = new ConfigParser(profilePath);
             var sections = parser.GetSectionNames();
@@ -507,6 +509,12 @@ namespace WireSockUI.Config
             {
                 if (!file.EndsWith(".conf", StringComparison.OrdinalIgnoreCase)) continue;
 
+                if (!IsRegularProfileFile(file, out var diagnostic))
+                {
+                    Trace.TraceWarning(diagnostic);
+                    continue;
+                }
+
                 var profileName = Path.GetFileNameWithoutExtension(file);
                 if (!IsValidProfileName(profileName))
                 {
@@ -575,6 +583,75 @@ namespace WireSockUI.Config
         {
             var filename = GetProfilePath(profileName);
             return new Profile(filename);
+        }
+
+        internal static void EnsureRegularProfileFile(string profilePath)
+        {
+            if (!IsRegularProfileFile(profilePath, out var diagnostic))
+                throw new IOException(diagnostic);
+        }
+
+        internal static bool ProfilePathExists(string profilePath)
+        {
+            if (string.IsNullOrWhiteSpace(profilePath))
+                return false;
+
+            try
+            {
+                File.GetAttributes(profilePath);
+                return true;
+            }
+            catch (FileNotFoundException)
+            {
+                return false;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning(
+                    $"Unable to inspect profile path '{Path.GetFileName(profilePath)}': {ex.Message}");
+                return true;
+            }
+        }
+
+        internal static bool IsRegularProfileFile(string profilePath, out string diagnostic)
+        {
+            diagnostic = null;
+
+            try
+            {
+                if (string.IsNullOrWhiteSpace(profilePath))
+                {
+                    diagnostic = "Profile path is empty.";
+                    return false;
+                }
+
+                var attributes = File.GetAttributes(profilePath);
+                if ((attributes & FileAttributes.Directory) != 0)
+                {
+                    diagnostic =
+                        $"Profile path '{Path.GetFileName(profilePath)}' is a directory and will not be loaded by elevated WireSock UI.";
+                    return false;
+                }
+
+                if ((attributes & FileAttributes.ReparsePoint) != 0)
+                {
+                    diagnostic =
+                        $"Profile file '{Path.GetFileName(profilePath)}' is a reparse point and will not be loaded by elevated WireSock UI.";
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                diagnostic =
+                    $"Unable to inspect profile file '{Path.GetFileName(profilePath)}': {ex.Message}";
+                return false;
+            }
         }
 
         private static string GetRequiredValue(string profilePath, string sectionName, Dictionary<string, string> section,

--- a/WireSockUI/Config/Profile.cs
+++ b/WireSockUI/Config/Profile.cs
@@ -646,6 +646,16 @@ namespace WireSockUI.Config
 
                 return true;
             }
+            catch (FileNotFoundException)
+            {
+                diagnostic = $"Profile file '{Path.GetFileName(profilePath)}' does not exist.";
+                return false;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                diagnostic = $"Profile directory for '{Path.GetFileName(profilePath)}' does not exist.";
+                return false;
+            }
             catch (Exception ex)
             {
                 diagnostic =

--- a/WireSockUI/Extensions/BitmapExtensions.cs
+++ b/WireSockUI/Extensions/BitmapExtensions.cs
@@ -36,7 +36,8 @@ namespace WireSockUI.Extensions
         public static Icon SuperImpose(this Icon icon, int size, WindowsIcons.Icons imposed, int imposedSize,
             int imposedOffset)
         {
-            using (var bitmap = new Icon(icon, new Size(size, size)).ToBitmap())
+            using (var resizedIcon = new Icon(icon, new Size(size, size)))
+            using (var bitmap = resizedIcon.ToBitmap())
             {
                 using (var gr = Graphics.FromImage(bitmap))
                 {

--- a/WireSockUI/Forms/frmEdit.cs
+++ b/WireSockUI/Forms/frmEdit.cs
@@ -50,7 +50,9 @@ namespace WireSockUI.Forms
                 Text = string.Format(Resources.EditProfileTitle, config);
 
                 txtProfileName.Text = config;
-                txtEditor.Text = File.ReadAllText(Profile.GetProfilePath(config));
+                var profilePath = Profile.GetProfilePath(config);
+                Profile.EnsureRegularProfileFile(profilePath);
+                txtEditor.Text = File.ReadAllText(profilePath);
             }
 
             var textChanged = ApplySyntaxHighlighting();
@@ -562,7 +564,7 @@ namespace WireSockUI.Forms
                            !string.Equals(_originalProfileName, requestedProfileName,
                                StringComparison.OrdinalIgnoreCase);
 
-            if (File.Exists(profilePath) && (!isExistingProfile || isRename))
+            if (Profile.ProfilePathExists(profilePath) && (!isExistingProfile || isRename))
             {
                 MessageBox.Show(string.Format(Resources.AddProfileExistsMsg, requestedProfileName),
                     Resources.EditProfileError,
@@ -583,10 +585,15 @@ namespace WireSockUI.Forms
 
             try
             {
-                if (File.Exists(profilePath))
+                if (Profile.ProfilePathExists(profilePath))
+                {
+                    Profile.EnsureRegularProfileFile(profilePath);
                     File.Replace(tmpProfile, profilePath, null);
+                }
                 else
+                {
                     File.Move(tmpProfile, profilePath);
+                }
 
                 if (isRename)
                     TryDeleteOriginalProfile(_originalProfileName, profilePath);
@@ -612,8 +619,11 @@ namespace WireSockUI.Forms
                 var originalProfilePath = Profile.GetProfilePath(originalProfileName);
                 if (!string.Equals(Path.GetFullPath(originalProfilePath), Path.GetFullPath(newProfilePath),
                         StringComparison.OrdinalIgnoreCase) &&
-                    File.Exists(originalProfilePath))
+                    Profile.ProfilePathExists(originalProfilePath))
+                {
+                    Profile.EnsureRegularProfileFile(originalProfilePath);
                     File.Delete(originalProfilePath);
+                }
             }
             catch (Exception ex)
             {

--- a/WireSockUI/Forms/frmEdit.cs
+++ b/WireSockUI/Forms/frmEdit.cs
@@ -566,7 +566,11 @@ namespace WireSockUI.Forms
 
             if (Profile.ProfilePathExists(profilePath) && (!isExistingProfile || isRename))
             {
-                MessageBox.Show(string.Format(Resources.AddProfileExistsMsg, requestedProfileName),
+                var message = Profile.IsRegularProfileFile(profilePath, out var diagnostic)
+                    ? string.Format(Resources.AddProfileExistsMsg, requestedProfileName)
+                    : diagnostic;
+
+                MessageBox.Show(message,
                     Resources.EditProfileError,
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
                 TryDeleteTemporaryProfile(tmpProfile);

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -188,14 +188,21 @@ namespace WireSockUI.Forms
             while (panel.Controls.Count > 0)
             {
                 var control = panel.Controls[0];
-                if (control is PictureBox pictureBox &&
-                    (ReferenceEquals(pictureBox.Image, _inactiveStatusImage) ||
-                     ReferenceEquals(pictureBox.Image, _connectedStatusImage)))
-                    pictureBox.Image = null;
-
+                DetachSharedStatusImages(control);
                 panel.Controls.RemoveAt(0);
                 control.Dispose();
             }
+        }
+
+        private void DetachSharedStatusImages(Control control)
+        {
+            if (control is PictureBox pictureBox &&
+                (ReferenceEquals(pictureBox.Image, _inactiveStatusImage) ||
+                 ReferenceEquals(pictureBox.Image, _connectedStatusImage)))
+                pictureBox.Image = null;
+
+            foreach (Control child in control.Controls)
+                DetachSharedStatusImages(child);
         }
 
         private bool TryGetProfileItem(string profileName, out ListViewItem profileItem)

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -342,14 +342,18 @@ namespace WireSockUI.Forms
                     }
                 });
 
-                cleanupTask.ContinueWith(task =>
-                    Trace.TraceWarning(
-                        $"WireSock manager shutdown completed with an error after exit continued: {task.Exception?.GetBaseException().Message}"),
-                    TaskContinuationOptions.OnlyOnFaulted);
-
                 if (!cleanupTask.Wait(ShutdownDisconnectTimeoutMilliseconds))
+                {
                     Trace.TraceWarning(
                         $"WireSock manager shutdown exceeded {ShutdownDisconnectTimeoutMilliseconds} ms; continuing application exit.");
+
+                    cleanupTask.ContinueWith(task =>
+                            Trace.TraceWarning(
+                                $"WireSock manager shutdown completed with an error after exit continued: {task.Exception?.GetBaseException().Message}"),
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted,
+                        TaskScheduler.Default);
+                }
             }
             catch (AggregateException ex)
             {

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -479,7 +479,10 @@ namespace WireSockUI.Forms
                     return;
 
                 if (e.Error != null)
+                {
                     Trace.TraceWarning($"Tunnel connection monitor stopped unexpectedly: {e.Error.Message}");
+                    return;
+                }
 
                 if (_currentState == ConnectionState.Connecting && !_wiresock.Connected && !worker.IsBusy)
                     worker.RunWorkerAsync(CurrentTunnelGeneration());
@@ -610,7 +613,10 @@ namespace WireSockUI.Forms
                     return;
 
                 if (e.Error != null)
+                {
                     Trace.TraceWarning($"Tunnel state monitor stopped unexpectedly: {e.Error.Message}");
+                    return;
+                }
 
                 if (_currentState == ConnectionState.Connected && _wiresock.Connected && !worker.IsBusy)
                     worker.RunWorkerAsync(CurrentTunnelGeneration());

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -930,18 +930,23 @@ namespace WireSockUI.Forms
 
                 var profileName = Path.GetFileNameWithoutExtension(filePath);
 
-                if (Profile.GetProfiles().Contains(profileName, StringComparer.OrdinalIgnoreCase))
-                {
-                    MessageBox.Show(string.Format(Resources.AddProfileExistsMsg, profileName),
-                        Resources.AddProfileExistsTitle,
-                        MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return;
-                }
-
                 if (!Profile.IsValidProfileName(profileName))
                 {
                     MessageBox.Show(Resources.EditProfileNameError, Resources.ProfileError, MessageBoxButtons.OK,
                         MessageBoxIcon.Error);
+                    return;
+                }
+
+                var destinationPath = Profile.GetProfilePath(profileName);
+                if (Profile.ProfilePathExists(destinationPath))
+                {
+                    var message = Profile.IsRegularProfileFile(destinationPath, out var diagnostic)
+                        ? string.Format(Resources.AddProfileExistsMsg, profileName)
+                        : diagnostic;
+
+                    MessageBox.Show(message,
+                        Resources.AddProfileExistsTitle,
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
@@ -950,16 +955,6 @@ namespace WireSockUI.Forms
                     var profile = new Profile(filePath);
                     if (!ProfileScriptWarning.ConfirmIfProfileHasScriptHooks(this, profile))
                         return;
-
-                    var destinationPath = Profile.GetProfilePath(profileName);
-                    if (Profile.ProfilePathExists(destinationPath))
-                    {
-                        Profile.EnsureRegularProfileFile(destinationPath);
-                        MessageBox.Show(string.Format(Resources.AddProfileExistsMsg, profileName),
-                            Resources.AddProfileExistsTitle,
-                            MessageBoxButtons.OK, MessageBoxIcon.Error);
-                        return;
-                    }
 
                     File.Copy(filePath, destinationPath);
                     LoadProfiles(profileName);

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -31,6 +31,8 @@ namespace WireSockUI.Forms
         private readonly BackgroundWorker _tunnelConnectionWorker;
         private readonly BackgroundWorker _tunnelStateWorker;
         private const int TunnelConnectionTimeoutMilliseconds = 30000;
+        private const int MaxVisibleLogMessages = 2000;
+        private const int ShutdownDisconnectTimeoutMilliseconds = 5000;
 
         /**
          * @brief The manager that handles the Wireguard connections.
@@ -44,6 +46,8 @@ namespace WireSockUI.Forms
         private int _tunnelGeneration;
         private int _tunnelConnectionTimeoutGeneration;
         private Icon _ownedTrayIcon;
+        private Image _inactiveStatusImage;
+        private Image _connectedStatusImage;
 
         private sealed class TunnelConnectionProgress
         {
@@ -77,8 +81,10 @@ namespace WireSockUI.Forms
 
             // Configure icons
             Icon = Resources.ico;
+            _inactiveStatusImage = BitmapExtensions.DrawCircle(16, 15, Brushes.DarkGray);
+            _connectedStatusImage = GetWindowsIconBitmap(WindowsIcons.Icons.Activated, 16);
             SetTrayIcon(Resources.ico, false);
-            cmiStatus.Image = BitmapExtensions.DrawCircle(16, 15, Brushes.DarkGray);
+            SetStatusImage(null, _inactiveStatusImage);
 
             // Populate menu items with Windows supplied icons
             ddmAddTunnel.Image = GetWindowsIconBitmap(WindowsIcons.Icons.Addtunnel, 16);
@@ -154,6 +160,42 @@ namespace WireSockUI.Forms
         {
             if (layoutInterface.Controls["btnActivate"] is Button btnActivate)
                 btnActivate.Enabled = enabled;
+        }
+
+        private void SetStatusImage(PictureBox imgStatus, Image image)
+        {
+            if (imgStatus != null)
+                imgStatus.Image = image;
+
+            cmiStatus.Image = image;
+        }
+
+        private void DisposeStatusImages()
+        {
+            foreach (var control in layoutInterface.Controls.Find("imgStatus", true))
+                if (control is PictureBox pictureBox)
+                    pictureBox.Image = null;
+
+            cmiStatus.Image = null;
+            _inactiveStatusImage?.Dispose();
+            _inactiveStatusImage = null;
+            _connectedStatusImage?.Dispose();
+            _connectedStatusImage = null;
+        }
+
+        private void ClearDynamicLayout(TableLayoutPanel panel)
+        {
+            while (panel.Controls.Count > 0)
+            {
+                var control = panel.Controls[0];
+                if (control is PictureBox pictureBox &&
+                    (ReferenceEquals(pictureBox.Image, _inactiveStatusImage) ||
+                     ReferenceEquals(pictureBox.Image, _connectedStatusImage)))
+                    pictureBox.Image = null;
+
+                panel.Controls.RemoveAt(0);
+                control.Dispose();
+            }
         }
 
         private bool TryGetProfileItem(string profileName, out ListViewItem profileItem)
@@ -261,23 +303,55 @@ namespace WireSockUI.Forms
             _tunnelConnectionWorker.CancelAsync();
             _tunnelStateWorker.CancelAsync();
 
-            try
-            {
-                _wiresock?.Disconnect();
-                _wiresock?.Dispose();
-            }
-            catch (Exception ex)
-            {
-                Trace.TraceWarning($"Failed to cleanly shut down WireSock manager: {ex.Message}");
-            }
+            DisposeWireSockWithTimeout();
 
             trayIcon.Visible = false;
             SetTrayIcon(null, false);
+            DisposeStatusImages();
 
             if (Global.AlreadyRunning != null)
             {
                 Global.AlreadyRunning.Dispose();
                 Global.AlreadyRunning = null;
+            }
+        }
+
+        private void DisposeWireSockWithTimeout()
+        {
+            if (_wiresock == null)
+                return;
+
+            try
+            {
+                var cleanupTask = Task.Run(() =>
+                {
+                    try
+                    {
+                        _wiresock.Disconnect();
+                    }
+                    finally
+                    {
+                        _wiresock.Dispose();
+                    }
+                });
+
+                cleanupTask.ContinueWith(task =>
+                    Trace.TraceWarning(
+                        $"WireSock manager shutdown completed with an error after exit continued: {task.Exception?.GetBaseException().Message}"),
+                    TaskContinuationOptions.OnlyOnFaulted);
+
+                if (!cleanupTask.Wait(ShutdownDisconnectTimeoutMilliseconds))
+                    Trace.TraceWarning(
+                        $"WireSock manager shutdown exceeded {ShutdownDisconnectTimeoutMilliseconds} ms; continuing application exit.");
+            }
+            catch (AggregateException ex)
+            {
+                Trace.TraceWarning(
+                    $"Failed to cleanly shut down WireSock manager: {ex.GetBaseException().Message}");
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to cleanly shut down WireSock manager: {ex.Message}");
             }
         }
 
@@ -390,8 +464,11 @@ namespace WireSockUI.Forms
 
             worker.RunWorkerCompleted += (s, e) =>
             {
-                if (_shutdownComplete || IsDisposed || Disposing || e.Cancelled || e.Error != null)
+                if (_shutdownComplete || IsDisposed || Disposing)
                     return;
+
+                if (e.Error != null)
+                    Trace.TraceWarning($"Tunnel connection monitor stopped unexpectedly: {e.Error.Message}");
 
                 if (_currentState == ConnectionState.Connecting && !_wiresock.Connected && !worker.IsBusy)
                     worker.RunWorkerAsync(CurrentTunnelGeneration());
@@ -518,8 +595,11 @@ namespace WireSockUI.Forms
 
             worker.RunWorkerCompleted += (s, e) =>
             {
-                if (_shutdownComplete || IsDisposed || Disposing || e.Cancelled || e.Error != null)
+                if (_shutdownComplete || IsDisposed || Disposing)
                     return;
+
+                if (e.Error != null)
+                    Trace.TraceWarning($"Tunnel state monitor stopped unexpectedly: {e.Error.Message}");
 
                 if (_currentState == ConnectionState.Connected && _wiresock.Connected && !worker.IsBusy)
                     worker.RunWorkerAsync(CurrentTunnelGeneration());
@@ -636,13 +716,11 @@ namespace WireSockUI.Forms
 
                     if (imgStatus != null)
                     {
-                        imgStatus.Image = GetWindowsIconBitmap(WindowsIcons.Icons.Activated, 16);
+                        SetStatusImage(imgStatus, _connectedStatusImage);
                         if (txtStatus != null) txtStatus.Text = Resources.InterfaceStatusActive;
 
                         SetTrayIcon(Resources.ico.SuperImpose(64, WindowsIcons.Icons.Activated, 48, 24), true);
                         trayIcon.Text = Resources.TrayActive;
-
-                        cmiStatus.Image = imgStatus.Image;
                     }
 
                     cmiStatus.Text = Resources.ContextMenuActive;
@@ -693,13 +771,11 @@ namespace WireSockUI.Forms
 
                     if (imgStatus != null)
                     {
-                        imgStatus.Image = BitmapExtensions.DrawCircle(16, 15, Brushes.DarkGray);
+                        SetStatusImage(imgStatus, _inactiveStatusImage);
                         if (txtStatus != null) txtStatus.Text = Resources.InterfaceStatusInactive;
 
                         SetTrayIcon(Resources.ico, false);
                         trayIcon.Text = Resources.TrayInactive;
-
-                        cmiStatus.Image = imgStatus.Image;
                     }
 
                     cmiStatus.Text = Resources.ContextMenuInactive;
@@ -858,7 +934,17 @@ namespace WireSockUI.Forms
                     if (!ProfileScriptWarning.ConfirmIfProfileHasScriptHooks(this, profile))
                         return;
 
-                    File.Copy(filePath, Profile.GetProfilePath(profileName));
+                    var destinationPath = Profile.GetProfilePath(profileName);
+                    if (Profile.ProfilePathExists(destinationPath))
+                    {
+                        Profile.EnsureRegularProfileFile(destinationPath);
+                        MessageBox.Show(string.Format(Resources.AddProfileExistsMsg, profileName),
+                            Resources.AddProfileExistsTitle,
+                            MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+
+                    File.Copy(filePath, destinationPath);
                     LoadProfiles(profileName);
                 }
                 catch (Exception ex)
@@ -911,7 +997,9 @@ namespace WireSockUI.Forms
                     if (!await DisconnectCurrentTunnelAsync())
                         return;
 
-                File.Delete(Profile.GetProfilePath(selectedConf));
+                var profilePath = Profile.GetProfilePath(selectedConf);
+                Profile.EnsureRegularProfileFile(profilePath);
+                File.Delete(profilePath);
                 LoadProfiles();
             }
             catch (Exception ex)
@@ -1135,6 +1223,9 @@ namespace WireSockUI.Forms
                 ListViewItem item = new ListViewItem(new[]
                     { logMessage.Timestamp.ToString(Resources.LogTimestampFormat), logMessage.Message });
                 lstLog.Items.Add(item);
+                while (lstLog.Items.Count > MaxVisibleLogMessages)
+                    lstLog.Items.RemoveAt(0);
+
                 lstLog.Items[lstLog.Items.Count - 1].EnsureVisible();
             }
             catch (ObjectDisposedException)
@@ -1167,15 +1258,15 @@ namespace WireSockUI.Forms
         {
             gbxInterface.Visible = false;
             gbxInterface.Text = string.Empty;
-            layoutInterface.Controls.Clear();
+            ClearDynamicLayout(layoutInterface);
             layoutInterface.RowStyles.Clear();
 
             gbxPeer.Visible = false;
-            layoutPeer.Controls.Clear();
+            ClearDynamicLayout(layoutPeer);
             layoutPeer.RowStyles.Clear();
 
             gbxState.Visible = false;
-            layoutState.Controls.Clear();
+            ClearDynamicLayout(layoutState);
             layoutState.RowStyles.Clear();
 
             if (e.IsSelected)
@@ -1190,7 +1281,7 @@ namespace WireSockUI.Forms
                     gbxInterface.Text = string.Format(Resources.InterfaceTitle, selectedConf);
 
                     AddRow(layoutInterface, "Status", Resources.InterfaceStatus, Resources.InterfaceStatusInactive,
-                        false, BitmapExtensions.DrawCircle(16, 15, Brushes.DarkGray));
+                        false, _inactiveStatusImage);
                     AddRow(layoutInterface, "PrivateKey", Resources.InterfacePublicKey, profile.PublicKey);
                     AddRow(layoutInterface, "MTU", Resources.InterfaceMTU, profile.Mtu, true);
                     AddRow(layoutInterface, "ListenPort", Resources.InterfaceListenPort, profile.ListenPort, true);
@@ -1282,7 +1373,7 @@ namespace WireSockUI.Forms
             return;
 
             void AddRow(TableLayoutPanel container, string name, string key, string value, bool isOptional = false,
-                Bitmap icon = null)
+                Image icon = null)
             {
                 if (isOptional && string.IsNullOrWhiteSpace(value)) return;
 

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -119,7 +119,7 @@ namespace WireSockUI
                 {
                     if (IsReparsePoint(file))
                     {
-                        Trace.TraceWarning($"Skipping WireSock UI configuration file reparse point '{file}'.");
+                        DeleteConfigurationFileReparsePoint(file);
                         continue;
                     }
 
@@ -177,6 +177,20 @@ namespace WireSockUI
             {
                 Trace.TraceWarning($"Unable to inspect reparse point attributes for '{path}': {ex.Message}");
                 return true;
+            }
+        }
+
+        private static void DeleteConfigurationFileReparsePoint(string file)
+        {
+            try
+            {
+                File.Delete(file);
+                Trace.TraceWarning($"Deleted WireSock UI configuration file reparse point '{file}'.");
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning(
+                    $"Skipping WireSock UI configuration file reparse point '{file}' because it could not be deleted: {ex.Message}");
             }
         }
     }

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -182,6 +182,26 @@ namespace WireSockUI
 
         private static void DeleteConfigurationFileReparsePoint(string file)
         {
+            FileAttributes attributes;
+
+            try
+            {
+                attributes = File.GetAttributes(file);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning(
+                    $"Skipping WireSock UI configuration file reparse point '{file}' because its attributes could not be inspected: {ex.Message}");
+                return;
+            }
+
+            if ((attributes & FileAttributes.ReparsePoint) == 0)
+            {
+                Trace.TraceWarning(
+                    $"Skipping WireSock UI configuration file '{file}' because it is no longer a reparse point.");
+                return;
+            }
+
             try
             {
                 File.Delete(file);

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -327,8 +327,15 @@ namespace WireSockUI
                 }
 
                 var destinationPath = Profile.GetProfilePath(profileName);
-                if (File.Exists(destinationPath))
+                if (Profile.ProfilePathExists(destinationPath))
                 {
+                    if (!Profile.IsRegularProfileFile(destinationPath, out var diagnostic))
+                    {
+                        Trace.TraceWarning(
+                            $"Skipping legacy profile '{profileName}' because the secured profile path is unsafe: {diagnostic}");
+                        continue;
+                    }
+
                     if (FilesHaveSameContent(legacyProfilePath, destinationPath))
                         TryDeleteLegacyProfile(legacyProfilePath, profileName);
                     else

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -42,6 +42,7 @@ namespace WireSockUI
 
         private readonly LogPrinter _logPrinter;
 
+        private const int MaxQueuedLogMessages = 1000;
         private readonly BlockingCollection<LogMessage> _logQueue;
         private readonly BackgroundWorker _logWorker;
         private readonly object _syncRoot = new object();
@@ -60,7 +61,9 @@ namespace WireSockUI
         /// </param>
         public WireSockManager(LogMessageCallback logMessageCallback = null)
         {
-            _logQueue = new BlockingCollection<LogMessage>(new ConcurrentQueue<LogMessage>());
+            _logQueue = new BlockingCollection<LogMessage>(
+                new ConcurrentQueue<LogMessage>(),
+                MaxQueuedLogMessages);
             _logWorker = InitializeLogWorker(logMessageCallback);
             _logWorker.RunWorkerAsync();
 
@@ -342,7 +345,12 @@ namespace WireSockUI
 
             try
             {
-                _logQueue.Add(new LogMessage { Message = message });
+                var logMessage = new LogMessage { Message = message };
+                if (_logQueue.TryAdd(logMessage))
+                    return;
+
+                _logQueue.TryTake(out _);
+                _logQueue.TryAdd(logMessage);
             }
             catch (InvalidOperationException)
             {
@@ -481,6 +489,8 @@ namespace WireSockUI
 
                 try
                 {
+                    Profile.EnsureRegularProfileFile(profilePath);
+
                     if (_handle != IntPtr.Zero && !DropCurrentHandle(true))
                         return ShowTunnelError(
                             "A previous WireSock tunnel handle could not be released. Retry disconnect or restart WireSock UI before connecting again.");

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -501,7 +501,8 @@ namespace WireSockUI
 
                 try
                 {
-                    Profile.EnsureRegularProfileFile(profilePath);
+                    if (!Profile.IsRegularProfileFile(profilePath, out var profileDiagnostic))
+                        return ShowTunnelError($"Failed to load profile '{profile}'.", profileDiagnostic);
 
                     if (_handle != IntPtr.Zero && !DropCurrentHandle(true))
                         return ShowTunnelError(

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -44,6 +44,7 @@ namespace WireSockUI
 
         private const int MaxQueuedLogMessages = 1000;
         private readonly BlockingCollection<LogMessage> _logQueue;
+        private readonly object _logQueueSyncRoot = new object();
         private readonly BackgroundWorker _logWorker;
         private readonly object _syncRoot = new object();
 
@@ -340,17 +341,25 @@ namespace WireSockUI
         /// <param name="message">The message to append to the log queue.</param>
         private void PrintLog(string message)
         {
-            if (_disposed || _logQueue.IsAddingCompleted)
+            if (_disposed)
                 return;
 
             try
             {
                 var logMessage = new LogMessage { Message = message };
-                if (_logQueue.TryAdd(logMessage))
-                    return;
 
-                _logQueue.TryTake(out _);
-                _logQueue.TryAdd(logMessage);
+                lock (_logQueueSyncRoot)
+                {
+                    // CompleteAdding shares this lock, so a failed TryAdd below means the bounded queue is full.
+                    if (_disposed || _logQueue.IsAddingCompleted)
+                        return;
+
+                    if (_logQueue.TryAdd(logMessage))
+                        return;
+
+                    _logQueue.TryTake(out _);
+                    _logQueue.TryAdd(logMessage);
+                }
             }
             catch (InvalidOperationException)
             {
@@ -414,8 +423,11 @@ namespace WireSockUI
         {
             try
             {
-                if (!_logQueue.IsAddingCompleted)
-                    _logQueue.CompleteAdding();
+                lock (_logQueueSyncRoot)
+                {
+                    if (!_logQueue.IsAddingCompleted)
+                        _logQueue.CompleteAdding();
+                }
             }
             catch (ObjectDisposedException)
             {


### PR DESCRIPTION
## Summary
- reject reparse-point and directory-backed profile paths across enumeration, load, import/save/delete, legacy migration, and native connect
- restart tunnel monitor workers after cancelled runs when the current state still requires monitoring
- bound native/UI log growth and clean up status image/icon ownership, including nested layout controls
- use timed background shutdown cleanup to reduce UI exit hangs
- document SetDllDirectory/profile reparse behavior and add focused profile path tests

## Verification
- git diff --check
- dotnet run --project WireSockUI.Tests\\WireSockUI.Tests.csproj --configuration Release --framework net472-windows (17 passed; symlink-specific branch skipped because Windows refused file symlink creation in this environment)
- dotnet build WireSockUI.sln --configuration Release -p:Platform=x64 -p:UseSharedCompilation=false -m:1 (0 warnings, 0 errors)
- dotnet list WireSockUI\\WireSockUI.csproj package --vulnerable --include-transitive --source https://api.nuget.org/v3/index.json (no vulnerable packages reported)