### PR TITLE
Harden native recovery and profile migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Build solution
         run: dotnet build WireSockUI.sln --configuration Release /p:Platform=x64 /p:UseSharedCompilation=false -m:1
+
+      - name: Build UWP-enabled solution
+        run: dotnet build WireSockUI.sln --configuration "Release UWP" /p:Platform=x64 /p:UseSharedCompilation=false -m:1

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Profiles containing `PreUp`, `PostUp`, `PreDown`, or `PostDown` script hooks req
 
 The Settings dialog includes an optional Kill Switch toggle. When enabled, WireSockUI calls the `wgbooster.dll` network-lock API before creating the tunnel and clears the lock through normal tunnel cleanup when disconnecting. The option is off by default so existing SDK/minimal installations keep their current behavior.
 
-If a native connect or shutdown cleanup call does not return, WireSockUI attempts to reset the network lock and disables further tunnel operations with a recovery warning instead of leaving the Activate button silently stuck. Restart WireSockUI as administrator and use **Reset Kill Switch** from the tray menu if network access remains blocked.
+If a native connect cleanup call does not return, WireSockUI attempts to reset the network lock and disables further tunnel operations with a recovery warning instead of leaving the Activate button silently stuck. Shutdown cleanup timeouts are written to the diagnostic trace without blocking process exit. Restart WireSockUI as administrator and use **Reset Kill Switch** from the tray menu if network access remains blocked.
 
 ## Compatibility Notes
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ WireSock-specific directives may use the current SDK comment-extension syntax:
 
 Plain WireGuard keys are still parsed normally. WireSockUI validates common SDK fields such as script hooks, masking parameters, SOCKS5 settings, `BypassLanTraffic`, and profile-level `VirtualAdapterMode` while preserving the file-based profile workflow.
 
-Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are moved into the secured folder on startup when no secured profile with the same name exists. Legacy migration uses a bounded temporary copy and rejects reparse-point sources; profiles larger than 1 MiB must be moved or trimmed manually. If a secured profile already exists, the legacy copy is deleted only when its content matches. Profile files that are reparse points are not loaded, imported, saved over, or activated; app-owned reparse-point files in the secured profile tree are removed during startup hardening when possible.
+Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are moved into the secured folder on startup when no secured profile with the same name exists. Legacy migration uses a bounded temporary copy and rejects reparse-point sources; profiles larger than 1 MiB must be moved or trimmed manually. If a secured profile already exists, the legacy copy is deleted only when its content matches. Profile files that are reparse points are not loaded, imported, saved over, or activated; app-owned reparse-point files in the secured profile tree are removed during startup hardening when possible. Legacy profiles containing script hooks are not auto-migrated; import them manually so the hook warning can be reviewed.
 
 Profiles containing `PreUp`, `PostUp`, `PreDown`, or `PostDown` script hooks require confirmation before import/save and again before activation. Treat script-hook profiles as privileged code.
 
 The Settings dialog includes an optional Kill Switch toggle. When enabled, WireSockUI calls the `wgbooster.dll` network-lock API before creating the tunnel and clears the lock through normal tunnel cleanup when disconnecting. The option is off by default so existing SDK/minimal installations keep their current behavior.
+
+If a native connect or shutdown cleanup call does not return, WireSockUI attempts to reset the network lock and disables further tunnel operations with a recovery warning instead of leaving the Activate button silently stuck. Restart WireSockUI as administrator and use **Reset Kill Switch** from the tray menu if network access remains blocked.
 
 ## Compatibility Notes
 
@@ -52,6 +54,7 @@ The Settings dialog includes an optional Kill Switch toggle. When enabled, WireS
 ```powershell
 dotnet run --project WireSockUI.Tests\WireSockUI.Tests.csproj --configuration Release --framework net472-windows
 dotnet build WireSockUI.sln --configuration Release -p:Platform=x64 -p:UseSharedCompilation=false -m:1
+dotnet build WireSockUI.sln --configuration "Release UWP" -p:Platform=x64 -p:UseSharedCompilation=false -m:1
 ```
 
 The single-node `-m:1` solution build avoids a silent MSBuild failure that can happen when recent .NET SDKs schedule the WinForms app and the test project reference concurrently.

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -53,7 +53,10 @@ namespace WireSockUI.Tests
                 { "Profile import rejects oversized files", ProfileImportRejectsOversizedFiles },
                 { "Legacy migration rejects oversized files", LegacyMigrationRejectsOversizedFiles },
                 { "Legacy migration rejects reparse point sources", LegacyMigrationRejectsReparsePointSources },
+                { "Legacy migration rejects script hooks", LegacyMigrationRejectsScriptHooks },
+                { "Legacy migration script-hook check is narrow", LegacyMigrationScriptHookCheckIsNarrow },
                 { "Editor validates Amnezia options", EditorValidatesAmneziaOptions },
+                { "AppUserModelID is path seeded", AppUserModelIdIsPathSeeded },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi },
                 { "Stats struct matches wgbooster ABI", StatsStructMatchesWgboosterAbi }
             };
@@ -554,6 +557,74 @@ namespace WireSockUI.Tests
                 "Expected unknown Ib values to be rejected.");
         }
 
+        private static void LegacyMigrationRejectsScriptHooks()
+        {
+            var path = WriteConfig("[Interface]\n" +
+                                   $"PrivateKey = {PrivateKey}\n" +
+                                   "Address = 10.0.0.2/32\n" +
+                                   "PostUp = powershell.exe -NoProfile -Command Write-Host test\n" +
+                                   "\n" +
+                                   "[Peer]\n" +
+                                   $"PublicKey = {PublicKey}\n" +
+                                   "Endpoint = example.com:51820\n" +
+                                   "AllowedIPs = 0.0.0.0/0\n");
+
+            try
+            {
+                AssertInvocationThrows<InvalidOperationException>(
+                    () => EnsureMigratedProfileCanBePromoted(path),
+                    "script hooks");
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+        }
+
+        private static void LegacyMigrationScriptHookCheckIsNarrow()
+        {
+            var path = WriteConfig("[Interface]\nAddress = 10.0.0.2/32\n");
+
+            try
+            {
+                EnsureMigratedProfileCanBePromoted(path);
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+        }
+
+        private static void EnsureMigratedProfileCanBePromoted(string path)
+        {
+            var ensureMigratedProfileCanBePromoted = typeof(WireSockUI.Program).GetMethod(
+                "EnsureMigratedProfileCanBePromoted", BindingFlags.NonPublic | BindingFlags.Static);
+            if (ensureMigratedProfileCanBePromoted == null)
+                throw new InvalidOperationException("EnsureMigratedProfileCanBePromoted helper was not found.");
+
+            ensureMigratedProfileCanBePromoted.Invoke(null, new object[] { path });
+        }
+
+        private static void AppUserModelIdIsPathSeeded()
+        {
+            var buildDefaultAppUserModelId = typeof(WindowsApplicationContext).GetMethod(
+                "BuildDefaultAppUserModelId", BindingFlags.NonPublic | BindingFlags.Static);
+            if (buildDefaultAppUserModelId == null)
+                throw new InvalidOperationException("BuildDefaultAppUserModelId helper was not found.");
+
+            var first = (string)buildDefaultAppUserModelId.Invoke(null,
+                new object[] { "WireSock UI", @"C:\Program Files\WireSockUI\WireSockUI.exe" });
+            var firstAgain = (string)buildDefaultAppUserModelId.Invoke(null,
+                new object[] { "WireSock UI", @"C:\Program Files\WireSockUI\WireSockUI.exe" });
+            var second = (string)buildDefaultAppUserModelId.Invoke(null,
+                new object[] { "WireSock UI", @"D:\Tools\WireSockUI\WireSockUI.exe" });
+
+            AssertEqual(first, firstAgain);
+            AssertFalse(string.Equals(first, second, StringComparison.Ordinal),
+                "Expected AppUserModelID to differ for side-by-side executable paths.");
+            AssertTrue(first.Length <= 128, "Expected AppUserModelID to fit the Windows shell length limit.");
+        }
+
         private static void NetworkLockEnumMatchesWgboosterAbi()
         {
             AssertEqual(0, (int)WireguardBoosterExports.WgbNetworkLockMode.Disabled);
@@ -599,6 +670,19 @@ namespace WireSockUI.Tests
                 return true;
 
             return CreateSymbolicLink(linkPath, targetPath, SymbolicLinkFlagFile);
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+            catch
+            {
+                // Best-effort cleanup must not hide the original test failure.
+            }
         }
 
         private static void WithTemporaryConfigFolder(Action action)

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -562,7 +562,7 @@ namespace WireSockUI.Tests
             var path = WriteConfig("[Interface]\n" +
                                    $"PrivateKey = {PrivateKey}\n" +
                                    "Address = 10.0.0.2/32\n" +
-                                   "PostUp = powershell.exe -NoProfile -Command Write-Host test\n" +
+                                   "postup = powershell.exe -NoProfile -Command Write-Host test\n" +
                                    "\n" +
                                    "[Peer]\n" +
                                    $"PublicKey = {PublicKey}\n" +

--- a/WireSockUI/Forms/frmEdit.cs
+++ b/WireSockUI/Forms/frmEdit.cs
@@ -54,8 +54,6 @@ namespace WireSockUI.Forms
                 Profile.EnsureRegularProfileFile(profilePath);
                 txtEditor.Text = File.ReadAllText(profilePath);
             }
-
-            ApplySyntaxHighlighting();
         }
 
         public string ReturnValue { get; private set; }

--- a/WireSockUI/Forms/frmEdit.cs
+++ b/WireSockUI/Forms/frmEdit.cs
@@ -43,6 +43,7 @@ namespace WireSockUI.Forms
             {
                 Text = Resources.EditProfileTitleNew;
                 txtEditor.Text = Resources.template_conf;
+                GenerateMissingPrivateKey();
             }
             else
             {
@@ -54,21 +55,37 @@ namespace WireSockUI.Forms
                 txtEditor.Text = File.ReadAllText(profilePath);
             }
 
-            var textChanged = ApplySyntaxHighlighting();
-            if (textChanged)
-                // Call it again to reapply highlighting
-                ApplySyntaxHighlighting();
+            ApplySyntaxHighlighting();
         }
 
         public string ReturnValue { get; private set; }
 
-        private bool ApplySyntaxHighlighting()
+        private void GenerateMissingPrivateKey()
         {
-            if (_highlighting) return false;
+            foreach (Match m in ProfileMatch.Matches(txtEditor.Text))
+            {
+                if (!m.Groups["key"].Success ||
+                    !string.Equals(m.Groups["key"].Value, "privatekey", StringComparison.OrdinalIgnoreCase) ||
+                    !m.Groups["value"].Success ||
+                    !string.IsNullOrEmpty(m.Groups["value"].Value))
+                    continue;
+
+                var newPrivateKey = Curve25519.CreateRandomPrivateKey();
+                var base64PrivateKey = Convert.ToBase64String(newPrivateKey);
+                txtEditor.Text = txtEditor.Text
+                    .Remove(m.Groups["value"].Index, m.Groups["value"].Length)
+                    .Insert(m.Groups["value"].Index, base64PrivateKey);
+                txtPublicKey.Text = Convert.ToBase64String(Curve25519.GetPublicKey(newPrivateKey));
+                return;
+            }
+        }
+
+        private void ApplySyntaxHighlighting()
+        {
+            if (_highlighting) return;
             _highlighting = true;
 
             var hasErrors = false;
-            var textChanged = false;
 
             // Saving the original settings
             var originalIndex = txtEditor.SelectionStart;
@@ -154,18 +171,9 @@ namespace WireSockUI.Forms
                                 {
                                     if (string.IsNullOrEmpty(value))
                                     {
-                                        // Generate a new private key
-                                        var newPrivateKey = Curve25519.CreateRandomPrivateKey();
-                                        var base64PrivateKey = Convert.ToBase64String(newPrivateKey);
-
-                                        // Insert the new private key into the text editor
-                                        txtEditor.SelectionStart = m.Groups["value"].Index;
-                                        txtEditor.SelectionLength = m.Groups["value"].Length;
-                                        txtEditor.SelectedText = base64PrivateKey;
-
-                                        // Update the public key display
-                                        txtPublicKey.Text = Convert.ToBase64String(Curve25519.GetPublicKey(newPrivateKey));
-                                        textChanged = true; // Set flag to true as text is changed
+                                        txtPublicKey.Text = string.Empty;
+                                        txtEditor.UnderlineSelection();
+                                        hasErrors = true;
                                     }
                                     else
                                     {
@@ -389,7 +397,6 @@ namespace WireSockUI.Forms
                 }
 
                 btnSave.Enabled = !hasErrors;
-                return textChanged;
             }
             finally
             {
@@ -590,10 +597,7 @@ namespace WireSockUI.Forms
 
         private void OnProfileChanged(object sender, EventArgs e)
         {
-            var textChanged = ApplySyntaxHighlighting();
-            if (textChanged)
-                // Call it again to reapply highlighting
-                ApplySyntaxHighlighting();
+            ApplySyntaxHighlighting();
         }
 
         private void OnAddAllowedAppClick(object sender, EventArgs e)

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -321,7 +321,7 @@ namespace WireSockUI.Forms
 
             var btnActivate = layoutInterface.Controls["btnActivate"] as Button;
             if (btnActivate != null)
-                btnActivate.Enabled = false;
+                SetActivateButtonEnabled(false);
 
             var txtStatus = layoutInterface.Controls.Find("txtStatus", true).FirstOrDefault() as TextBox;
             if (txtStatus != null)
@@ -474,9 +474,9 @@ namespace WireSockUI.Forms
                 {
                     Trace.TraceWarning(
                         $"WireSock manager shutdown exceeded {ShutdownDisconnectTimeoutMilliseconds} ms; continuing application exit.");
-                    TryResetNetworkLockAfterNativeCleanupFailure("shutdown timeout");
-                    MessageBox.Show(Resources.TunnelShutdownCleanupUnresolved, Resources.TunnelErrorTitle,
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    if (!TryResetNetworkLockAfterNativeCleanupFailure("shutdown timeout"))
+                        Trace.TraceWarning(
+                            "WireSock UI could not verify native tunnel cleanup before exit. Reopen WireSock UI as administrator and use Reset Kill Switch if network access remains blocked.");
 
                     cleanupTask.ContinueWith(task =>
                         {
@@ -796,7 +796,7 @@ namespace WireSockUI.Forms
         {
             Task.Delay(TimedOutConnectCleanupRecoveryMilliseconds).ContinueWith(_ =>
             {
-                if (_shutdownComplete || connectTask.IsCompleted || !IsTimedOutConnectCleanupInProgress())
+                if (_shutdownComplete || !IsTimedOutConnectCleanupInProgress())
                     return;
 
                 TryResetNetworkLockAfterNativeCleanupFailure("stalled timed-out connect cleanup");
@@ -1051,7 +1051,7 @@ namespace WireSockUI.Forms
                     if (btnActivate != null)
                     {
                         btnActivate.Text = Resources.ButtonActivating;
-                        btnActivate.Enabled = false;
+                        SetActivateButtonEnabled(false);
                     }
 
                     imgStatus?.Focus();
@@ -1069,7 +1069,7 @@ namespace WireSockUI.Forms
                     if (btnActivate != null)
                     {
                         btnActivate.Text = Resources.ButtonActive;
-                        btnActivate.Enabled = true;
+                        SetActivateButtonEnabled(true);
                     }
 
                     if (imgStatus != null)
@@ -1725,6 +1725,7 @@ namespace WireSockUI.Forms
                     btnActivate.Click += OnProfileClick;
 
                     layoutInterface.Controls.Add(btnActivate, 1, layoutInterface.RowCount - 1);
+                    SetActivateButtonEnabled(true);
 
                     layoutInterface.RowStyles.Add(new RowStyle(SizeType.AutoSize));
                     gbxInterface.Visible = true;
@@ -1781,7 +1782,7 @@ namespace WireSockUI.Forms
                         if (_wiresock.ProfileName == selectedConf)
                             UpdateState(ConnectionState.Connected, false);
                         else
-                            btnActivate.Enabled = false;
+                            SetActivateButtonEnabled(false);
                     }
                 }
                 catch (Exception ex)

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -778,7 +778,7 @@ namespace WireSockUI.Forms
         private void ScheduleTimedOutConnectCleanup(Task<ConnectAttemptResult> connectTask, int generation,
             string profile)
         {
-            ScheduleTimedOutConnectRecoveryWatchdog(connectTask, profile);
+            ScheduleTimedOutConnectRecoveryWatchdog(profile);
 
             connectTask.ContinueWith(task =>
             {
@@ -792,7 +792,7 @@ namespace WireSockUI.Forms
             }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
         }
 
-        private void ScheduleTimedOutConnectRecoveryWatchdog(Task<ConnectAttemptResult> connectTask, string profile)
+        private void ScheduleTimedOutConnectRecoveryWatchdog(string profile)
         {
             Task.Delay(TimedOutConnectCleanupRecoveryMilliseconds).ContinueWith(_ =>
             {

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -31,6 +31,7 @@ namespace WireSockUI.Forms
         private readonly BackgroundWorker _tunnelConnectionWorker;
         private readonly BackgroundWorker _tunnelStateWorker;
         private const int TunnelConnectionTimeoutMilliseconds = 30000;
+        private const int TimedOutConnectCleanupRecoveryMilliseconds = 30000;
         private const int MaxVisibleLogMessages = 2000;
         private const int ShutdownDisconnectTimeoutMilliseconds = 5000;
         private const long MaxImportedProfileSizeBytes = 1024 * 1024;
@@ -47,6 +48,7 @@ namespace WireSockUI.Forms
         private int _tunnelGeneration;
         private int _tunnelConnectionTimeoutGeneration = -1;
         private int _timedOutConnectCleanupInProgress;
+        private int _nativeRecoveryRequired;
         private Icon _ownedTrayIcon;
         private Image _inactiveStatusImage;
         private Image _connectedStatusImage;
@@ -167,7 +169,9 @@ namespace WireSockUI.Forms
         private void SetActivateButtonEnabled(bool enabled)
         {
             if (layoutInterface.Controls["btnActivate"] is Button btnActivate)
-                btnActivate.Enabled = enabled && !IsTimedOutConnectCleanupInProgress();
+                btnActivate.Enabled = enabled &&
+                                      !IsTimedOutConnectCleanupInProgress() &&
+                                      !IsNativeRecoveryRequired();
         }
 
         private void SetStatusImage(PictureBox imgStatus, Image image)
@@ -240,6 +244,11 @@ namespace WireSockUI.Forms
             return Volatile.Read(ref _timedOutConnectCleanupInProgress) != 0;
         }
 
+        private bool IsNativeRecoveryRequired()
+        {
+            return Volatile.Read(ref _nativeRecoveryRequired) != 0;
+        }
+
         private void BeginTimedOutConnectCleanup()
         {
             Interlocked.Exchange(ref _timedOutConnectCleanupInProgress, 1);
@@ -264,6 +273,71 @@ namespace WireSockUI.Forms
             });
         }
 
+        private void MarkNativeRecoveryRequired(string profile, string context)
+        {
+            var wasAlreadyMarked = Interlocked.Exchange(ref _nativeRecoveryRequired, 1) != 0;
+            Trace.TraceWarning(
+                $"Native WireSock cleanup did not finish safely after {context}. New tunnel operations are disabled until WireSock UI is restarted.");
+
+            TryRunOnUiThread(() =>
+            {
+                if (!IsNativeRecoveryRequired())
+                    return;
+
+                SetNativeRecoveryUi(profile);
+
+                if (!wasAlreadyMarked)
+                    MessageBox.Show(Resources.TunnelNativeRecoveryRequired, Resources.TunnelErrorTitle,
+                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            });
+        }
+
+        private void ClearNativeRecoveryRequired(string profile)
+        {
+            if (Interlocked.Exchange(ref _nativeRecoveryRequired, 0) == 0)
+                return;
+
+            TryRunOnUiThread(() =>
+            {
+                if (_currentState != ConnectionState.Disconnected)
+                    return;
+
+                var txtStatus = layoutInterface.Controls.Find("txtStatus", true).FirstOrDefault() as TextBox;
+                if (txtStatus != null)
+                    txtStatus.Text = Resources.InterfaceStatusInactive;
+
+                SetActivateButtonEnabled(true);
+                if (TryGetProfileItem(profile, out var profileItem))
+                    profileItem.ImageKey = ConnectionState.Disconnected.ToString();
+            });
+        }
+
+        private void SetNativeRecoveryUi(string profile)
+        {
+            if (_shutdownComplete || IsDisposed || Disposing)
+                return;
+
+            UpdateState(ConnectionState.Disconnected, false, profile);
+
+            var btnActivate = layoutInterface.Controls["btnActivate"] as Button;
+            if (btnActivate != null)
+                btnActivate.Enabled = false;
+
+            var txtStatus = layoutInterface.Controls.Find("txtStatus", true).FirstOrDefault() as TextBox;
+            if (txtStatus != null)
+                txtStatus.Text = Resources.InterfaceStatusRecoveryRequired;
+
+            cmiDeactivateTunnel.Enabled = false;
+        }
+
+        private void ShowTunnelOperationBlockedMessage(string message)
+        {
+            if (_shutdownComplete || IsDisposed || Disposing)
+                return;
+
+            MessageBox.Show(message, Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+
         private void CancelTunnelMonitoring()
         {
             AdvanceTunnelGeneration();
@@ -274,9 +348,22 @@ namespace WireSockUI.Forms
         private bool TryBeginTunnelOperation()
         {
             if (IsTimedOutConnectCleanupInProgress())
+            {
+                ShowTunnelOperationBlockedMessage(Resources.TunnelConnectCleanupPending);
                 return false;
+            }
 
-            return Interlocked.CompareExchange(ref _tunnelOperationInProgress, 1, 0) == 0;
+            if (IsNativeRecoveryRequired())
+            {
+                ShowTunnelOperationBlockedMessage(Resources.TunnelNativeRecoveryRequired);
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _tunnelOperationInProgress, 1, 0) == 0)
+                return true;
+
+            ShowTunnelOperationBlockedMessage(Resources.TunnelOperationPending);
+            return false;
         }
 
         private void EndTunnelOperation()
@@ -388,6 +475,8 @@ namespace WireSockUI.Forms
                     Trace.TraceWarning(
                         $"WireSock manager shutdown exceeded {ShutdownDisconnectTimeoutMilliseconds} ms; continuing application exit.");
                     TryResetNetworkLockAfterNativeCleanupFailure("shutdown timeout");
+                    MessageBox.Show(Resources.TunnelShutdownCleanupUnresolved, Resources.TunnelErrorTitle,
+                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
 
                     cleanupTask.ContinueWith(task =>
                         {
@@ -413,7 +502,7 @@ namespace WireSockUI.Forms
             }
         }
 
-        private static void TryResetNetworkLockAfterNativeCleanupFailure(string context)
+        private static bool TryResetNetworkLockAfterNativeCleanupFailure(string context)
         {
             try
             {
@@ -421,19 +510,25 @@ namespace WireSockUI.Forms
                 {
                     Trace.TraceWarning(
                         $"Unable to query WireSock network lock after {context}: {queryDiagnostic}");
-                    return;
+                    return false;
                 }
 
                 if (!networkLockActive)
-                    return;
+                    return true;
 
                 if (!WireSockManager.TryResetNetworkLock(out var resetDiagnostic))
+                {
                     Trace.TraceWarning(
                         $"Unable to reset WireSock network lock after {context}: {resetDiagnostic}");
+                    return false;
+                }
+
+                return true;
             }
             catch (Exception ex)
             {
                 Trace.TraceWarning($"Failed to reset WireSock network lock after {context}: {ex.Message}");
+                return false;
             }
         }
 
@@ -683,6 +778,8 @@ namespace WireSockUI.Forms
         private void ScheduleTimedOutConnectCleanup(Task<ConnectAttemptResult> connectTask, int generation,
             string profile)
         {
+            ScheduleTimedOutConnectRecoveryWatchdog(connectTask, profile);
+
             connectTask.ContinueWith(task =>
             {
                 var cleanupTask = CompleteTimedOutConnectCleanupAsync(task, generation, profile);
@@ -692,6 +789,19 @@ namespace WireSockUI.Forms
                     CancellationToken.None,
                     TaskContinuationOptions.OnlyOnFaulted,
                     TaskScheduler.Default);
+            }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+        }
+
+        private void ScheduleTimedOutConnectRecoveryWatchdog(Task<ConnectAttemptResult> connectTask, string profile)
+        {
+            Task.Delay(TimedOutConnectCleanupRecoveryMilliseconds).ContinueWith(_ =>
+            {
+                if (_shutdownComplete || connectTask.IsCompleted || !IsTimedOutConnectCleanupInProgress())
+                    return;
+
+                TryResetNetworkLockAfterNativeCleanupFailure("stalled timed-out connect cleanup");
+                MarkNativeRecoveryRequired(profile, "stalled timed-out connect cleanup");
+                EndTimedOutConnectCleanup(profile);
             }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
         }
 
@@ -717,10 +827,15 @@ namespace WireSockUI.Forms
         {
             ConnectAttemptResult result = null;
             var cleanupFailed = false;
+            var cleanupCompletedSafely = false;
 
             try
             {
-                if (TryGetCompletedConnectResult(connectTask, out result) && result.Connected)
+                if (!TryGetCompletedConnectResult(connectTask, out result))
+                {
+                    cleanupCompletedSafely = true;
+                }
+                else if (result.Connected)
                 {
                     var disconnected = await DisconnectNativeTunnelAsync(result.ConnectionSequence, false);
                     if (!disconnected)
@@ -729,6 +844,14 @@ namespace WireSockUI.Forms
                             $"Timed-out tunnel sequence {result.ConnectionSequence} could not be disconnected. The tunnel may still be active.");
                         cleanupFailed = true;
                     }
+                    else
+                    {
+                        cleanupCompletedSafely = true;
+                    }
+                }
+                else
+                {
+                    cleanupCompletedSafely = true;
                 }
             }
             catch (Exception ex)
@@ -739,7 +862,14 @@ namespace WireSockUI.Forms
             finally
             {
                 if (cleanupFailed)
+                {
                     TryResetNetworkLockAfterNativeCleanupFailure("timed-out connect cleanup");
+                    MarkNativeRecoveryRequired(profile, "timed-out connect cleanup failure");
+                }
+                else if (cleanupCompletedSafely)
+                {
+                    ClearNativeRecoveryRequired(profile);
+                }
 
                 EndTimedOutConnectCleanup(profile);
             }

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -292,26 +292,6 @@ namespace WireSockUI.Forms
             });
         }
 
-        private void ClearNativeRecoveryRequired(string profile)
-        {
-            if (Interlocked.Exchange(ref _nativeRecoveryRequired, 0) == 0)
-                return;
-
-            TryRunOnUiThread(() =>
-            {
-                if (_currentState != ConnectionState.Disconnected)
-                    return;
-
-                var txtStatus = layoutInterface.Controls.Find("txtStatus", true).FirstOrDefault() as TextBox;
-                if (txtStatus != null)
-                    txtStatus.Text = Resources.InterfaceStatusInactive;
-
-                SetActivateButtonEnabled(true);
-                if (TryGetProfileItem(profile, out var profileItem))
-                    profileItem.ImageKey = ConnectionState.Disconnected.ToString();
-            });
-        }
-
         private void SetNativeRecoveryUi(string profile)
         {
             if (_shutdownComplete || IsDisposed || Disposing)
@@ -827,15 +807,10 @@ namespace WireSockUI.Forms
         {
             ConnectAttemptResult result = null;
             var cleanupFailed = false;
-            var cleanupCompletedSafely = false;
 
             try
             {
-                if (!TryGetCompletedConnectResult(connectTask, out result))
-                {
-                    cleanupCompletedSafely = true;
-                }
-                else if (result.Connected)
+                if (TryGetCompletedConnectResult(connectTask, out result) && result.Connected)
                 {
                     var disconnected = await DisconnectNativeTunnelAsync(result.ConnectionSequence, false);
                     if (!disconnected)
@@ -844,14 +819,6 @@ namespace WireSockUI.Forms
                             $"Timed-out tunnel sequence {result.ConnectionSequence} could not be disconnected. The tunnel may still be active.");
                         cleanupFailed = true;
                     }
-                    else
-                    {
-                        cleanupCompletedSafely = true;
-                    }
-                }
-                else
-                {
-                    cleanupCompletedSafely = true;
                 }
             }
             catch (Exception ex)
@@ -865,10 +832,6 @@ namespace WireSockUI.Forms
                 {
                     TryResetNetworkLockAfterNativeCleanupFailure("timed-out connect cleanup");
                     MarkNativeRecoveryRequired(profile, "timed-out connect cleanup failure");
-                }
-                else if (cleanupCompletedSafely)
-                {
-                    ClearNativeRecoveryRequired(profile);
                 }
 
                 EndTimedOutConnectCleanup(profile);

--- a/WireSockUI/Native/WindowsApplicationContext.cs
+++ b/WireSockUI/Native/WindowsApplicationContext.cs
@@ -2,6 +2,8 @@
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Windows.Forms;
 
 namespace WireSockUI.Native
@@ -33,7 +35,7 @@ namespace WireSockUI.Native
             if (mainModule?.FileName == null) throw new InvalidOperationException("No valid process module found.");
 
             var appName = customName ?? Path.GetFileNameWithoutExtension(mainModule.FileName);
-            var aumid = appUserModelId ?? appName; //TODO: Add seeded bits to avoid collisions?
+            var aumid = appUserModelId ?? BuildDefaultAppUserModelId(appName, mainModule.FileName);
 
             SetCurrentProcessExplicitAppUserModelID(aumid);
 
@@ -52,6 +54,44 @@ namespace WireSockUI.Native
             }
 
             return new WindowsApplicationContext(appName, aumid);
+        }
+
+        private static string BuildDefaultAppUserModelId(string appName, string executablePath)
+        {
+            const int maxAppUserModelIdLength = 128;
+            const string prefix = "WireSock.Foundation";
+
+            var seed = HashPath(executablePath);
+            var segment = SanitizeAppUserModelIdSegment(appName);
+            var maxSegmentLength = maxAppUserModelIdLength - prefix.Length - seed.Length - 2;
+            if (segment.Length > maxSegmentLength)
+                segment = segment.Substring(0, maxSegmentLength).Trim('.');
+
+            return $"{prefix}.{segment}.{seed}";
+        }
+
+        private static string SanitizeAppUserModelIdSegment(string value)
+        {
+            var builder = new StringBuilder();
+            foreach (var character in value ?? string.Empty)
+                builder.Append(char.IsLetterOrDigit(character) ? character : '.');
+
+            var segment = builder.ToString().Trim('.');
+            return string.IsNullOrWhiteSpace(segment) ? "WireSockUI" : segment;
+        }
+
+        private static string HashPath(string path)
+        {
+            using (var sha256 = SHA256.Create())
+            {
+                var normalizedPath = Path.GetFullPath(path ?? string.Empty).ToUpperInvariant();
+                var hash = sha256.ComputeHash(Encoding.Unicode.GetBytes(normalizedPath));
+                var builder = new StringBuilder(16);
+                for (var index = 0; index < 8; index++)
+                    builder.Append(hash[index].ToString("x2"));
+
+                return builder.ToString();
+            }
         }
     }
 }

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.Win32.SafeHandles;
 using WireSockUI.Config;
 using WireSockUI.Extensions;
 using WireSockUI.Forms;
+using WireSockUI.Native;
 using WireSockUI.Properties;
 
 namespace WireSockUI
@@ -25,6 +26,7 @@ namespace WireSockUI
         private const uint OpenExisting = 3;
         private const uint FileFlagOpenReparsePoint = 0x00200000;
         private const uint FileFlagSequentialScan = 0x08000000;
+        private static readonly string[] ScriptHookKeys = { "PreUp", "PostUp", "PreDown", "PostDown" };
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool SetDllDirectory(string lpPathName);
@@ -167,8 +169,7 @@ namespace WireSockUI
             }
             catch (Exception ex)
             {
-                // user possibly doesn't have internet
-                
+                Trace.TraceWarning($"Unable to check for WireSock UI updates: {ex.Message}");
             }
         }
 #endif
@@ -430,6 +431,7 @@ namespace WireSockUI
             try
             {
                 CopyLegacyProfileToTemporaryFile(legacyProfilePath, tmpProfile);
+                EnsureMigratedProfileCanBePromoted(tmpProfile);
                 File.Move(tmpProfile, destinationPath);
                 tmpProfile = null;
                 return true;
@@ -444,6 +446,16 @@ namespace WireSockUI
                 if (tmpProfile != null)
                     TryDeleteTemporaryMigratedProfile(tmpProfile, profileName);
             }
+        }
+
+        private static void EnsureMigratedProfileCanBePromoted(string migratedProfilePath)
+        {
+            var parser = new WireguardConfigParser.ConfigParser(migratedProfilePath);
+            var interfaceSection = parser.GetSection("Interface");
+            foreach (var key in ScriptHookKeys)
+                if (interfaceSection.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
+                    throw new InvalidOperationException(
+                        "The legacy profile contains script hooks. Import this profile manually to review and confirm the scripts.");
         }
 
         private static void CopyLegacyProfileToTemporaryFile(string sourcePath, string destinationPath)

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -452,10 +452,15 @@ namespace WireSockUI
         {
             var parser = new WireguardConfigParser.ConfigParser(migratedProfilePath);
             var interfaceSection = parser.GetSection("Interface");
-            foreach (var key in ScriptHookKeys)
-                if (interfaceSection.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
-                    throw new InvalidOperationException(
-                        "The legacy profile contains script hooks. Import this profile manually to review and confirm the scripts.");
+            if (interfaceSection == null)
+                return;
+
+            foreach (var item in interfaceSection)
+                foreach (var key in ScriptHookKeys)
+                    if (string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase) &&
+                        !string.IsNullOrWhiteSpace(item.Value))
+                        throw new InvalidOperationException(
+                            "The legacy profile contains script hooks. Import this profile manually to review and confirm the scripts.");
         }
 
         private static void CopyLegacyProfileToTemporaryFile(string sourcePath, string destinationPath)

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -452,7 +452,7 @@ namespace WireSockUI
         {
             var parser = new WireguardConfigParser.ConfigParser(migratedProfilePath);
             var interfaceSection = parser.GetSection("Interface");
-            if (interfaceSection == null)
+            if (interfaceSection.Count == 0)
                 return;
 
             foreach (var item in interfaceSection)

--- a/WireSockUI/Properties/Resources.Designer.cs
+++ b/WireSockUI/Properties/Resources.Designer.cs
@@ -1272,15 +1272,6 @@ namespace WireSockUI.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to WireSock UI could not verify that native tunnel cleanup finished before exit. If network access remains blocked, reopen WireSock UI as administrator and use Reset Kill Switch from the tray menu..
-        /// </summary>
-        internal static string TunnelShutdownCleanupUnresolved {
-            get {
-                return ResourceManager.GetString("TunnelShutdownCleanupUnresolved", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Recovery required.
         /// </summary>
         internal static string InterfaceStatusRecoveryRequired {

--- a/WireSockUI/Properties/Resources.Designer.cs
+++ b/WireSockUI/Properties/Resources.Designer.cs
@@ -1227,6 +1227,15 @@ namespace WireSockUI.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to WireSock UI is still cleaning up a timed-out tunnel connection. Wait for cleanup to finish before trying another tunnel operation..
+        /// </summary>
+        internal static string TunnelConnectCleanupPending {
+            get {
+                return ResourceManager.GetString("TunnelConnectCleanupPending", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Tunnel has failed to start. Please check log..
         /// </summary>
         internal static string TunnelErrorStart {
@@ -1241,6 +1250,42 @@ namespace WireSockUI.Properties {
         internal static string TunnelErrorTitle {
             get {
                 return ResourceManager.GetString("TunnelErrorTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to WireSock UI could not finish cleaning up a native tunnel operation. New tunnel operations are disabled to avoid unsafe network state. Restart WireSock UI as administrator; if network access remains blocked, use Reset Kill Switch from the tray menu..
+        /// </summary>
+        internal static string TunnelNativeRecoveryRequired {
+            get {
+                return ResourceManager.GetString("TunnelNativeRecoveryRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to A WireSock tunnel operation is already in progress. Wait for it to finish before trying again..
+        /// </summary>
+        internal static string TunnelOperationPending {
+            get {
+                return ResourceManager.GetString("TunnelOperationPending", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to WireSock UI could not verify that native tunnel cleanup finished before exit. If network access remains blocked, reopen WireSock UI as administrator and use Reset Kill Switch from the tray menu..
+        /// </summary>
+        internal static string TunnelShutdownCleanupUnresolved {
+            get {
+                return ResourceManager.GetString("TunnelShutdownCleanupUnresolved", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Recovery required.
+        /// </summary>
+        internal static string InterfaceStatusRecoveryRequired {
+            get {
+                return ResourceManager.GetString("InterfaceStatusRecoveryRequired", resourceCulture);
             }
         }
     }

--- a/WireSockUI/Properties/Resources.resx
+++ b/WireSockUI/Properties/Resources.resx
@@ -520,9 +520,6 @@
   <data name="TunnelOperationPending" xml:space="preserve">
     <value>A WireSock tunnel operation is already in progress. Wait for it to finish before trying again.</value>
   </data>
-  <data name="TunnelShutdownCleanupUnresolved" xml:space="preserve">
-    <value>WireSock UI could not verify that native tunnel cleanup finished before exit. If network access remains blocked, reopen WireSock UI as administrator and use Reset Kill Switch from the tray menu.</value>
-  </data>
   <data name="InterfaceStatusRecoveryRequired" xml:space="preserve">
     <value>Recovery required</value>
   </data>

--- a/WireSockUI/Properties/Resources.resx
+++ b/WireSockUI/Properties/Resources.resx
@@ -505,10 +505,25 @@
   <data name="TunnelConnectTimeout" xml:space="preserve">
     <value>The tunnel did not report an active connection in time. WireSock UI stopped the pending tunnel; try again or check the log.</value>
   </data>
+  <data name="TunnelConnectCleanupPending" xml:space="preserve">
+    <value>WireSock UI is still cleaning up a timed-out tunnel connection. Wait for cleanup to finish before trying another tunnel operation.</value>
+  </data>
   <data name="TunnelErrorStart" xml:space="preserve">
     <value>Tunnel has failed to start. Please check log.</value>
   </data>
   <data name="TunnelErrorTitle" xml:space="preserve">
     <value>Error</value>
+  </data>
+  <data name="TunnelNativeRecoveryRequired" xml:space="preserve">
+    <value>WireSock UI could not finish cleaning up a native tunnel operation. New tunnel operations are disabled to avoid unsafe network state. Restart WireSock UI as administrator; if network access remains blocked, use Reset Kill Switch from the tray menu.</value>
+  </data>
+  <data name="TunnelOperationPending" xml:space="preserve">
+    <value>A WireSock tunnel operation is already in progress. Wait for it to finish before trying again.</value>
+  </data>
+  <data name="TunnelShutdownCleanupUnresolved" xml:space="preserve">
+    <value>WireSock UI could not verify that native tunnel cleanup finished before exit. If network access remains blocked, reopen WireSock UI as administrator and use Reset Kill Switch from the tray menu.</value>
+  </data>
+  <data name="InterfaceStatusRecoveryRequired" xml:space="preserve">
+    <value>Recovery required</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- add explicit recovery handling for stuck native connect/shutdown cleanup so tunnel operations do not fail silently
- stop auto-migrating legacy profiles with script hooks and keep editor highlighting side-effect free
- seed AppUserModelID per executable path, expand CI to the UWP build path, and document migration/recovery notes

## Verification
- dotnet run --project WireSockUI.Tests\WireSockUI.Tests.csproj --configuration Release --framework net472-windows
- dotnet build WireSockUI.sln --configuration Release /p:Platform=x64 /p:UseSharedCompilation=false -m:1
- dotnet build WireSockUI.sln --configuration "Release UWP" /p:Platform=x64 /p:UseSharedCompilation=false -m:1

## Review
- Performed repeated diff and targeted risk scans after implementation.
- Fixed issues found during review before pushing, including the UWP warning, stale recovery UI race, and overly broad legacy-profile validation.