### PR TITLE
Harden tunnel lifecycle and profile handling

### DIFF
--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -49,6 +49,8 @@ namespace WireSockUI.Tests
                 { "Time formatting handles future values", TimeFormattingHandlesFutureValues },
                 { "Program path normalization preserves drive roots", ProgramPathNormalizationPreservesDriveRoots },
                 { "Program rejects user-writable WireSock library directories", ProgramRejectsUserWritableWireSockLibraryDirectories },
+                { "Program detects user-writable WireSock library files", ProgramDetectsUserWritableWireSockLibraryFiles },
+                { "Profile import rejects oversized files", ProfileImportRejectsOversizedFiles },
                 { "Editor validates Amnezia options", EditorValidatesAmneziaOptions },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi },
                 { "Stats struct matches wgbooster ABI", StatsStructMatchesWgboosterAbi }
@@ -380,6 +382,76 @@ namespace WireSockUI.Tests
             }
         }
 
+        private static void ProgramDetectsUserWritableWireSockLibraryFiles()
+        {
+            var isPotentiallyUserWritableFile = typeof(WireSockUI.Program).GetMethod("IsPotentiallyUserWritableFile",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (isPotentiallyUserWritableFile == null)
+                throw new InvalidOperationException("IsPotentiallyUserWritableFile helper was not found.");
+
+            var file = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", $"{Guid.NewGuid():N}.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(file));
+
+            try
+            {
+                File.WriteAllText(file, string.Empty);
+
+                var userWritable = (bool)isPotentiallyUserWritableFile.Invoke(null, new object[] { file });
+
+                AssertTrue(userWritable, "Expected user-writable WireSock library files to be detected.");
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(file))
+                        File.Delete(file);
+                }
+                catch
+                {
+                    // Best-effort cleanup must not hide the original test failure.
+                }
+            }
+        }
+
+        private static void ProfileImportRejectsOversizedFiles()
+        {
+            var copyProfileToTemporaryFile = typeof(FrmMain).GetMethod("CopyProfileToTemporaryFile",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (copyProfileToTemporaryFile == null)
+                throw new InvalidOperationException("CopyProfileToTemporaryFile helper was not found.");
+
+            var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+            var source = Path.Combine(directory, "oversized.conf");
+            var destination = Path.Combine(directory, "oversized.tmp");
+
+            try
+            {
+                Directory.CreateDirectory(directory);
+                using (var stream = new FileStream(source, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                {
+                    stream.SetLength(1024 * 1024 + 1);
+                }
+
+                AssertInvocationThrows<InvalidOperationException>(
+                    () => copyProfileToTemporaryFile.Invoke(null, new object[] { source, destination }),
+                    "too large");
+                AssertFalse(File.Exists(destination), "Expected oversized profile imports not to create a temp copy.");
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(directory))
+                        Directory.Delete(directory, true);
+                }
+                catch
+                {
+                    // Best-effort cleanup must not hide the original test failure.
+                }
+            }
+        }
+
         private static void EditorValidatesAmneziaOptions()
         {
             var isUIntOrRange = typeof(FrmEdit).GetMethod("IsUIntOrRange",
@@ -497,6 +569,23 @@ namespace WireSockUI.Tests
             }
 
             throw new Exception($"Expected {typeof(T).Name}.");
+        }
+
+        private static void AssertInvocationThrows<T>(Action action, string messagePart) where T : Exception
+        {
+            try
+            {
+                action();
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is T inner)
+            {
+                if (messagePart == null || inner.Message.IndexOf(messagePart, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return;
+
+                throw new Exception($"Expected inner exception message to contain '{messagePart}', got '{inner.Message}'.");
+            }
+
+            throw new Exception($"Expected invocation to throw {typeof(T).Name}.");
         }
 
         private static void AssertTrue(bool condition, string message)

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -4,8 +4,11 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using WireSockUI.Config;
 using WireSockUI.Extensions;
+using WireSockUI.Forms;
 using WireSockUI.Native;
 
 namespace WireSockUI.Tests
@@ -45,7 +48,10 @@ namespace WireSockUI.Tests
                 { "Time formatting uses singular hour for partial second hour", TimeFormattingUsesSingularHourForPartialSecondHour },
                 { "Time formatting handles future values", TimeFormattingHandlesFutureValues },
                 { "Program path normalization preserves drive roots", ProgramPathNormalizationPreservesDriveRoots },
-                { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi }
+                { "Program rejects user-writable WireSock library directories", ProgramRejectsUserWritableWireSockLibraryDirectories },
+                { "Editor validates Amnezia options", EditorValidatesAmneziaOptions },
+                { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi },
+                { "Stats struct matches wgbooster ABI", StatsStructMatchesWgboosterAbi }
             };
 
             var failures = 0;
@@ -324,10 +330,98 @@ namespace WireSockUI.Tests
             AssertEqual(Path.Combine(root, "Windows"), normalizedChild);
         }
 
+        private static void ProgramRejectsUserWritableWireSockLibraryDirectories()
+        {
+            var validate = typeof(WireSockUI.Program).GetMethod("TryValidateWireSockLibraryDirectory",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (validate == null)
+                throw new InvalidOperationException("TryValidateWireSockLibraryDirectory helper was not found.");
+
+            var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            try
+            {
+                File.WriteAllText(Path.Combine(directory, "wgbooster.dll"), string.Empty);
+
+                try
+                {
+                    var security = Directory.GetAccessControl(directory);
+                    security.AddAccessRule(new FileSystemAccessRule(
+                        WindowsIdentity.GetCurrent().User,
+                        FileSystemRights.Modify,
+                        InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                        PropagationFlags.None,
+                        AccessControlType.Allow));
+                    Directory.SetAccessControl(directory, security);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Temporary test folders are normally user-writable already; explicit ACL setup is best effort.
+                }
+
+                var args = new object[] { directory, null };
+                var accepted = (bool)validate.Invoke(null, args);
+
+                AssertFalse(accepted, "Expected user-writable WireSock library directories to be rejected.");
+                AssertTrue(args[1] == null, "Expected rejected WireSock library directories not to return a path.");
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(directory))
+                        Directory.Delete(directory, true);
+                }
+                catch
+                {
+                    // Best-effort cleanup must not hide the original test failure.
+                }
+            }
+        }
+
+        private static void EditorValidatesAmneziaOptions()
+        {
+            var isUIntOrRange = typeof(FrmEdit).GetMethod("IsUIntOrRange",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            var isUIntInRange = typeof(FrmEdit).GetMethod("IsUIntInRange",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            var isOneOf = typeof(FrmEdit).GetMethod("IsOneOf",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            if (isUIntOrRange == null || isUIntInRange == null || isOneOf == null)
+                throw new InvalidOperationException("Expected Amnezia editor validation helpers were not found.");
+
+            AssertTrue((bool)isUIntOrRange.Invoke(null, new object[] { "1-4", 0u, uint.MaxValue }),
+                "Expected decimal H ranges to be accepted.");
+            AssertTrue((bool)isUIntOrRange.Invoke(null, new object[] { "0x10-0x20", 0u, uint.MaxValue }),
+                "Expected hexadecimal H ranges to be accepted.");
+            AssertFalse((bool)isUIntOrRange.Invoke(null, new object[] { "4-1", 0u, uint.MaxValue }),
+                "Expected descending H ranges to be rejected.");
+            AssertTrue((bool)isUIntInRange.Invoke(null, new object[] { "1280", 0u, 1280u }),
+                "Expected maximum S1/S2 padding to be accepted.");
+            AssertFalse((bool)isUIntInRange.Invoke(null, new object[] { "1281", 0u, 1280u }),
+                "Expected oversized S1/S2 padding to be rejected.");
+            AssertTrue((bool)isOneOf.Invoke(null, new object[] { "quic", new[] { "quic", "dns", "sip", "stun" } }),
+                "Expected known Ip values to be accepted.");
+            AssertFalse((bool)isOneOf.Invoke(null, new object[] { "invalid", new[] { "chrome", "firefox", "curl", "random" } }),
+                "Expected unknown Ib values to be rejected.");
+        }
+
         private static void NetworkLockEnumMatchesWgboosterAbi()
         {
             AssertEqual(0, (int)WireguardBoosterExports.WgbNetworkLockMode.Disabled);
             AssertEqual(1, (int)WireguardBoosterExports.WgbNetworkLockMode.Enabled);
+        }
+
+        private static void StatsStructMatchesWgboosterAbi()
+        {
+            AssertEqual(32, Marshal.SizeOf<WireguardBoosterExports.WgbStats>());
+            AssertEqual(0, Marshal.OffsetOf<WireguardBoosterExports.WgbStats>("time_since_last_handshake").ToInt32());
+            AssertEqual(8, Marshal.OffsetOf<WireguardBoosterExports.WgbStats>("tx_bytes").ToInt32());
+            AssertEqual(16, Marshal.OffsetOf<WireguardBoosterExports.WgbStats>("rx_bytes").ToInt32());
+            AssertEqual(24, Marshal.OffsetOf<WireguardBoosterExports.WgbStats>("estimated_loss").ToInt32());
+            AssertEqual(28, Marshal.OffsetOf<WireguardBoosterExports.WgbStats>("estimated_rtt").ToInt32());
         }
 
         private static string WriteConfig(string contents)

--- a/WireSockUI/Forms/TaskManager.cs
+++ b/WireSockUI/Forms/TaskManager.cs
@@ -68,10 +68,11 @@ namespace WireSockUI.Forms
                     displayName = process.Name;
                 var iconKey = process.ProcessId.ToString();
 
-                // If the process's image file exists, extract its associated icon and add it to the list view's image list
-                if (File.Exists(process.ImageName))
+                // If the process's image file exists, extract its associated icon and add it to the list view's image list.
+                if (!string.IsNullOrWhiteSpace(process.ImageName) && File.Exists(process.ImageName))
                 {
-                    if (process.ImageName != null)
+                    try
+                    {
                         using (var icon = Icon.ExtractAssociatedIcon(process.ImageName))
                         {
                             if (icon != null)
@@ -79,8 +80,13 @@ namespace WireSockUI.Forms
                             else
                                 iconKey = defaultIconKey;
                         }
-                    else
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Trace.TraceWarning(
+                            $"Failed to extract process icon for '{process.ImageName}': {ex.Message}");
                         iconKey = defaultIconKey;
+                    }
                 }
                 else
                 {
@@ -96,26 +102,31 @@ namespace WireSockUI.Forms
         private void FilterProcesses(string filter)
         {
             lstProcesses.BeginUpdate();
-            lstProcesses.Items.Clear();
+            try
+            {
+                lstProcesses.Items.Clear();
 
-            if (string.IsNullOrEmpty(filter))
-            {
-                lstProcesses.Items.AddRange(_cachedProcessListItems.ToArray());
-            }
-            else
-            {
-                foreach (var item in _cachedProcessListItems)
+                if (string.IsNullOrEmpty(filter))
                 {
-                    if (item.Text.IndexOf(filter, StringComparison.OrdinalIgnoreCase) != -1)
+                    lstProcesses.Items.AddRange(_cachedProcessListItems.ToArray());
+                }
+                else
+                {
+                    foreach (var item in _cachedProcessListItems)
                     {
-                        var addedItem = lstProcesses.Items.Add(item);
-                        addedItem.Selected = true;
-                        addedItem.EnsureVisible();
+                        if (item.Text.IndexOf(filter, StringComparison.OrdinalIgnoreCase) != -1)
+                        {
+                            var addedItem = lstProcesses.Items.Add(item);
+                            addedItem.Selected = true;
+                            addedItem.EnsureVisible();
+                        }
                     }
                 }
             }
-
-            lstProcesses.EndUpdate();
+            finally
+            {
+                lstProcesses.EndUpdate();
+            }
         }
 
         private void OnRefreshClick(object sender, EventArgs e)
@@ -131,6 +142,9 @@ namespace WireSockUI.Forms
 
         private void OnProcessSelected(object sender, EventArgs e)
         {
+            if (lstProcesses.SelectedItems.Count == 0)
+                return;
+
             DialogResult = DialogResult.OK;
             ReturnValue = lstProcesses.SelectedItems[0].Text;
             Close();

--- a/WireSockUI/Forms/frmEdit.cs
+++ b/WireSockUI/Forms/frmEdit.cs
@@ -76,328 +76,339 @@ namespace WireSockUI.Forms
             var originalLength = txtEditor.SelectionLength;
             var originalColor = Color.Black;
 
-            lblName.Focus();
-
-            // removes any previous highlighting
-            txtEditor.SelectionStart = 0;
-            txtEditor.SelectionLength = txtEditor.Text.Length;
-            txtEditor.SelectionColor = originalColor;
-
-            txtEditor.SelectionFont = _editorRegularFont;
-          
-            foreach (Match m in ProfileMatch.Matches(txtEditor.Text))
+            try
             {
-                if (m.Groups["comment"].Success)
-                {
-                    txtEditor.SelectionStart = m.Groups["comment"].Index;
-                    txtEditor.SelectionLength = m.Groups["comment"].Length;
-                    txtEditor.SelectionFont = _editorItalicFont;
+                lblName.Focus();
 
-                    switch (m.Groups["comment"].Value[0])
+                // removes any previous highlighting
+                txtEditor.SelectionStart = 0;
+                txtEditor.SelectionLength = txtEditor.Text.Length;
+                txtEditor.SelectionColor = originalColor;
+
+                txtEditor.SelectionFont = _editorRegularFont;
+
+                foreach (Match m in ProfileMatch.Matches(txtEditor.Text))
+                {
+                    if (m.Groups["comment"].Success)
                     {
-                        case '#':
-                            txtEditor.SelectionColor = Color.LightSlateGray;
-                            break;
-                        case ';':
-                            txtEditor.SelectionColor = Color.SaddleBrown;
-                            break;
+                        txtEditor.SelectionStart = m.Groups["comment"].Index;
+                        txtEditor.SelectionLength = m.Groups["comment"].Length;
+                        txtEditor.SelectionFont = _editorItalicFont;
+
+                        switch (m.Groups["comment"].Value[0])
+                        {
+                            case '#':
+                                txtEditor.SelectionColor = Color.LightSlateGray;
+                                break;
+                            case ';':
+                                txtEditor.SelectionColor = Color.SaddleBrown;
+                                break;
+                        }
+
+                        continue;
                     }
 
-                    continue;
+                    if (m.Groups["section"].Success)
+                    {
+                        txtEditor.SelectionStart = m.Groups["section"].Index;
+                        txtEditor.SelectionLength = m.Groups["section"].Length;
+                        txtEditor.SelectionColor = Color.DarkBlue;
+                        txtEditor.SelectionFont = _editorBoldFont;
+
+                        switch (m.Groups["section"].Value.ToLowerInvariant())
+                        {
+                            case "[interface]":
+                            case "[peer]":
+                                break;
+                            // Unrecognized sections
+                            default:
+                                txtEditor.UnderlineSelection();
+                                hasErrors = true;
+                                break;
+                        }
+
+                        continue;
+                    }
+
+                    if (m.Groups["key"].Success)
+                    {
+                        txtEditor.SelectionStart = m.Groups["key"].Index;
+                        txtEditor.SelectionLength = m.Groups["key"].Length;
+                        txtEditor.SelectionColor = Color.Navy;
+
+                        var key = m.Groups["key"].Value.ToLowerInvariant();
+                        var value = string.Empty;
+
+                        if (m.Groups["value"].Success)
+                        {
+                            txtEditor.SelectionStart = m.Groups["value"].Index;
+                            txtEditor.SelectionLength = m.Groups["value"].Length;
+                            txtEditor.SelectionColor = Color.DarkGreen;
+
+                            value = m.Groups["value"].Value;
+                        }
+
+                        switch (key)
+                        {
+                            // base64 256-bit keys
+                            case "privatekey":
+                                {
+                                    if (string.IsNullOrEmpty(value))
+                                    {
+                                        // Generate a new private key
+                                        var newPrivateKey = Curve25519.CreateRandomPrivateKey();
+                                        var base64PrivateKey = Convert.ToBase64String(newPrivateKey);
+
+                                        // Insert the new private key into the text editor
+                                        txtEditor.SelectionStart = m.Groups["value"].Index;
+                                        txtEditor.SelectionLength = m.Groups["value"].Length;
+                                        txtEditor.SelectedText = base64PrivateKey;
+
+                                        // Update the public key display
+                                        txtPublicKey.Text = Convert.ToBase64String(Curve25519.GetPublicKey(newPrivateKey));
+                                        textChanged = true; // Set flag to true as text is changed
+                                    }
+                                    else
+                                    {
+                                        try
+                                        {
+                                            var binaryKey = Convert.FromBase64String(value);
+                                            if (binaryKey.Length != 32)
+                                                throw new FormatException();
+
+                                            txtPublicKey.Text = Convert.ToBase64String(Curve25519.GetPublicKey(binaryKey));
+                                        }
+                                        catch (FormatException)
+                                        {
+                                            txtEditor.UnderlineSelection();
+                                            hasErrors = true;
+                                        }
+                                    }
+                                }
+                                break;
+                            case "publickey":
+                            case "presharedkey":
+                                {
+                                    if (!string.IsNullOrEmpty(value))
+                                        try
+                                        {
+                                            var binaryKey = Convert.FromBase64String(value);
+
+                                            if (binaryKey.Length != 32)
+                                                throw new FormatException();
+                                        }
+                                        catch (FormatException)
+                                        {
+                                            txtEditor.UnderlineSelection();
+                                            hasErrors = true;
+                                        }
+                                }
+                                break;
+                            // IPv4/IPv6 CIDR notation values
+                            case "address":
+                            case "allowedips":
+                            case "disallowedips":
+                                {
+                                    foreach (Match e in MultiValueMatch.Matches(value))
+                                        if (!string.IsNullOrWhiteSpace(e.Value) &&
+                                            !IpHelper.IsValidSubnetOrSingleIpAddress(e.Value.Trim()))
+                                        {
+                                            txtEditor.SelectionStart = m.Groups["value"].Index + e.Index;
+                                            txtEditor.SelectionLength = e.Length;
+                                            txtEditor.UnderlineSelection();
+                                            hasErrors = true;
+                                        }
+                                }
+                                break;
+                            // IPv4/IPv6 values
+                            case "dns":
+                                {
+                                    foreach (Match e in MultiValueMatch.Matches(value))
+                                        if (!string.IsNullOrWhiteSpace(e.Value) && !IpHelper.IsValidIpAddress(e.Value.Trim()))
+                                        {
+                                            txtEditor.SelectionStart = m.Groups["value"].Index + e.Index;
+                                            txtEditor.SelectionLength = e.Length;
+                                            txtEditor.UnderlineSelection();
+                                            hasErrors = true;
+                                        }
+                                }
+
+                                break;
+                            // IPv4, IPv6 or DNS value
+                            case "endpoint":
+                                if (!IpHelper.IsValidAddress(value.Trim()))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+
+                                break;
+                            case "socks5proxy":
+                                if (!string.IsNullOrWhiteSpace(value) && !IpHelper.IsValidAddress(value.Trim()))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+
+                                break;
+                            // Numerical values
+                            case "mtu":
+                                if (!IsIntInRange(value, 576, 65535))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "listenport":
+                                if (!IsIntInRange(value, 1, 65535))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "persistentkeepalive":
+                            case "scriptexectimeout":
+                                if (!IsIntInRange(value, 0, 65535))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "jc":
+                                if (!IsUIntInRange(value, 0, 128))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "jd":
+                                if (!IsUIntInRange(value, 0, 200))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "jmin":
+                            case "jmax":
+                            case "s1":
+                            case "s2":
+                                if (!IsUIntInRange(value, 0, 1280))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "s3":
+                            case "s4":
+                                if (!IsUIntInRange(value, 0, uint.MaxValue))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "h1":
+                            case "h2":
+                            case "h3":
+                            case "h4":
+                                if (!IsUIntOrRange(value, 0, uint.MaxValue))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            // Comma-delimited string values
+                            case "allowedapps":
+                            case "disallowedapps":
+                                {
+                                    foreach (Match e in MultiValueMatch.Matches(value))
+                                        if (!string.IsNullOrWhiteSpace(e.Value) &&
+                                            !Regex.IsMatch(e.Value.Trim(),
+                                                @"^(?:[a-zA-Z]:\\)?(?:[^<>:\\\""/\\|?*\n\r]+\\)*[^<>:\\\""/\\|?*\n\r]*$",
+                                                RegexOptions.IgnoreCase))
+                                        {
+                                            txtEditor.SelectionStart = m.Groups["value"].Index + e.Index;
+                                            txtEditor.SelectionLength = e.Length;
+                                            txtEditor.UnderlineSelection();
+                                            hasErrors = true;
+                                        }
+                                }
+                                break;
+                            // Boolean values
+                            case "bypasslantraffic":
+                            case "virtualadaptermode":
+                            case "socks5proxyalltraffic":
+                                if (!IsBool(value))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            // Known free-form or WireGuard-managed values
+                            case "table":
+                                break;
+                            case "id":
+                                if (!string.IsNullOrWhiteSpace(value) &&
+                                    Uri.CheckHostName(value.Trim()) == UriHostNameType.Unknown)
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "ip":
+                                if (!IsOneOf(value, "quic", "dns", "sip", "stun"))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "ib":
+                                if (!IsOneOf(value, "chrome", "firefox", "curl", "random"))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "i1":
+                            case "i2":
+                            case "i3":
+                            case "i4":
+                            case "i5":
+                                break;
+                            // String values
+                            case "socks5proxyusername":
+                            case "socks5proxypassword":
+                            case "preup":
+                            case "postup":
+                            case "predown":
+                            case "postdown":
+                                break;
+                            // Unrecognized keys
+                            default:
+                                break;
+                        }
+                    }
                 }
 
-                if (m.Groups["section"].Success)
-                {
-                    txtEditor.SelectionStart = m.Groups["section"].Index;
-                    txtEditor.SelectionLength = m.Groups["section"].Length;
-                    txtEditor.SelectionColor = Color.DarkBlue;
-                    txtEditor.SelectionFont = _editorBoldFont;
-
-                    switch (m.Groups["section"].Value.ToLowerInvariant())
-                    {
-                        case "[interface]":
-                        case "[peer]":
-                            break;
-                        // Unrecognized sections
-                        default:
-                            txtEditor.UnderlineSelection();
-                            hasErrors = true;
-                            break;
-                    }
-
-                    continue;
-                }
-
-                if (m.Groups["key"].Success)
-                {
-                    txtEditor.SelectionStart = m.Groups["key"].Index;
-                    txtEditor.SelectionLength = m.Groups["key"].Length;
-                    txtEditor.SelectionColor = Color.Navy;
-
-                    var key = m.Groups["key"].Value.ToLowerInvariant();
-                    var value = string.Empty;
-
-                    if (m.Groups["value"].Success)
-                    {
-                        txtEditor.SelectionStart = m.Groups["value"].Index;
-                        txtEditor.SelectionLength = m.Groups["value"].Length;
-                        txtEditor.SelectionColor = Color.DarkGreen;
-
-                        value = m.Groups["value"].Value;
-                    }
-
-                    switch (key)
-                    {
-                        // base64 256-bit keys
-                        case "privatekey":
-                        {
-                            if (string.IsNullOrEmpty(value))
-                            {
-                                // Generate a new private key
-                                var newPrivateKey = Curve25519.CreateRandomPrivateKey();
-                                var base64PrivateKey = Convert.ToBase64String(newPrivateKey);
-
-                                // Insert the new private key into the text editor
-                                txtEditor.SelectionStart = m.Groups["value"].Index;
-                                txtEditor.SelectionLength = m.Groups["value"].Length;
-                                txtEditor.SelectedText = base64PrivateKey;
-
-                                // Update the public key display
-                                txtPublicKey.Text = Convert.ToBase64String(Curve25519.GetPublicKey(newPrivateKey));
-                                textChanged = true; // Set flag to true as text is changed
-                            }
-                            else
-                            {
-                                try
-                                {
-                                    var binaryKey = Convert.FromBase64String(value);
-                                    if (binaryKey.Length != 32)
-                                        throw new FormatException();
-
-                                    txtPublicKey.Text = Convert.ToBase64String(Curve25519.GetPublicKey(binaryKey));
-                                }
-                                catch (FormatException)
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                            }
-                        }
-                            break;
-                        case "publickey":
-                        case "presharedkey":
-                        {
-                            if (!string.IsNullOrEmpty(value))
-                                try
-                                {
-                                    var binaryKey = Convert.FromBase64String(value);
-
-                                    if (binaryKey.Length != 32)
-                                        throw new FormatException();
-                                }
-                                catch (FormatException)
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                        }
-                            break;
-                        // IPv4/IPv6 CIDR notation values
-                        case "address":
-                        case "allowedips":
-                        case "disallowedips":
-                        {
-                            foreach (Match e in MultiValueMatch.Matches(value))
-                                if (!string.IsNullOrWhiteSpace(e.Value) &&
-                                    !IpHelper.IsValidSubnetOrSingleIpAddress(e.Value.Trim()))
-                                {
-                                    txtEditor.SelectionStart = m.Groups["value"].Index + e.Index;
-                                    txtEditor.SelectionLength = e.Length;
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                        }
-                            break;
-                        // IPv4/IPv6 values
-                        case "dns":
-                        {
-                            foreach (Match e in MultiValueMatch.Matches(value))
-                                if (!string.IsNullOrWhiteSpace(e.Value) && !IpHelper.IsValidIpAddress(e.Value.Trim()))
-                                {
-                                    txtEditor.SelectionStart = m.Groups["value"].Index + e.Index;
-                                    txtEditor.SelectionLength = e.Length;
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                        }
-
-                            break;
-                        // IPv4, IPv6 or DNS value
-                        case "endpoint":
-                            if (!IpHelper.IsValidAddress(value.Trim()))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-
-                            break;
-                        case "socks5proxy":
-                            if (!string.IsNullOrWhiteSpace(value) && !IpHelper.IsValidAddress(value.Trim()))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-
-                            break;
-                        // Numerical values
-                        case "mtu":
-                            if (!IsIntInRange(value, 576, 65535))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "listenport":
-                            if (!IsIntInRange(value, 1, 65535))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "persistentkeepalive":
-                        case "scriptexectimeout":
-                            if (!IsIntInRange(value, 0, 65535))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "jc":
-                            if (!IsUIntInRange(value, 0, 128))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "jd":
-                            if (!IsUIntInRange(value, 0, 200))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "jmin":
-                        case "jmax":
-                        case "s1":
-                        case "s2":
-                            if (!IsUIntInRange(value, 0, 1280))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "s3":
-                        case "s4":
-                            if (!IsUIntInRange(value, 0, uint.MaxValue))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "h1":
-                        case "h2":
-                        case "h3":
-                        case "h4":
-                            if (!IsUIntOrRange(value, 0, uint.MaxValue))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        // Comma-delimited string values
-                        case "allowedapps":
-                        case "disallowedapps":
-                        {
-                            foreach (Match e in MultiValueMatch.Matches(value))
-                                if (!string.IsNullOrWhiteSpace(e.Value) &&
-                                    !Regex.IsMatch(e.Value.Trim(),
-                                        @"^(?:[a-zA-Z]:\\)?(?:[^<>:\\\""/\\|?*\n\r]+\\)*[^<>:\\\""/\\|?*\n\r]*$",
-                                        RegexOptions.IgnoreCase))
-                                {
-                                    txtEditor.SelectionStart = m.Groups["value"].Index + e.Index;
-                                    txtEditor.SelectionLength = e.Length;
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                        }
-                            break;
-                        // Boolean values
-                        case "bypasslantraffic":
-                        case "virtualadaptermode":
-                        case "socks5proxyalltraffic":
-                            if (!IsBool(value))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        // Known free-form or WireGuard-managed values
-                        case "table":
-                            break;
-                        case "id":
-                            if (!string.IsNullOrWhiteSpace(value) &&
-                                Uri.CheckHostName(value.Trim()) == UriHostNameType.Unknown)
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "ip":
-                            if (!IsOneOf(value, "quic", "dns", "sip", "stun"))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "ib":
-                            if (!IsOneOf(value, "chrome", "firefox", "curl", "random"))
-                            {
-                                txtEditor.UnderlineSelection();
-                                hasErrors = true;
-                            }
-                            break;
-                        case "i1":
-                        case "i2":
-                        case "i3":
-                        case "i4":
-                        case "i5":
-                            break;
-                        // String values
-                        case "socks5proxyusername":
-                        case "socks5proxypassword":
-                        case "preup":
-                        case "postup":
-                        case "predown":
-                        case "postdown":
-                            break;
-                        // Unrecognized keys
-                        default:
-                            break;
-                    }
-                }
+                btnSave.Enabled = !hasErrors;
+                return textChanged;
             }
+            finally
+            {
+                try
+                {
+                    // restoring the original settings
+                    txtEditor.SelectionStart = Math.Min(originalIndex, txtEditor.TextLength);
+                    txtEditor.SelectionLength = Math.Min(originalLength, txtEditor.TextLength - txtEditor.SelectionStart);
+                    txtEditor.SelectionColor = originalColor;
+                    txtEditor.Focus();
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning($"Failed to restore editor selection after highlighting: {ex.Message}");
+                }
 
-            // restoring the original settings
-            txtEditor.SelectionStart = originalIndex;
-            txtEditor.SelectionLength = originalLength;
-            txtEditor.SelectionColor = originalColor;
-
-            txtEditor.Focus();
-
-            btnSave.Enabled = !hasErrors;
-
-            _highlighting = false;
-            return textChanged;
+                _highlighting = false;
+            }
         }
 
         private static bool IsIntInRange(string value, int minValue, int maxValue)

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -44,7 +44,7 @@ namespace WireSockUI.Forms
         private bool _shutdownComplete;
         private int _tunnelOperationInProgress;
         private int _tunnelGeneration;
-        private int _tunnelConnectionTimeoutGeneration;
+        private int _tunnelConnectionTimeoutGeneration = -1;
         private Icon _ownedTrayIcon;
         private Image _inactiveStatusImage;
         private Image _connectedStatusImage;
@@ -54,6 +54,12 @@ namespace WireSockUI.Forms
             public int Generation { get; set; }
             public bool Connected { get; set; }
             public bool TimedOut { get; set; }
+        }
+
+        private sealed class ConnectAttemptResult
+        {
+            public bool Connected { get; set; }
+            public long ConnectionSequence { get; set; }
         }
 
         private sealed class TunnelStateProgress
@@ -224,6 +230,7 @@ namespace WireSockUI.Forms
         private void AdvanceTunnelGeneration()
         {
             Interlocked.Increment(ref _tunnelGeneration);
+            Volatile.Write(ref _tunnelConnectionTimeoutGeneration, -1);
         }
 
         private void CancelTunnelMonitoring()
@@ -346,6 +353,7 @@ namespace WireSockUI.Forms
                 {
                     Trace.TraceWarning(
                         $"WireSock manager shutdown exceeded {ShutdownDisconnectTimeoutMilliseconds} ms; continuing application exit.");
+                    TryResetNetworkLockAfterShutdownTimeout();
 
                     cleanupTask.ContinueWith(task =>
                             Trace.TraceWarning(
@@ -363,6 +371,30 @@ namespace WireSockUI.Forms
             catch (Exception ex)
             {
                 Trace.TraceWarning($"Failed to cleanly shut down WireSock manager: {ex.Message}");
+            }
+        }
+
+        private static void TryResetNetworkLockAfterShutdownTimeout()
+        {
+            try
+            {
+                if (!WireSockManager.TryIsNetworkLockActive(out var networkLockActive, out var queryDiagnostic))
+                {
+                    Trace.TraceWarning(
+                        $"Unable to query WireSock network lock after shutdown timeout: {queryDiagnostic}");
+                    return;
+                }
+
+                if (!networkLockActive)
+                    return;
+
+                if (!WireSockManager.TryResetNetworkLock(out var resetDiagnostic))
+                    Trace.TraceWarning(
+                        $"Unable to reset WireSock network lock after shutdown timeout: {resetDiagnostic}");
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to reset WireSock network lock after shutdown timeout: {ex.Message}");
             }
         }
 
@@ -516,7 +548,8 @@ namespace WireSockUI.Forms
         private bool RequestTunnelConnectionTimeout(int generation)
         {
             if (_shutdownComplete || generation != CurrentTunnelGeneration() ||
-                _currentState != ConnectionState.Connecting)
+                _currentState != ConnectionState.Connecting ||
+                IsTunnelConnectionTimedOut(generation))
                 return false;
 
             Volatile.Write(ref _tunnelConnectionTimeoutGeneration, generation);
@@ -539,6 +572,96 @@ namespace WireSockUI.Forms
             if (!_shutdownComplete)
                 MessageBox.Show(Resources.TunnelConnectTimeout, Resources.TunnelErrorTitle, MessageBoxButtons.OK,
                     MessageBoxIcon.Warning);
+        }
+
+        private async Task<ConnectAttemptResult> ConnectWithTimeoutAsync(string profile, int generation)
+        {
+            var connectTask = Task.Run(() =>
+            {
+                var connected = _wiresock.Connect(profile);
+                return new ConnectAttemptResult
+                {
+                    Connected = connected,
+                    ConnectionSequence = connected ? _wiresock.ConnectionSequence : 0
+                };
+            });
+
+            var completedTask = await Task.WhenAny(connectTask, Task.Delay(TunnelConnectionTimeoutMilliseconds));
+            if (completedTask == connectTask)
+                return await connectTask;
+
+            ScheduleTimedOutConnectCleanup(connectTask, generation, profile);
+
+            if (!_shutdownComplete && generation == CurrentTunnelGeneration() &&
+                _currentState == ConnectionState.Connecting)
+            {
+                Volatile.Write(ref _tunnelConnectionTimeoutGeneration, generation);
+                UpdateState(ConnectionState.Disconnected, false, profile);
+                MessageBox.Show(Resources.TunnelConnectTimeout, Resources.TunnelErrorTitle, MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
+
+            return null;
+        }
+
+        private void ScheduleTimedOutConnectCleanup(Task<ConnectAttemptResult> connectTask, int generation,
+            string profile)
+        {
+            connectTask.ContinueWith(task =>
+            {
+                if (_shutdownComplete || IsDisposed || Disposing || !IsHandleCreated)
+                    return;
+
+                try
+                {
+                    BeginInvoke(new Action(async () =>
+                    {
+                        try
+                        {
+                            await CompleteTimedOutConnectCleanupAsync(task, generation, profile);
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.TraceWarning($"Unhandled timed-out tunnel cleanup error: {ex.Message}");
+                        }
+                    }));
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+        }
+
+        private async Task CompleteTimedOutConnectCleanupAsync(Task<ConnectAttemptResult> connectTask, int generation,
+            string profile)
+        {
+            ConnectAttemptResult result;
+            try
+            {
+                result = await connectTask;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Timed-out tunnel connect finished with an error: {ex.Message}");
+                return;
+            }
+
+            try
+            {
+                if (result.Connected)
+                    await DisconnectNativeTunnelAsync(result.ConnectionSequence, false);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to clean up timed-out tunnel connect: {ex.Message}");
+            }
+
+            if (!_shutdownComplete && generation == CurrentTunnelGeneration() &&
+                _currentState == ConnectionState.Connecting)
+                UpdateState(ConnectionState.Disconnected, false, profile);
         }
 
         /// <summary>
@@ -952,17 +1075,60 @@ namespace WireSockUI.Forms
 
                 try
                 {
-                    var profile = new Profile(filePath);
-                    if (!ProfileScriptWarning.ConfirmIfProfileHasScriptHooks(this, profile))
-                        return;
-
-                    File.Copy(filePath, destinationPath);
-                    LoadProfiles(profileName);
+                    if (ImportProfileFromFile(filePath, destinationPath))
+                        LoadProfiles(profileName);
                 }
                 catch (Exception ex)
                 {
                     MessageBox.Show(ex.Message, Resources.ProfileError, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
+            }
+        }
+
+        private bool ImportProfileFromFile(string filePath, string destinationPath)
+        {
+            var tmpProfile = Path.Combine(Global.ConfigsFolder, $"{Guid.NewGuid():N}.tmp");
+
+            try
+            {
+                CopyProfileToTemporaryFile(filePath, tmpProfile);
+
+                var profile = new Profile(tmpProfile);
+                if (!ProfileScriptWarning.ConfirmIfProfileHasScriptHooks(this, profile))
+                    return false;
+
+                File.Move(tmpProfile, destinationPath);
+                tmpProfile = null;
+                return true;
+            }
+            finally
+            {
+                if (tmpProfile != null)
+                    TryDeleteTemporaryProfile(tmpProfile);
+            }
+        }
+
+        private static void CopyProfileToTemporaryFile(string sourcePath, string destinationPath)
+        {
+            using (var source = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read,
+                       81920, FileOptions.SequentialScan))
+            using (var destination = new FileStream(destinationPath, FileMode.CreateNew, FileAccess.Write,
+                       FileShare.None))
+            {
+                source.CopyTo(destination);
+            }
+        }
+
+        private static void TryDeleteTemporaryProfile(string tmpProfile)
+        {
+            try
+            {
+                if (File.Exists(tmpProfile))
+                    File.Delete(tmpProfile);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to delete temporary imported profile '{tmpProfile}': {ex.Message}");
             }
         }
 
@@ -1174,8 +1340,12 @@ namespace WireSockUI.Forms
                 {
                     var connectGeneration = CurrentTunnelGeneration();
                     UpdateState(ConnectionState.Connecting, true, profile);
-                    var connected = await Task.Run(() => _wiresock.Connect(profile));
-                    var connectionSequence = connected ? _wiresock.ConnectionSequence : 0;
+                    var connectResult = await ConnectWithTimeoutAsync(profile, connectGeneration);
+                    if (connectResult == null)
+                        return;
+
+                    var connected = connectResult.Connected;
+                    var connectionSequence = connectResult.ConnectionSequence;
 
                     if (!_shutdownComplete && connectGeneration == CurrentTunnelGeneration() &&
                         IsTunnelConnectionTimedOut(connectGeneration))
@@ -1208,6 +1378,12 @@ namespace WireSockUI.Forms
                         MessageBox.Show(_wiresock.LastError ?? Resources.TunnelErrorManager, Resources.TunnelErrorTitle,
                             MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
+                }
+                catch (Exception ex)
+                {
+                    UpdateState(ConnectionState.Disconnected, false, profile);
+                    MessageBox.Show(ex.Message, Resources.TunnelErrorTitle, MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
                 }
                 finally
                 {

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -33,6 +33,7 @@ namespace WireSockUI.Forms
         private const int TunnelConnectionTimeoutMilliseconds = 30000;
         private const int MaxVisibleLogMessages = 2000;
         private const int ShutdownDisconnectTimeoutMilliseconds = 5000;
+        private const long MaxImportedProfileSizeBytes = 1024 * 1024;
 
         /**
          * @brief The manager that handles the Wireguard connections.
@@ -586,9 +587,16 @@ namespace WireSockUI.Forms
                 };
             });
 
-            var completedTask = await Task.WhenAny(connectTask, Task.Delay(TunnelConnectionTimeoutMilliseconds));
-            if (completedTask == connectTask)
-                return await connectTask;
+            using (var delayCancellation = new CancellationTokenSource())
+            {
+                var delayTask = Task.Delay(TunnelConnectionTimeoutMilliseconds, delayCancellation.Token);
+                var completedTask = await Task.WhenAny(connectTask, delayTask);
+                if (completedTask == connectTask)
+                {
+                    delayCancellation.Cancel();
+                    return await connectTask;
+                }
+            }
 
             ScheduleTimedOutConnectCleanup(connectTask, generation, profile);
 
@@ -652,7 +660,12 @@ namespace WireSockUI.Forms
             try
             {
                 if (result.Connected)
-                    await DisconnectNativeTunnelAsync(result.ConnectionSequence, false);
+                {
+                    var disconnected = await DisconnectNativeTunnelAsync(result.ConnectionSequence, false);
+                    if (!disconnected)
+                        Trace.TraceWarning(
+                            $"Timed-out tunnel sequence {result.ConnectionSequence} could not be disconnected. The tunnel may still be active.");
+                }
             }
             catch (Exception ex)
             {
@@ -1112,10 +1125,26 @@ namespace WireSockUI.Forms
         {
             using (var source = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read,
                        81920, FileOptions.SequentialScan))
-            using (var destination = new FileStream(destinationPath, FileMode.CreateNew, FileAccess.Write,
-                       FileShare.None))
             {
-                source.CopyTo(destination);
+                if (source.Length > MaxImportedProfileSizeBytes)
+                    throw new InvalidOperationException("The profile file is too large to be imported.");
+
+                using (var destination = new FileStream(destinationPath, FileMode.CreateNew, FileAccess.Write,
+                           FileShare.None))
+                {
+                    var buffer = new byte[81920];
+                    long bytesCopied = 0;
+                    int bytesRead;
+
+                    while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        bytesCopied += bytesRead;
+                        if (bytesCopied > MaxImportedProfileSizeBytes)
+                            throw new InvalidOperationException("The profile file is too large to be imported.");
+
+                        destination.Write(buffer, 0, bytesRead);
+                    }
+                }
             }
         }
 

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -617,6 +617,9 @@ namespace WireSockUI.Forms
         {
             connectTask.ContinueWith(task =>
             {
+                if (!TryGetCompletedConnectResult(task, out var result))
+                    return;
+
                 if (_shutdownComplete || IsDisposed || Disposing || !IsHandleCreated)
                     return;
 
@@ -626,7 +629,7 @@ namespace WireSockUI.Forms
                     {
                         try
                         {
-                            await CompleteTimedOutConnectCleanupAsync(task, generation, profile);
+                            await CompleteTimedOutConnectCleanupAsync(result, generation, profile);
                         }
                         catch (Exception ex)
                         {
@@ -643,20 +646,26 @@ namespace WireSockUI.Forms
             }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
         }
 
-        private async Task CompleteTimedOutConnectCleanupAsync(Task<ConnectAttemptResult> connectTask, int generation,
-            string profile)
+        private static bool TryGetCompletedConnectResult(Task<ConnectAttemptResult> connectTask,
+            out ConnectAttemptResult result)
         {
-            ConnectAttemptResult result;
+            result = null;
+
             try
             {
-                result = await connectTask;
+                result = connectTask.GetAwaiter().GetResult();
+                return true;
             }
             catch (Exception ex)
             {
                 Trace.TraceWarning($"Timed-out tunnel connect finished with an error: {ex.Message}");
-                return;
+                return false;
             }
+        }
 
+        private async Task CompleteTimedOutConnectCleanupAsync(ConnectAttemptResult result, int generation,
+            string profile)
+        {
             try
             {
                 if (result.Connected)

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -166,21 +166,15 @@ namespace WireSockUI
             libraryDirectory = null;
 
             var fullDirectory = NormalizePathDirectory(directory);
-            if (fullDirectory == null || !ContainsWireSockLibrary(fullDirectory))
+            if (fullDirectory == null ||
+                !TryGetExistingAttributes(fullDirectory, out var directoryAttributes) ||
+                (directoryAttributes & FileAttributes.Directory) == 0)
                 return false;
 
-            if (!TryIsReparsePoint(fullDirectory, out var directoryIsReparsePoint) || directoryIsReparsePoint)
+            if ((directoryAttributes & FileAttributes.ReparsePoint) != 0)
             {
                 Trace.TraceWarning(
-                    $"Skipping WireSock library directory '{fullDirectory}' because it is a reparse point or cannot be inspected.");
-                return false;
-            }
-
-            var libraryPath = Path.Combine(fullDirectory, "wgbooster.dll");
-            if (!TryIsReparsePoint(libraryPath, out var libraryIsReparsePoint) || libraryIsReparsePoint)
-            {
-                Trace.TraceWarning(
-                    $"Skipping WireSock library '{libraryPath}' because it is a reparse point or cannot be inspected.");
+                    $"Skipping WireSock library directory '{fullDirectory}' because it is a reparse point.");
                 return false;
             }
 
@@ -188,6 +182,24 @@ namespace WireSockUI
             {
                 Trace.TraceWarning(
                     $"Skipping WireSock library directory '{fullDirectory}' because it is writable by non-administrative users.");
+                return false;
+            }
+
+            var libraryPath = Path.Combine(fullDirectory, "wgbooster.dll");
+            if (!TryGetExistingAttributes(libraryPath, out var libraryAttributes))
+                return false;
+
+            if ((libraryAttributes & FileAttributes.Directory) != 0)
+            {
+                Trace.TraceWarning(
+                    $"Skipping WireSock library '{libraryPath}' because it is a directory.");
+                return false;
+            }
+
+            if ((libraryAttributes & FileAttributes.ReparsePoint) != 0)
+            {
+                Trace.TraceWarning(
+                    $"Skipping WireSock library '{libraryPath}' because it is a reparse point.");
                 return false;
             }
 
@@ -200,20 +212,6 @@ namespace WireSockUI
 
             libraryDirectory = fullDirectory;
             return true;
-        }
-
-        private static bool ContainsWireSockLibrary(string directory)
-        {
-            try
-            {
-                return !string.IsNullOrWhiteSpace(directory) &&
-                       File.Exists(Path.Combine(directory, "wgbooster.dll"));
-            }
-            catch (Exception ex)
-            {
-                Trace.TraceWarning($"Skipping invalid WireSock library directory '{directory}': {ex.Message}");
-                return false;
-            }
         }
 
         private static string[] GetLibraryDirectories(string installLocation)
@@ -390,14 +388,36 @@ namespace WireSockUI
         {
             isReparsePoint = false;
 
+            if (!TryGetExistingAttributes(path, out var attributes, true))
+                return false;
+
+            isReparsePoint = (attributes & FileAttributes.ReparsePoint) != 0;
+            return true;
+        }
+
+        private static bool TryGetExistingAttributes(string path, out FileAttributes attributes,
+            bool warnOnFailure = false)
+        {
+            attributes = 0;
+
             try
             {
-                isReparsePoint = (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
+                attributes = File.GetAttributes(path);
                 return true;
+            }
+            catch (FileNotFoundException)
+            {
+                return false;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return false;
             }
             catch (Exception ex)
             {
-                Trace.TraceWarning($"Unable to inspect reparse point attributes for '{path}': {ex.Message}");
+                if (warnOnFailure)
+                    Trace.TraceWarning($"Unable to inspect file system attributes for '{path}': {ex.Message}");
+
                 return false;
             }
         }

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -146,31 +146,53 @@ namespace WireSockUI
             libraryDirectory = null;
 
             var localDirectory = AppDomain.CurrentDomain.BaseDirectory;
-            if (ContainsWireSockLibrary(localDirectory))
-            {
-                if (!IsPotentiallyUserWritableDirectory(localDirectory))
-                {
-                    libraryDirectory = localDirectory;
-                    return true;
-                }
-
-                Trace.TraceWarning(
-                    $"Skipping app-local wgbooster.dll in user-writable directory '{localDirectory}'.");
-            }
+            if (TryValidateWireSockLibraryDirectory(localDirectory, out libraryDirectory))
+                return true;
 
             foreach (var installLocation in GetInstallLocations())
             {
                 foreach (var candidate in GetLibraryDirectories(installLocation))
                 {
-                    if (!ContainsWireSockLibrary(candidate))
-                        continue;
-
-                    libraryDirectory = candidate;
-                    return true;
+                    if (TryValidateWireSockLibraryDirectory(candidate, out libraryDirectory))
+                        return true;
                 }
             }
 
             return false;
+        }
+
+        private static bool TryValidateWireSockLibraryDirectory(string directory, out string libraryDirectory)
+        {
+            libraryDirectory = null;
+
+            var fullDirectory = NormalizePathDirectory(directory);
+            if (fullDirectory == null || !ContainsWireSockLibrary(fullDirectory))
+                return false;
+
+            if (!TryIsReparsePoint(fullDirectory, out var directoryIsReparsePoint) || directoryIsReparsePoint)
+            {
+                Trace.TraceWarning(
+                    $"Skipping WireSock library directory '{fullDirectory}' because it is a reparse point or cannot be inspected.");
+                return false;
+            }
+
+            var libraryPath = Path.Combine(fullDirectory, "wgbooster.dll");
+            if (!TryIsReparsePoint(libraryPath, out var libraryIsReparsePoint) || libraryIsReparsePoint)
+            {
+                Trace.TraceWarning(
+                    $"Skipping WireSock library '{libraryPath}' because it is a reparse point or cannot be inspected.");
+                return false;
+            }
+
+            if (IsPotentiallyUserWritableDirectory(fullDirectory))
+            {
+                Trace.TraceWarning(
+                    $"Skipping WireSock library directory '{fullDirectory}' because it is writable by non-administrative users.");
+                return false;
+            }
+
+            libraryDirectory = fullDirectory;
+            return true;
         }
 
         private static bool ContainsWireSockLibrary(string directory)

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -191,6 +191,13 @@ namespace WireSockUI
                 return false;
             }
 
+            if (IsPotentiallyUserWritableFile(libraryPath))
+            {
+                Trace.TraceWarning(
+                    $"Skipping WireSock library '{libraryPath}' because it is writable by non-administrative users.");
+                return false;
+            }
+
             libraryDirectory = fullDirectory;
             return true;
         }
@@ -472,43 +479,71 @@ namespace WireSockUI
             {
                 var security = Directory.GetAccessControl(normalizedDirectory);
                 var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
-                const FileSystemRights writeRights =
-                    FileSystemRights.FullControl |
-                    FileSystemRights.Modify |
-                    FileSystemRights.Write |
-                    FileSystemRights.WriteData |
-                    FileSystemRights.CreateFiles |
-                    FileSystemRights.AppendData |
-                    FileSystemRights.CreateDirectories |
-                    FileSystemRights.WriteAttributes |
-                    FileSystemRights.WriteExtendedAttributes;
-
-                foreach (FileSystemAccessRule rule in rules)
-                {
-                    if (rule.AccessControlType != AccessControlType.Allow ||
-                        !(rule.IdentityReference is SecurityIdentifier sid) ||
-                        (rule.FileSystemRights & writeRights) == 0)
-                        continue;
-
-                    if (sid.IsWellKnown(WellKnownSidType.CreatorOwnerSid))
-                    {
-                        if ((rule.PropagationFlags & PropagationFlags.InheritOnly) != 0)
-                            continue;
-
-                        return true;
-                    }
-
-                    if (!IsAdministrativeOrServiceSid(sid))
-                        return true;
-                }
-
-                return false;
+                return ContainsPotentiallyUserWritableRule(rules);
             }
             catch (Exception ex)
             {
                 Trace.TraceWarning($"Unable to inspect ACL for '{normalizedDirectory}': {ex.Message}");
                 return true;
             }
+        }
+
+        private static bool IsPotentiallyUserWritableFile(string file)
+        {
+            var normalizedFile = NormalizePathFile(file);
+            if (normalizedFile == null)
+                return true;
+
+            try
+            {
+                var security = File.GetAccessControl(normalizedFile);
+                var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
+                return ContainsPotentiallyUserWritableRule(rules);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Unable to inspect ACL for '{normalizedFile}': {ex.Message}");
+                return true;
+            }
+        }
+
+        private static bool ContainsPotentiallyUserWritableRule(AuthorizationRuleCollection rules)
+        {
+            const FileSystemRights writeRights =
+                FileSystemRights.FullControl |
+                FileSystemRights.Modify |
+                FileSystemRights.Write |
+                FileSystemRights.WriteData |
+                FileSystemRights.CreateFiles |
+                FileSystemRights.AppendData |
+                FileSystemRights.CreateDirectories |
+                FileSystemRights.WriteAttributes |
+                FileSystemRights.WriteExtendedAttributes |
+                FileSystemRights.ChangePermissions |
+                FileSystemRights.TakeOwnership |
+                FileSystemRights.Delete |
+                FileSystemRights.DeleteSubdirectoriesAndFiles;
+
+            foreach (FileSystemAccessRule rule in rules)
+            {
+                if (rule.AccessControlType != AccessControlType.Allow ||
+                    !(rule.IdentityReference is SecurityIdentifier sid) ||
+                    (rule.FileSystemRights & writeRights) == 0)
+                    continue;
+
+                if (sid.IsWellKnown(WellKnownSidType.CreatorOwnerSid))
+                {
+                    if ((rule.PropagationFlags & PropagationFlags.InheritOnly) != 0)
+                        continue;
+
+                    return true;
+                }
+
+                if (!IsAdministrativeOrServiceSid(sid))
+                    return true;
+            }
+
+            return false;
         }
 
         private static bool IsAdministrativeOrServiceSid(SecurityIdentifier sid)
@@ -533,6 +568,22 @@ namespace WireSockUI
             catch (Exception ex)
             {
                 Trace.TraceWarning($"Skipping invalid PATH directory '{directory}': {ex.Message}");
+                return null;
+            }
+        }
+
+        private static string NormalizePathFile(string file)
+        {
+            if (string.IsNullOrWhiteSpace(file))
+                return null;
+
+            try
+            {
+                return NormalizePathRoot(Path.GetFullPath(file.Trim().Trim('"')));
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Skipping invalid file path '{file}': {ex.Message}");
                 return null;
             }
         }

--- a/WireSockUI/WireSockUI.csproj
+++ b/WireSockUI/WireSockUI.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <Configurations>Debug;Release;Debug UWP;Release UWP</Configurations>
     <Platforms>AnyCPU;x86;x64;ARM64</Platforms>
-    <TargetFrameworks>net472-windows</TargetFrameworks> <!-- or net8.0-windows10.0.19041.0 -->
+    <TargetFrameworks>net472-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <RootNamespace>WireSockUI</RootNamespace>
@@ -69,17 +69,6 @@
     <Reference Condition=" $(Configuration.Contains('UWP')) " Include="Windows.UI">
       <HintPath>$(SystemRoot)\System32\WinMetadata\Windows.UI.winmd</HintPath>
     </Reference>
-  </ItemGroup>
-
-  <!-- Dependencies when targeting .NET Core -->
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net8.0')) ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="System.Management" Version="8.0.0" />
-    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
-    <PackageReference Include="TaskScheduler" Version="2.10.1" />
   </ItemGroup>
 
   <!-- Conditional UWP support -->


### PR DESCRIPTION
## Summary
- Harden wgbooster.dll discovery so all candidates reject user-writable and reparse-point paths.
- Close profile import TOCTOU by validating and warning from a protected temp copy before moving it into place.
- Add native connect timeout handling, delayed sequence-scoped cleanup, shutdown network-lock fallback, process picker resilience, and editor highlighter recovery.
- Remove stale dormant net8 dependency block and add tests for DLL trust rejection, Amnezia validation helpers, and wgbooster stats ABI layout.

## Ultra review and verification
- Reviewed the full diff repeatedly after fixes; final pass found no remaining issues.
- dotnet run --project WireSockUI.Tests\\WireSockUI.Tests.csproj --configuration Release --framework net472-windows
- dotnet build WireSockUI.sln --configuration Release -p:Platform=x64 -p:UseSharedCompilation=false -m:1
- dotnet list WireSockUI\\WireSockUI.csproj package --vulnerable --include-transitive --source https://api.nuget.org/v3/index.json

## Notes
- Tests were run from clean temp copies to avoid local obj permission noise; file symlink creation was unavailable, so that existing reparse-point branch reported SKIP as before.