### PR TITLE
Harden profile validation and autorun ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build-and-test:
+  test:
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -21,8 +21,36 @@ jobs:
       - name: Run focused tests
         run: dotnet run --project WireSockUI.Tests/WireSockUI.Tests.csproj --configuration Release --framework net472-windows
 
-      - name: Build solution
-        run: dotnet build WireSockUI.sln --configuration Release /p:Platform=x64 /p:UseSharedCompilation=false -m:1
+  publish:
+    runs-on: windows-latest
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration:
+          - Release
+          - Release UWP
+        platform:
+          - AnyCPU
+          - ARM64
+          - x64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Build UWP-enabled solution
-        run: dotnet build WireSockUI.sln --configuration "Release UWP" /p:Platform=x64 /p:UseSharedCompilation=false -m:1
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.x'
+
+      - name: Publish WireSockUI
+        run: >
+          dotnet publish WireSockUI/WireSockUI.csproj
+          --configuration "${{ matrix.configuration }}"
+          --framework net472-windows
+          --no-self-contained
+          /p:Platform="${{ matrix.platform }}"
+          /p:UseSharedCompilation=false
+          /p:Version=0.0.0
+          /p:Repository="${{ github.repository }}"
+          -m:1

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -45,6 +45,7 @@ namespace WireSockUI.Tests
                 { "Parser strips WireSock directive prefixes", ParserStripsWireSockDirectivePrefixes },
                 { "Parser rejects duplicate sections", ParserRejectsDuplicateSections },
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
+                { "Profile rejects invalid Amnezia passthrough options", ProfileRejectsInvalidAmneziaPassthroughOptions },
                 { "Stats formatting handles extreme values", StatsFormattingHandlesExtremeValues },
                 { "Time formatting uses plural hours", TimeFormattingUsesPluralHours },
                 { "Time formatting uses singular hour for partial second hour", TimeFormattingUsesSingularHourForPartialSecondHour },
@@ -55,6 +56,7 @@ namespace WireSockUI.Tests
                 { "Profile import rejects oversized files", ProfileImportRejectsOversizedFiles },
                 { "Profile import preserves pre-existing destination on copy failure", ProfileImportPreservesExistingDestinationOnCopyFailure },
                 { "Profile import rejects reparse point sources", ProfileImportRejectsReparsePointSources },
+                { "Profile import rejects directory sources", ProfileImportRejectsDirectorySources },
                 { "Legacy migration rejects oversized files", LegacyMigrationRejectsOversizedFiles },
                 { "Legacy migration rejects reparse point sources", LegacyMigrationRejectsReparsePointSources },
                 { "Legacy migration rejects script hooks", LegacyMigrationRejectsScriptHooks },
@@ -62,6 +64,7 @@ namespace WireSockUI.Tests
                 { "Native recovery marker cleanup removes directory markers", NativeRecoveryMarkerCleanupRemovesDirectoryMarkers },
                 { "Editor validates Amnezia options", EditorValidatesAmneziaOptions },
                 { "AppUserModelID is path seeded", AppUserModelIdIsPathSeeded },
+                { "Autorun task name is path seeded", AutoRunTaskNameIsPathSeeded },
                 { "WireSock disconnect forwards network-lock preservation", WireSockDisconnectForwardsNetworkLockPreservation },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi },
                 { "Stats struct matches wgbooster ABI", StatsStructMatchesWgboosterAbi }
@@ -289,6 +292,38 @@ namespace WireSockUI.Tests
             AssertEqual("1280", interfaceSection["S1"]);
             AssertEqual("chrome", interfaceSection["Ib"]);
             new Profile(path);
+        }
+
+        private static void ProfileRejectsInvalidAmneziaPassthroughOptions()
+        {
+            AssertProfileRejectsInterfaceOption("#@ws:H1 = 4-1", "H1");
+            AssertProfileRejectsInterfaceOption("#@ws:S1 = 1281", "S1");
+            AssertProfileRejectsInterfaceOption("#@ws:Id = ***", "Id");
+            AssertProfileRejectsInterfaceOption("#@ws:Ip = ftp", "Ip");
+            AssertProfileRejectsInterfaceOption("#@ws:Ib = safari", "Ib");
+        }
+
+        private static void AssertProfileRejectsInterfaceOption(string optionLine, string messagePart)
+        {
+            var path = WriteConfig(
+                "[Interface]\n" +
+                $"PrivateKey = {PrivateKey}\n" +
+                "Address = 10.0.0.2/32\n" +
+                optionLine + "\n" +
+                "\n" +
+                "[Peer]\n" +
+                $"PublicKey = {PublicKey}\n" +
+                "Endpoint = example.com:51820\n" +
+                "AllowedIPs = 0.0.0.0/0\n");
+
+            try
+            {
+                AssertThrows<FormatException>(() => new Profile(path), messagePart);
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
         }
 
         private static void StatsFormattingHandlesExtremeValues()
@@ -542,6 +577,37 @@ namespace WireSockUI.Tests
             }
         }
 
+        private static void ProfileImportRejectsDirectorySources()
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+
+            try
+            {
+                Directory.CreateDirectory(directory);
+
+                AssertThrows<IOException>(
+                    () =>
+                    {
+                        using (RegularFileSource.OpenForRead(directory, "profile"))
+                        {
+                        }
+                    },
+                    "directory");
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(directory))
+                        Directory.Delete(directory, true);
+                }
+                catch
+                {
+                    // Best-effort cleanup must not hide the original test failure.
+                }
+            }
+        }
+
         private static void LegacyMigrationRejectsOversizedFiles()
         {
             var copyLegacyProfileToTemporaryFile = typeof(WireSockUI.Program).GetMethod(
@@ -724,6 +790,38 @@ namespace WireSockUI.Tests
             AssertFalse(string.Equals(first, second, StringComparison.Ordinal),
                 "Expected AppUserModelID to differ for side-by-side executable paths.");
             AssertTrue(first.Length <= 128, "Expected AppUserModelID to fit the Windows shell length limit.");
+        }
+
+        private static void AutoRunTaskNameIsPathSeeded()
+        {
+            var buildAutoRunTaskName = typeof(FrmSettings).GetMethod(
+                "BuildAutoRunTaskName", BindingFlags.NonPublic | BindingFlags.Static);
+            if (buildAutoRunTaskName == null)
+                throw new InvalidOperationException("BuildAutoRunTaskName helper was not found.");
+
+            var isSameExecutablePath = typeof(FrmSettings).GetMethod(
+                "IsSameExecutablePath", BindingFlags.NonPublic | BindingFlags.Static);
+            if (isSameExecutablePath == null)
+                throw new InvalidOperationException("IsSameExecutablePath helper was not found.");
+
+            var first = (string)buildAutoRunTaskName.Invoke(null,
+                new object[] { @"C:\Program Files\WireSockUI\WireSockUI.exe" });
+            var firstAgain = (string)buildAutoRunTaskName.Invoke(null,
+                new object[] { @"C:\Program Files\WireSockUI\WireSockUI.exe" });
+            var second = (string)buildAutoRunTaskName.Invoke(null,
+                new object[] { @"D:\Tools\WireSockUI\WireSockUI.exe" });
+
+            AssertEqual(first, firstAgain);
+            AssertFalse(string.Equals(first, second, StringComparison.Ordinal),
+                "Expected autorun task names to differ for side-by-side executable paths.");
+            AssertTrue(first.StartsWith("WireSockUI-", StringComparison.Ordinal),
+                $"Expected autorun task name to include the application prefix, got '{first}'.");
+            AssertTrue((bool)isSameExecutablePath.Invoke(null, new object[]
+                {
+                    @"C:\Program Files\WireSockUI\WireSockUI.exe",
+                    @"""c:\program files\wiresockui\wiresockui.exe"""
+                }),
+                "Expected autorun ownership checks to tolerate quoted task action paths.");
         }
 
         private static void WireSockDisconnectForwardsNetworkLockPreservation()

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -585,14 +585,22 @@ namespace WireSockUI.Tests
             {
                 Directory.CreateDirectory(directory);
 
-                AssertThrows<IOException>(
-                    () =>
+                try
+                {
+                    using (RegularFileSource.OpenForRead(directory + Path.DirectorySeparatorChar, "profile"))
                     {
-                        using (RegularFileSource.OpenForRead(directory, "profile"))
-                        {
-                        }
-                    },
-                    "directory");
+                    }
+                }
+                catch (IOException ex)
+                {
+                    AssertTrue(ex.Message.IndexOf("directory", StringComparison.OrdinalIgnoreCase) >= 0,
+                        $"Expected directory source diagnostic, got '{ex.Message}'.");
+                    AssertTrue(ex.Message.Contains(Path.GetFileName(directory)),
+                        $"Expected directory source diagnostic to include the selected folder name, got '{ex.Message}'.");
+                    return;
+                }
+
+                throw new InvalidOperationException("Expected directory source imports to be rejected.");
             }
             finally
             {
@@ -822,6 +830,12 @@ namespace WireSockUI.Tests
                     @"""c:\program files\wiresockui\wiresockui.exe"""
                 }),
                 "Expected autorun ownership checks to tolerate quoted task action paths.");
+            AssertFalse((bool)isSameExecutablePath.Invoke(null, new object[]
+                {
+                    string.Empty,
+                    @"C:\Program Files\WireSockUI\WireSockUI.exe"
+                }),
+                "Expected empty autorun paths not to match the current executable.");
         }
 
         private static void WireSockDisconnectForwardsNetworkLockPreservation()

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -57,6 +57,7 @@ namespace WireSockUI.Tests
                 { "Profile import preserves pre-existing destination on copy failure", ProfileImportPreservesExistingDestinationOnCopyFailure },
                 { "Profile import rejects reparse point sources", ProfileImportRejectsReparsePointSources },
                 { "Profile import rejects directory sources", ProfileImportRejectsDirectorySources },
+                { "Profile import reports malformed source paths consistently", ProfileImportReportsMalformedSourcePathsConsistently },
                 { "Legacy migration rejects oversized files", LegacyMigrationRejectsOversizedFiles },
                 { "Legacy migration rejects reparse point sources", LegacyMigrationRejectsReparsePointSources },
                 { "Legacy migration rejects script hooks", LegacyMigrationRejectsScriptHooks },
@@ -614,6 +615,21 @@ namespace WireSockUI.Tests
                     // Best-effort cleanup must not hide the original test failure.
                 }
             }
+        }
+
+        private static void ProfileImportReportsMalformedSourcePathsConsistently()
+        {
+            var invalidPath = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+                              Path.DirectorySeparatorChar + "<invalid>.conf";
+
+            AssertThrows<IOException>(
+                () =>
+                {
+                    using (RegularFileSource.OpenForRead(invalidPath, "profile"))
+                    {
+                    }
+                },
+                "Unable to open");
         }
 
         private static void LegacyMigrationRejectsOversizedFiles()

--- a/WireSockUI/Config/Profile.cs
+++ b/WireSockUI/Config/Profile.cs
@@ -80,6 +80,7 @@ namespace WireSockUI.Config
             PostDownScript = section.Get("PostDown");
             BypassLanTraffic = section.Get("BypassLanTraffic");
             VirtualAdapterMode = section.Get("VirtualAdapterMode");
+            ValidateInterfaceExtensions(section);
 
             if (!configESections.Contains("Peer", StringComparer.OrdinalIgnoreCase))
                 throw new ArgumentException(
@@ -488,6 +489,58 @@ namespace WireSockUI.Config
             if (!string.Equals(trimmedValue, "true", StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(trimmedValue, "false", StringComparison.OrdinalIgnoreCase))
                 throw new FormatException($"\"{key}\" in \"{section}\", must be true or false.");
+        }
+
+        private static void ValidateInterfaceExtensions(Dictionary<string, string> section)
+        {
+            ValidateUInt("Interface", "Jc", section.Get("Jc"), 0, 128);
+            ValidateUInt("Interface", "Jd", section.Get("Jd"), 0, 200);
+            ValidateUInt("Interface", "Jmin", section.Get("Jmin"), 0, 1280);
+            ValidateUInt("Interface", "Jmax", section.Get("Jmax"), 0, 1280);
+            ValidateUInt("Interface", "S1", section.Get("S1"), 0, 1280);
+            ValidateUInt("Interface", "S2", section.Get("S2"), 0, 1280);
+            ValidateUInt("Interface", "S3", section.Get("S3"), 0, uint.MaxValue);
+            ValidateUInt("Interface", "S4", section.Get("S4"), 0, uint.MaxValue);
+
+            ValidateUIntOrRange("Interface", "H1", section.Get("H1"), 0, uint.MaxValue);
+            ValidateUIntOrRange("Interface", "H2", section.Get("H2"), 0, uint.MaxValue);
+            ValidateUIntOrRange("Interface", "H3", section.Get("H3"), 0, uint.MaxValue);
+            ValidateUIntOrRange("Interface", "H4", section.Get("H4"), 0, uint.MaxValue);
+
+            ValidateHostName("Interface", "Id", section.Get("Id"));
+            ValidateOneOf("Interface", "Ip", section.Get("Ip"), "quic", "dns", "sip", "stun");
+            ValidateOneOf("Interface", "Ib", section.Get("Ib"), "chrome", "firefox", "curl", "random");
+        }
+
+        private static void ValidateUInt(string section, string key, string keyValue, uint minValue, uint maxValue)
+        {
+            if (!ConfigValueValidator.IsUIntInRange(keyValue, minValue, maxValue))
+                throw new FormatException(
+                    $"\"{key}\" in \"{section}\", invalid value. Expected {minValue}...{maxValue}.");
+        }
+
+        private static void ValidateUIntOrRange(string section, string key, string keyValue, uint minValue,
+            uint maxValue)
+        {
+            if (!ConfigValueValidator.IsUIntOrRange(keyValue, minValue, maxValue))
+                throw new FormatException(
+                    $"\"{key}\" in \"{section}\", invalid value. Expected {minValue}...{maxValue} or an ascending range.");
+        }
+
+        private static void ValidateHostName(string section, string key, string keyValue)
+        {
+            if (string.IsNullOrWhiteSpace(keyValue))
+                return;
+
+            if (Uri.CheckHostName(keyValue.Trim()) == UriHostNameType.Unknown)
+                throw new FormatException($"\"{key}\" in \"{section}\", is not a valid host name.");
+        }
+
+        private static void ValidateOneOf(string section, string key, string keyValue, params string[] values)
+        {
+            if (!ConfigValueValidator.IsOneOf(keyValue, values))
+                throw new FormatException(
+                    $"\"{key}\" in \"{section}\", invalid value. Expected one of: {string.Join(", ", values)}.");
         }
 
         public static IEnumerable<string> GetProfiles()

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -275,6 +275,10 @@ namespace WireSockUI.Forms
 
         private void MarkNativeRecoveryRequired(string profile, string context)
         {
+            Global.WriteNativeRecoveryMarker(
+                context,
+                "Native WireSock cleanup did not finish safely. New tunnel operations are disabled until WireSock UI is restarted.");
+
             var wasAlreadyMarked = Interlocked.Exchange(ref _nativeRecoveryRequired, 1) != 0;
             Trace.TraceWarning(
                 $"Native WireSock cleanup did not finish safely after {context}. New tunnel operations are disabled until WireSock UI is restarted.");

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -275,9 +275,16 @@ namespace WireSockUI.Forms
 
         private void MarkNativeRecoveryRequired(string profile, string context)
         {
-            Global.WriteNativeRecoveryMarker(
-                context,
-                "Native WireSock cleanup did not finish safely. New tunnel operations are disabled until WireSock UI is restarted.");
+            try
+            {
+                Global.WriteNativeRecoveryMarker(
+                    context,
+                    "Native WireSock cleanup did not finish safely. New tunnel operations are disabled until WireSock UI is restarted.");
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to persist native recovery marker after {context}: {ex.Message}");
+            }
 
             var wasAlreadyMarked = Interlocked.Exchange(ref _nativeRecoveryRequired, 1) != 0;
             Trace.TraceWarning(

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -275,16 +275,9 @@ namespace WireSockUI.Forms
 
         private void MarkNativeRecoveryRequired(string profile, string context)
         {
-            try
-            {
-                Global.WriteNativeRecoveryMarker(
-                    context,
-                    "Native WireSock cleanup did not finish safely. New tunnel operations are disabled until WireSock UI is restarted.");
-            }
-            catch (Exception ex)
-            {
-                Trace.TraceWarning($"Failed to persist native recovery marker after {context}: {ex.Message}");
-            }
+            Global.WriteNativeRecoveryMarker(
+                context,
+                "Native WireSock cleanup did not finish safely. New tunnel operations are disabled until WireSock UI is restarted.");
 
             var wasAlreadyMarked = Interlocked.Exchange(ref _nativeRecoveryRequired, 1) != 0;
             Trace.TraceWarning(

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
 using Microsoft.Win32.TaskScheduler;
+using WireSockUI.Native;
 using WireSockUI.Properties;
 
 namespace WireSockUI.Forms
@@ -11,6 +12,7 @@ namespace WireSockUI.Forms
     public partial class FrmSettings : Form
     {
         private readonly bool _initialAutoRun;
+        private readonly bool _initialAutoRunUsesPathScopedTask;
 
         public FrmSettings()
         {
@@ -18,7 +20,7 @@ namespace WireSockUI.Forms
 
             Icon = Resources.ico;
 
-            _initialAutoRun = IsAutoRunEnabled();
+            _initialAutoRun = IsAutoRunEnabled(out _initialAutoRunUsesPathScopedTask);
             chkAutorun.Checked = _initialAutoRun;
             chkAutoMinimize.Checked = Settings.Default.AutoMinimize;
             chkAutoConnect.Checked = Settings.Default.AutoConnect;
@@ -54,13 +56,37 @@ namespace WireSockUI.Forms
             return Path.Combine(startupFolderPath, $"{GetAppName()}.lnk");
         }
 
+        private static string GetAutoRunTaskName()
+        {
+            return BuildAutoRunTaskName(Application.ExecutablePath);
+        }
+
+        private static string GetLegacyAutoRunTaskName()
+        {
+            return GetAppName();
+        }
+
+        private static string BuildAutoRunTaskName(string executablePath)
+        {
+            return $"{GetAppName()}-{WindowsApplicationContext.BuildPathSeed(executablePath)}";
+        }
+
         private static void DeleteLegacyStartupShortcutIfPresent()
         {
             try
             {
                 var shortcutPath = GetLegacyStartupShortcutPath();
-                if (File.Exists(shortcutPath))
-                    File.Delete(shortcutPath);
+                if (!File.Exists(shortcutPath))
+                    return;
+
+                if (!IsShortcutOwnedByCurrentExecutable(shortcutPath))
+                {
+                    Trace.TraceWarning(
+                        $"Skipping legacy Startup shortcut '{shortcutPath}' because it points to a different executable.");
+                    return;
+                }
+
+                File.Delete(shortcutPath);
             }
             catch (Exception ex)
             {
@@ -75,16 +101,23 @@ namespace WireSockUI.Forms
         ///     Returns true if the auto-run feature is enabled, otherwise false.
         /// </returns>
         /// <remarks>
-        ///     This method uses the TaskService to find a task with the same name as the current application.
-        ///     If such a task is found, it means that the auto-run feature is enabled.
+        ///     This method uses a path-seeded task name and verifies that the task points to the current executable.
         /// </remarks>
-        private static bool IsAutoRunEnabled()
+        private static bool IsAutoRunEnabled(out bool usesPathScopedTask)
         {
+            usesPathScopedTask = false;
+
             try
             {
                 using (var ts = new TaskService())
                 {
-                    return ts.FindTask(GetAppName()) != null;
+                    if (IsTaskOwnedByCurrentExecutable(ts.FindTask(GetAutoRunTaskName())))
+                    {
+                        usesPathScopedTask = true;
+                        return true;
+                    }
+
+                    return IsTaskOwnedByCurrentExecutable(ts.FindTask(GetLegacyAutoRunTaskName()));
                 }
             }
             catch (Exception ex)
@@ -98,7 +131,7 @@ namespace WireSockUI.Forms
         ///     Enables the auto-run feature for the current application with administrative privileges.
         /// </summary>
         /// <remarks>
-        ///     This method creates a new task in the Task Scheduler with the same name as the current application.
+        ///     This method creates a new path-scoped task in the Task Scheduler.
         ///     The task is configured to run with the highest privileges and to trigger on logon.
         ///     The task action is set to the path of the current executable.
         ///     The task is also configured to run even if the computer is running on batteries, to not stop if the computer
@@ -130,7 +163,8 @@ namespace WireSockUI.Forms
                     td.Settings.IdleSettings.StopOnIdleEnd =
                         false; // Do not stop the task when the computer ceases to be idle
 
-                    ts.RootFolder.RegisterTaskDefinition(GetAppName(), td);
+                    ts.RootFolder.RegisterTaskDefinition(GetAutoRunTaskName(), td);
+                    DeleteAutoRunTaskIfOwned(ts, GetLegacyAutoRunTaskName());
                 }
 
                 DeleteLegacyStartupShortcutIfPresent();
@@ -147,8 +181,7 @@ namespace WireSockUI.Forms
         ///     Disables the auto-run feature for the current application with administrative privileges.
         /// </summary>
         /// <remarks>
-        ///     This method uses the TaskService to delete a task with the same name as the current application.
-        ///     If such a task is found and deleted, it means that the auto-run feature is disabled.
+        ///     This method deletes only tasks that point to the current executable.
         ///     If an error occurs while disabling auto-run, an error message is displayed.
         /// </remarks>
         private static bool DisableAutoRun()
@@ -157,8 +190,8 @@ namespace WireSockUI.Forms
             {
                 using (var ts = new TaskService())
                 {
-                    if (ts.FindTask(GetAppName()) != null)
-                        ts.RootFolder.DeleteTask(GetAppName(), false);
+                    DeleteAutoRunTaskIfOwned(ts, GetAutoRunTaskName());
+                    DeleteAutoRunTaskIfOwned(ts, GetLegacyAutoRunTaskName());
                 }
 
                 DeleteLegacyStartupShortcutIfPresent();
@@ -171,6 +204,64 @@ namespace WireSockUI.Forms
             }
         }
 
+        private static void DeleteAutoRunTaskIfOwned(TaskService ts, string taskName)
+        {
+            var task = ts.FindTask(taskName);
+            if (task == null)
+                return;
+
+            if (!IsTaskOwnedByCurrentExecutable(task))
+            {
+                Trace.TraceWarning(
+                    $"Skipping autorun task '{taskName}' because it points to a different executable.");
+                return;
+            }
+
+            ts.RootFolder.DeleteTask(taskName, false);
+        }
+
+        private static bool IsTaskOwnedByCurrentExecutable(Microsoft.Win32.TaskScheduler.Task task)
+        {
+            if (task?.Definition?.Actions == null)
+                return false;
+
+            foreach (var action in task.Definition.Actions)
+            {
+                var execAction = action as ExecAction;
+                if (execAction != null && IsSameExecutablePath(execAction.Path, Application.ExecutablePath))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsShortcutOwnedByCurrentExecutable(string shortcutPath)
+        {
+            using (var shortcut = new ShellLink(shortcutPath))
+            {
+                return IsSameExecutablePath(shortcut.TargetPath, Application.ExecutablePath);
+            }
+        }
+
+        private static bool IsSameExecutablePath(string first, string second)
+        {
+            try
+            {
+                return string.Equals(NormalizeExecutablePath(first), NormalizeExecutablePath(second),
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to compare autorun executable paths: {ex.Message}");
+                return string.Equals(first, second, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private static string NormalizeExecutablePath(string path)
+        {
+            return Path.GetFullPath((path ?? string.Empty).Trim().Trim('"'));
+        }
+
         private static void ShowSettingsError(string messageFormat, Exception ex)
         {
             MessageBox.Show(string.Format(messageFormat, ex.Message), Resources.TunnelErrorTitle, MessageBoxButtons.OK,
@@ -179,7 +270,8 @@ namespace WireSockUI.Forms
 
         private void OnSaveClick(object sender, EventArgs e)
         {
-            if (_initialAutoRun != chkAutorun.Checked)
+            if (_initialAutoRun != chkAutorun.Checked ||
+                (chkAutorun.Checked && !_initialAutoRunUsesPathScopedTask))
             {
                 var autoRunUpdated = chkAutorun.Checked ? EnableAutoRun() : DisableAutoRun();
                 if (!autoRunUpdated)

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -259,7 +259,8 @@ namespace WireSockUI.Forms
 
         private static string NormalizeExecutablePath(string path)
         {
-            return Path.GetFullPath((path ?? string.Empty).Trim().Trim('"'));
+            var trimmedPath = (path ?? string.Empty).Trim().Trim('"');
+            return string.IsNullOrEmpty(trimmedPath) ? string.Empty : Path.GetFullPath(trimmedPath);
         }
 
         private static void ShowSettingsError(string messageFormat, Exception ex)

--- a/WireSockUI/Native/RegularFileSource.cs
+++ b/WireSockUI/Native/RegularFileSource.cs
@@ -70,7 +70,7 @@ namespace WireSockUI.Native
                 var errorCode = Marshal.GetLastWin32Error();
                 handle.Dispose();
                 throw new IOException(
-                    $"Unable to open {sourceDescription} '{Path.GetFileName(sourcePath)}'.",
+                    $"Unable to open {sourceDescription} '{GetSourceDisplayName(sourcePath)}'.",
                     new Win32Exception(errorCode));
             }
 
@@ -78,16 +78,16 @@ namespace WireSockUI.Native
             {
                 if (!GetFileInformationByHandle(handle, out var fileInformation))
                     throw new IOException(
-                        $"Unable to inspect {sourceDescription} '{Path.GetFileName(sourcePath)}'.",
+                        $"Unable to inspect {sourceDescription} '{GetSourceDisplayName(sourcePath)}'.",
                         new Win32Exception(Marshal.GetLastWin32Error()));
 
                 if ((fileInformation.FileAttributes & FileAttributes.ReparsePoint) != 0)
                     throw new IOException(
-                        $"{ToSentenceCase(sourceDescription)} '{Path.GetFileName(sourcePath)}' is a reparse point.");
+                        $"{ToSentenceCase(sourceDescription)} '{GetSourceDisplayName(sourcePath)}' is a reparse point.");
 
                 if ((fileInformation.FileAttributes & FileAttributes.Directory) != 0)
                     throw new IOException(
-                        $"{ToSentenceCase(sourceDescription)} '{Path.GetFileName(sourcePath)}' is a directory.");
+                        $"{ToSentenceCase(sourceDescription)} '{GetSourceDisplayName(sourcePath)}' is a directory.");
 
                 return new FileStream(handle, FileAccess.Read, 81920, false);
             }
@@ -125,11 +125,21 @@ namespace WireSockUI.Native
 
             if ((attributes & FileAttributes.ReparsePoint) != 0)
                 throw new IOException(
-                    $"{ToSentenceCase(sourceDescription)} '{Path.GetFileName(sourcePath)}' is a reparse point.");
+                    $"{ToSentenceCase(sourceDescription)} '{GetSourceDisplayName(sourcePath)}' is a reparse point.");
 
             if ((attributes & FileAttributes.Directory) != 0)
                 throw new IOException(
-                    $"{ToSentenceCase(sourceDescription)} '{Path.GetFileName(sourcePath)}' is a directory.");
+                    $"{ToSentenceCase(sourceDescription)} '{GetSourceDisplayName(sourcePath)}' is a directory.");
+        }
+
+        private static string GetSourceDisplayName(string sourcePath)
+        {
+            if (string.IsNullOrWhiteSpace(sourcePath))
+                return string.Empty;
+
+            var trimmedPath = sourcePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var fileName = Path.GetFileName(trimmedPath);
+            return string.IsNullOrWhiteSpace(fileName) ? sourcePath : fileName;
         }
 
         public static void CopyToTemporaryFile(

--- a/WireSockUI/Native/RegularFileSource.cs
+++ b/WireSockUI/Native/RegularFileSource.cs
@@ -114,7 +114,23 @@ namespace WireSockUI.Native
             {
                 return;
             }
+            catch (ArgumentException)
+            {
+                return;
+            }
+            catch (NotSupportedException)
+            {
+                return;
+            }
+            catch (PathTooLongException)
+            {
+                return;
+            }
             catch (UnauthorizedAccessException)
+            {
+                return;
+            }
+            catch (System.Security.SecurityException)
             {
                 return;
             }
@@ -138,8 +154,26 @@ namespace WireSockUI.Native
                 return string.Empty;
 
             var trimmedPath = sourcePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var fileName = Path.GetFileName(trimmedPath);
-            return string.IsNullOrWhiteSpace(fileName) ? sourcePath : fileName;
+            try
+            {
+                var fileName = Path.GetFileName(trimmedPath);
+                if (!string.IsNullOrWhiteSpace(fileName))
+                    return fileName;
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (NotSupportedException)
+            {
+            }
+            catch (PathTooLongException)
+            {
+            }
+            catch (System.Security.SecurityException)
+            {
+            }
+
+            return string.IsNullOrWhiteSpace(trimmedPath) ? sourcePath : trimmedPath;
         }
 
         public static void CopyToTemporaryFile(

--- a/WireSockUI/Native/RegularFileSource.cs
+++ b/WireSockUI/Native/RegularFileSource.cs
@@ -12,6 +12,7 @@ namespace WireSockUI.Native
         private const uint FileShareRead = 0x00000001;
         private const uint OpenExisting = 3;
         private const uint FileFlagOpenReparsePoint = 0x00200000;
+        private const uint FileFlagBackupSemantics = 0x02000000;
         private const uint FileFlagSequentialScan = 0x08000000;
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
@@ -53,13 +54,15 @@ namespace WireSockUI.Native
 
         public static FileStream OpenForRead(string sourcePath, string sourceDescription)
         {
+            RejectUnsupportedSourceAttributes(sourcePath, sourceDescription);
+
             var handle = CreateFile(
                 sourcePath,
                 GenericRead,
                 FileShareRead,
                 IntPtr.Zero,
                 OpenExisting,
-                FileFlagOpenReparsePoint | FileFlagSequentialScan,
+                FileFlagOpenReparsePoint | FileFlagBackupSemantics | FileFlagSequentialScan,
                 IntPtr.Zero);
 
             if (handle.IsInvalid)
@@ -93,6 +96,40 @@ namespace WireSockUI.Native
                 handle.Dispose();
                 throw;
             }
+        }
+
+        private static void RejectUnsupportedSourceAttributes(string sourcePath, string sourceDescription)
+        {
+            FileAttributes attributes;
+
+            try
+            {
+                attributes = File.GetAttributes(sourcePath);
+            }
+            catch (FileNotFoundException)
+            {
+                return;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return;
+            }
+            catch (IOException)
+            {
+                return;
+            }
+
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+                throw new IOException(
+                    $"{ToSentenceCase(sourceDescription)} '{Path.GetFileName(sourcePath)}' is a reparse point.");
+
+            if ((attributes & FileAttributes.Directory) != 0)
+                throw new IOException(
+                    $"{ToSentenceCase(sourceDescription)} '{Path.GetFileName(sourcePath)}' is a directory.");
         }
 
         public static void CopyToTemporaryFile(

--- a/WireSockUI/Native/WindowsApplicationContext.cs
+++ b/WireSockUI/Native/WindowsApplicationContext.cs
@@ -61,7 +61,7 @@ namespace WireSockUI.Native
             const int maxAppUserModelIdLength = 128;
             const string prefix = "WireSock.Foundation";
 
-            var seed = HashPath(executablePath);
+            var seed = BuildPathSeed(executablePath);
             var segment = SanitizeAppUserModelIdSegment(appName);
             var maxSegmentLength = maxAppUserModelIdLength - prefix.Length - seed.Length - 2;
             if (segment.Length > maxSegmentLength)
@@ -80,7 +80,7 @@ namespace WireSockUI.Native
             return string.IsNullOrWhiteSpace(segment) ? "WireSockUI" : segment;
         }
 
-        private static string HashPath(string path)
+        internal static string BuildPathSeed(string path)
         {
             using (var sha256 = SHA256.Create())
             {


### PR DESCRIPTION
Summary: persist native recovery markers for timed-out cleanup, scope autorun ownership to the executable path, validate Amnezia/WireSock extension options on profile load, improve directory-source diagnostics, and expand CI publish coverage. Verification: focused test harness passed; Release x64 solution build passed with zero warnings; final publish matrix passed for Release and UWP-enabled builds across x64, AnyCPU, and ARM64; git diff --check passed.