### PR TITLE
Harden kill switch settings and recovery UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Profiles containing `PreUp`, `PostUp`, `PreDown`, or `PostDown` script hooks req
 
 The Settings dialog includes an optional Kill Switch toggle. When enabled, WireSockUI calls the `wgbooster.dll` network-lock API before creating the tunnel, preserves the native lock during reconnect/profile-switch cleanup, and clears the lock through normal tunnel cleanup when disconnecting. The option is off by default so existing SDK/minimal installations keep their current behavior.
 
-If a native connect cleanup call does not return, WireSockUI attempts to reset the network lock and disables further tunnel operations with a recovery warning instead of leaving the Activate button silently stuck. Shutdown cleanup timeouts do not block process exit; if WireSockUI cannot verify/reset the network lock during shutdown it writes a secured recovery marker and shows a visible startup warning on the next elevated launch. Restart WireSockUI as administrator and use **Reset Kill Switch** from the tray menu if network access remains blocked.
+If a native connect cleanup call does not return, WireSockUI attempts to reset the network lock and disables further tunnel operations with a recovery warning instead of leaving the Activate button silently stuck. Shutdown cleanup timeouts do not block process exit; if WireSockUI cannot verify/reset the network lock during shutdown it writes a secured recovery marker and shows a visible startup warning on the next elevated launch. Restart WireSockUI as administrator and use **Reset Kill Switch** from the tray menu while disconnected or in recovery mode if network access remains blocked.
 
 ## Compatibility Notes
 

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -239,6 +239,10 @@ namespace WireSockUI.Tests
                 "Expected malformed profile paths to be rejected.");
             AssertTrue(!string.IsNullOrWhiteSpace(diagnostic),
                 "Expected malformed profile paths to produce a diagnostic.");
+            AssertFalse(diagnostic.Contains("\0"),
+                $"Expected malformed profile diagnostics to escape embedded NULs, got '{diagnostic}'.");
+            AssertTrue(diagnostic.Contains("\\0"),
+                $"Expected malformed profile diagnostics to include the escaped NUL marker, got '{diagnostic}'.");
             AssertThrows<IOException>(() => Profile.EnsureRegularProfileFile(malformedPath), "profile");
         }
 

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -42,10 +42,12 @@ namespace WireSockUI.Tests
                 { "Profile rejects directory profile paths", ProfileRejectsDirectoryProfilePaths },
                 { "Profile rejects reparse point profile files", ProfileRejectsReparsePointProfileFiles },
                 { "Profile reports missing profile paths clearly", ProfileReportsMissingProfilePathsClearly },
+                { "Profile reports malformed profile paths consistently", ProfileReportsMalformedProfilePathsConsistently },
                 { "Parser strips WireSock directive prefixes", ParserStripsWireSockDirectivePrefixes },
                 { "Parser rejects duplicate sections", ParserRejectsDuplicateSections },
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
                 { "Profile rejects invalid Amnezia passthrough options", ProfileRejectsInvalidAmneziaPassthroughOptions },
+                { "Interface extension validation rules are shared", InterfaceExtensionValidationRulesAreShared },
                 { "Stats formatting handles extreme values", StatsFormattingHandlesExtremeValues },
                 { "Time formatting uses plural hours", TimeFormattingUsesPluralHours },
                 { "Time formatting uses singular hour for partial second hour", TimeFormattingUsesSingularHourForPartialSecondHour },
@@ -229,6 +231,17 @@ namespace WireSockUI.Tests
             });
         }
 
+        private static void ProfileReportsMalformedProfilePathsConsistently()
+        {
+            var malformedPath = "invalid\0profile.conf";
+
+            AssertFalse(Profile.IsRegularProfileFile(malformedPath, out var diagnostic),
+                "Expected malformed profile paths to be rejected.");
+            AssertTrue(!string.IsNullOrWhiteSpace(diagnostic),
+                "Expected malformed profile paths to produce a diagnostic.");
+            AssertThrows<IOException>(() => Profile.EnsureRegularProfileFile(malformedPath), "profile");
+        }
+
         private static void ParserStripsWireSockDirectivePrefixes()
         {
             var path = WriteConfig(
@@ -302,6 +315,23 @@ namespace WireSockUI.Tests
             AssertProfileRejectsInterfaceOption("#@ws:Id = ***", "Id");
             AssertProfileRejectsInterfaceOption("#@ws:Ip = ftp", "Ip");
             AssertProfileRejectsInterfaceOption("#@ws:Ib = safari", "Ib");
+        }
+
+        private static void InterfaceExtensionValidationRulesAreShared()
+        {
+            AssertTrue(ConfigValueValidator.TryGetInterfaceExtensionRule("h1", out var h1),
+                "Expected H1 to be registered as a shared interface extension rule.");
+            AssertTrue(h1.IsValid("1-4"), "Expected H1 to accept ascending ranges.");
+            AssertFalse(h1.IsValid("4-1"), "Expected H1 to reject descending ranges.");
+
+            AssertTrue(ConfigValueValidator.TryGetInterfaceExtensionRule("Ib", out var ib),
+                "Expected Ib to be registered as a shared interface extension rule.");
+            AssertTrue(ib.IsValid("chrome"), "Expected Ib to accept supported browser profiles.");
+            AssertFalse(ib.IsValid("safari"), "Expected Ib to reject unsupported browser profiles.");
+
+            AssertTrue(ConfigValueValidator.TryGetInterfaceExtensionRule("Id", out var id),
+                "Expected Id to be registered as a shared interface extension rule.");
+            AssertFalse(id.IsValid("***"), "Expected Id to reject invalid host names.");
         }
 
         private static void AssertProfileRejectsInterfaceOption(string optionLine, string messagePart)

--- a/WireSockUI/Config/ConfigValueValidator.cs
+++ b/WireSockUI/Config/ConfigValueValidator.cs
@@ -1,10 +1,46 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace WireSockUI.Config
 {
     internal static class ConfigValueValidator
     {
+        private static readonly ConfigValueRule[] InterfaceExtensionRuleList =
+        {
+            new ConfigValueRule("Jc", value => IsUIntInRange(value, 0, 128), "0...128"),
+            new ConfigValueRule("Jd", value => IsUIntInRange(value, 0, 200), "0...200"),
+            new ConfigValueRule("Jmin", value => IsUIntInRange(value, 0, 1280), "0...1280"),
+            new ConfigValueRule("Jmax", value => IsUIntInRange(value, 0, 1280), "0...1280"),
+            new ConfigValueRule("S1", value => IsUIntInRange(value, 0, 1280), "0...1280"),
+            new ConfigValueRule("S2", value => IsUIntInRange(value, 0, 1280), "0...1280"),
+            new ConfigValueRule("S3", value => IsUIntInRange(value, 0, uint.MaxValue), $"0...{uint.MaxValue}"),
+            new ConfigValueRule("S4", value => IsUIntInRange(value, 0, uint.MaxValue), $"0...{uint.MaxValue}"),
+            new ConfigValueRule("H1", value => IsUIntOrRange(value, 0, uint.MaxValue),
+                $"0...{uint.MaxValue} or an ascending range"),
+            new ConfigValueRule("H2", value => IsUIntOrRange(value, 0, uint.MaxValue),
+                $"0...{uint.MaxValue} or an ascending range"),
+            new ConfigValueRule("H3", value => IsUIntOrRange(value, 0, uint.MaxValue),
+                $"0...{uint.MaxValue} or an ascending range"),
+            new ConfigValueRule("H4", value => IsUIntOrRange(value, 0, uint.MaxValue),
+                $"0...{uint.MaxValue} or an ascending range"),
+            new ConfigValueRule("Id", IsHostName, "a valid host name"),
+            new ConfigValueRule("Ip", value => IsOneOf(value, "quic", "dns", "sip", "stun"),
+                "one of: quic, dns, sip, stun"),
+            new ConfigValueRule("Ib", value => IsOneOf(value, "chrome", "firefox", "curl", "random"),
+                "one of: chrome, firefox, curl, random")
+        };
+
+        private static readonly Dictionary<string, ConfigValueRule> InterfaceExtensionRuleLookup =
+            BuildInterfaceExtensionRuleLookup();
+
+        public static IEnumerable<ConfigValueRule> InterfaceExtensionRules => InterfaceExtensionRuleList;
+
+        public static bool TryGetInterfaceExtensionRule(string key, out ConfigValueRule rule)
+        {
+            return InterfaceExtensionRuleLookup.TryGetValue(key ?? string.Empty, out rule);
+        }
+
         public static bool IsIntInRange(string value, int minValue, int maxValue)
         {
             if (string.IsNullOrWhiteSpace(value))
@@ -70,6 +106,24 @@ namespace WireSockUI.Config
             return false;
         }
 
+        public static bool IsHostName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return true;
+
+            return Uri.CheckHostName(value.Trim()) != UriHostNameType.Unknown;
+        }
+
+        private static Dictionary<string, ConfigValueRule> BuildInterfaceExtensionRuleLookup()
+        {
+            var rules = new Dictionary<string, ConfigValueRule>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var rule in InterfaceExtensionRuleList)
+                rules[rule.Key] = rule;
+
+            return rules;
+        }
+
         private static bool TryParseUInt(string value, out uint result)
         {
             var trimmed = value.Trim();
@@ -78,6 +132,22 @@ namespace WireSockUI.Config
                     out result);
 
             return uint.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+        }
+
+        internal sealed class ConfigValueRule
+        {
+            public ConfigValueRule(string key, Func<string, bool> isValid, string expectedValueDescription)
+            {
+                Key = key;
+                IsValid = isValid;
+                ExpectedValueDescription = expectedValueDescription;
+            }
+
+            public string Key { get; }
+
+            public Func<string, bool> IsValid { get; }
+
+            public string ExpectedValueDescription { get; }
         }
     }
 }

--- a/WireSockUI/Config/Profile.cs
+++ b/WireSockUI/Config/Profile.cs
@@ -700,7 +700,7 @@ namespace WireSockUI.Config
             {
                 var fileName = Path.GetFileName(trimmedPath);
                 if (!string.IsNullOrWhiteSpace(fileName))
-                    return fileName;
+                    return EscapeProfileDisplayName(fileName);
             }
             catch (ArgumentException)
             {
@@ -715,7 +715,12 @@ namespace WireSockUI.Config
             {
             }
 
-            return string.IsNullOrWhiteSpace(trimmedPath) ? profilePath : trimmedPath;
+            return EscapeProfileDisplayName(string.IsNullOrWhiteSpace(trimmedPath) ? profilePath : trimmedPath);
+        }
+
+        private static string EscapeProfileDisplayName(string value)
+        {
+            return (value ?? string.Empty).Replace("\0", "\\0");
         }
 
         private static void AddScriptHook(List<KeyValuePair<string, string>> hooks, string name, string value)

--- a/WireSockUI/Config/Profile.cs
+++ b/WireSockUI/Config/Profile.cs
@@ -53,7 +53,7 @@ namespace WireSockUI.Config
         public Profile(string profilePath)
         {
             if (!ProfilePathExists(profilePath))
-                throw new FileNotFoundException($"Profile {Path.GetFileName(profilePath)} does not exist.");
+                throw new FileNotFoundException($"Profile {GetProfileDisplayName(profilePath)} does not exist.");
 
             EnsureRegularProfileFile(profilePath);
 
@@ -63,7 +63,7 @@ namespace WireSockUI.Config
             var configESections = sections as string[] ?? sections.ToArray();
             if (!configESections.Contains("Interface", StringComparer.OrdinalIgnoreCase))
                 throw new ArgumentException(
-                    $"Profile {Path.GetFileName(profilePath)} does not contain an \"Interface\" section.");
+                    $"Profile {GetProfileDisplayName(profilePath)} does not contain an \"Interface\" section.");
 
             var section = parser.GetSection("Interface");
 
@@ -84,7 +84,7 @@ namespace WireSockUI.Config
 
             if (!configESections.Contains("Peer", StringComparer.OrdinalIgnoreCase))
                 throw new ArgumentException(
-                    $"Profile {Path.GetFileName(profilePath)} does not contain a \"Peer\" section.");
+                    $"Profile {GetProfileDisplayName(profilePath)} does not contain a \"Peer\" section.");
 
             section = parser.GetSection("Peer");
 
@@ -493,54 +493,12 @@ namespace WireSockUI.Config
 
         private static void ValidateInterfaceExtensions(Dictionary<string, string> section)
         {
-            ValidateUInt("Interface", "Jc", section.Get("Jc"), 0, 128);
-            ValidateUInt("Interface", "Jd", section.Get("Jd"), 0, 200);
-            ValidateUInt("Interface", "Jmin", section.Get("Jmin"), 0, 1280);
-            ValidateUInt("Interface", "Jmax", section.Get("Jmax"), 0, 1280);
-            ValidateUInt("Interface", "S1", section.Get("S1"), 0, 1280);
-            ValidateUInt("Interface", "S2", section.Get("S2"), 0, 1280);
-            ValidateUInt("Interface", "S3", section.Get("S3"), 0, uint.MaxValue);
-            ValidateUInt("Interface", "S4", section.Get("S4"), 0, uint.MaxValue);
-
-            ValidateUIntOrRange("Interface", "H1", section.Get("H1"), 0, uint.MaxValue);
-            ValidateUIntOrRange("Interface", "H2", section.Get("H2"), 0, uint.MaxValue);
-            ValidateUIntOrRange("Interface", "H3", section.Get("H3"), 0, uint.MaxValue);
-            ValidateUIntOrRange("Interface", "H4", section.Get("H4"), 0, uint.MaxValue);
-
-            ValidateHostName("Interface", "Id", section.Get("Id"));
-            ValidateOneOf("Interface", "Ip", section.Get("Ip"), "quic", "dns", "sip", "stun");
-            ValidateOneOf("Interface", "Ib", section.Get("Ib"), "chrome", "firefox", "curl", "random");
-        }
-
-        private static void ValidateUInt(string section, string key, string keyValue, uint minValue, uint maxValue)
-        {
-            if (!ConfigValueValidator.IsUIntInRange(keyValue, minValue, maxValue))
-                throw new FormatException(
-                    $"\"{key}\" in \"{section}\", invalid value. Expected {minValue}...{maxValue}.");
-        }
-
-        private static void ValidateUIntOrRange(string section, string key, string keyValue, uint minValue,
-            uint maxValue)
-        {
-            if (!ConfigValueValidator.IsUIntOrRange(keyValue, minValue, maxValue))
-                throw new FormatException(
-                    $"\"{key}\" in \"{section}\", invalid value. Expected {minValue}...{maxValue} or an ascending range.");
-        }
-
-        private static void ValidateHostName(string section, string key, string keyValue)
-        {
-            if (string.IsNullOrWhiteSpace(keyValue))
-                return;
-
-            if (Uri.CheckHostName(keyValue.Trim()) == UriHostNameType.Unknown)
-                throw new FormatException($"\"{key}\" in \"{section}\", is not a valid host name.");
-        }
-
-        private static void ValidateOneOf(string section, string key, string keyValue, params string[] values)
-        {
-            if (!ConfigValueValidator.IsOneOf(keyValue, values))
-                throw new FormatException(
-                    $"\"{key}\" in \"{section}\", invalid value. Expected one of: {string.Join(", ", values)}.");
+            foreach (var rule in ConfigValueValidator.InterfaceExtensionRules)
+            {
+                if (!rule.IsValid(section.Get(rule.Key)))
+                    throw new FormatException(
+                        $"\"{rule.Key}\" in \"Interface\", invalid value. Expected {rule.ExpectedValueDescription}.");
+            }
         }
 
         public static IEnumerable<string> GetProfiles()
@@ -665,7 +623,7 @@ namespace WireSockUI.Config
             catch (Exception ex)
             {
                 Trace.TraceWarning(
-                    $"Unable to inspect profile path '{Path.GetFileName(profilePath)}': {ex.Message}");
+                    $"Unable to inspect profile path '{GetProfileDisplayName(profilePath)}': {ex.Message}");
                 return true;
             }
         }
@@ -686,14 +644,14 @@ namespace WireSockUI.Config
                 if ((attributes & FileAttributes.Directory) != 0)
                 {
                     diagnostic =
-                        $"Profile path '{Path.GetFileName(profilePath)}' is a directory and will not be loaded by elevated WireSock UI.";
+                        $"Profile path '{GetProfileDisplayName(profilePath)}' is a directory and will not be loaded by elevated WireSock UI.";
                     return false;
                 }
 
                 if ((attributes & FileAttributes.ReparsePoint) != 0)
                 {
                     diagnostic =
-                        $"Profile file '{Path.GetFileName(profilePath)}' is a reparse point and will not be loaded by elevated WireSock UI.";
+                        $"Profile file '{GetProfileDisplayName(profilePath)}' is a reparse point and will not be loaded by elevated WireSock UI.";
                     return false;
                 }
 
@@ -701,18 +659,18 @@ namespace WireSockUI.Config
             }
             catch (FileNotFoundException)
             {
-                diagnostic = $"Profile file '{Path.GetFileName(profilePath)}' does not exist.";
+                diagnostic = $"Profile file '{GetProfileDisplayName(profilePath)}' does not exist.";
                 return false;
             }
             catch (DirectoryNotFoundException)
             {
-                diagnostic = $"Profile directory for '{Path.GetFileName(profilePath)}' does not exist.";
+                diagnostic = $"Profile directory for '{GetProfileDisplayName(profilePath)}' does not exist.";
                 return false;
             }
             catch (Exception ex)
             {
                 diagnostic =
-                    $"Unable to inspect profile file '{Path.GetFileName(profilePath)}': {ex.Message}";
+                    $"Unable to inspect profile file '{GetProfileDisplayName(profilePath)}': {ex.Message}";
                 return false;
             }
         }
@@ -722,14 +680,42 @@ namespace WireSockUI.Config
         {
             if (!section.ContainsKey(key))
                 throw new ArgumentException(
-                    $"Profile {Path.GetFileName(profilePath)}, section \"{sectionName}\" does not have a \"{key}\" defined.");
+                    $"Profile {GetProfileDisplayName(profilePath)}, section \"{sectionName}\" does not have a \"{key}\" defined.");
 
             var value = section.Get(key);
             if (string.IsNullOrWhiteSpace(value))
                 throw new ArgumentException(
-                    $"Profile {Path.GetFileName(profilePath)}, section \"{sectionName}\" has an empty \"{key}\" value.");
+                    $"Profile {GetProfileDisplayName(profilePath)}, section \"{sectionName}\" has an empty \"{key}\" value.");
 
             return value;
+        }
+
+        private static string GetProfileDisplayName(string profilePath)
+        {
+            if (string.IsNullOrWhiteSpace(profilePath))
+                return string.Empty;
+
+            var trimmedPath = profilePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            try
+            {
+                var fileName = Path.GetFileName(trimmedPath);
+                if (!string.IsNullOrWhiteSpace(fileName))
+                    return fileName;
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (NotSupportedException)
+            {
+            }
+            catch (PathTooLongException)
+            {
+            }
+            catch (System.Security.SecurityException)
+            {
+            }
+
+            return string.IsNullOrWhiteSpace(trimmedPath) ? profilePath : trimmedPath;
         }
 
         private static void AddScriptHook(List<KeyValuePair<string, string>> hooks, string name, string value)

--- a/WireSockUI/Forms/frmEdit.cs
+++ b/WireSockUI/Forms/frmEdit.cs
@@ -163,6 +163,17 @@ namespace WireSockUI.Forms
                             value = m.Groups["value"].Value;
                         }
 
+                        if (ConfigValueValidator.TryGetInterfaceExtensionRule(key, out var interfaceExtensionRule))
+                        {
+                            if (!interfaceExtensionRule.IsValid(value))
+                            {
+                                txtEditor.UnderlineSelection();
+                                hasErrors = true;
+                            }
+
+                            continue;
+                        }
+
                         switch (key)
                         {
                             // base64 256-bit keys
@@ -280,48 +291,6 @@ namespace WireSockUI.Forms
                                     hasErrors = true;
                                 }
                                 break;
-                            case "jc":
-                                if (!ConfigValueValidator.IsUIntInRange(value, 0, 128))
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                                break;
-                            case "jd":
-                                if (!ConfigValueValidator.IsUIntInRange(value, 0, 200))
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                                break;
-                            case "jmin":
-                            case "jmax":
-                            case "s1":
-                            case "s2":
-                                if (!ConfigValueValidator.IsUIntInRange(value, 0, 1280))
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                                break;
-                            case "s3":
-                            case "s4":
-                                if (!ConfigValueValidator.IsUIntInRange(value, 0, uint.MaxValue))
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                                break;
-                            case "h1":
-                            case "h2":
-                            case "h3":
-                            case "h4":
-                                if (!ConfigValueValidator.IsUIntOrRange(value, 0, uint.MaxValue))
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                                break;
                             // Comma-delimited string values
                             case "allowedapps":
                             case "disallowedapps":
@@ -351,28 +320,6 @@ namespace WireSockUI.Forms
                                 break;
                             // Known free-form or WireGuard-managed values
                             case "table":
-                                break;
-                            case "id":
-                                if (!string.IsNullOrWhiteSpace(value) &&
-                                    Uri.CheckHostName(value.Trim()) == UriHostNameType.Unknown)
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                                break;
-                            case "ip":
-                                if (!ConfigValueValidator.IsOneOf(value, "quic", "dns", "sip", "stun"))
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
-                                break;
-                            case "ib":
-                                if (!ConfigValueValidator.IsOneOf(value, "chrome", "firefox", "curl", "random"))
-                                {
-                                    txtEditor.UnderlineSelection();
-                                    hasErrors = true;
-                                }
                                 break;
                             case "i1":
                             case "i2":

--- a/WireSockUI/Forms/frmMain.Designer.cs
+++ b/WireSockUI/Forms/frmMain.Designer.cs
@@ -38,6 +38,7 @@ namespace WireSockUI.Forms
             this.cmiAddresses = new System.Windows.Forms.ToolStripMenuItem();
             this.cmiSepTunnels = new System.Windows.Forms.ToolStripSeparator();
             this.cmiDeactivateTunnel = new System.Windows.Forms.ToolStripMenuItem();
+            this.cmiResetKillSwitch = new System.Windows.Forms.ToolStripMenuItem();
             this.cmiManageTunnels = new System.Windows.Forms.ToolStripMenuItem();
             this.cmiOpenTunnel = new System.Windows.Forms.ToolStripMenuItem();
             this.cmiSepBottom = new System.Windows.Forms.ToolStripSeparator();
@@ -103,13 +104,14 @@ namespace WireSockUI.Forms
             this.cmiAddresses,
             this.cmiSepTunnels,
             this.cmiDeactivateTunnel,
+            this.cmiResetKillSwitch,
             this.cmiManageTunnels,
             this.cmiOpenTunnel,
             this.cmiSepBottom,
             this.cmiExit});
             this.mnuContext.Name = "contextMenuStrip1";
             this.resControls.SetResourceKey(this.mnuContext, null);
-            this.mnuContext.Size = new System.Drawing.Size(211, 126);
+            this.mnuContext.Size = new System.Drawing.Size(211, 148);
             // 
             // cmiStatus
             // 
@@ -142,6 +144,14 @@ namespace WireSockUI.Forms
             this.cmiDeactivateTunnel.Size = new System.Drawing.Size(210, 22);
             this.cmiDeactivateTunnel.Text = "Deactivate tunnel";
             this.cmiDeactivateTunnel.Click += new System.EventHandler(this.OnDisconnectClick);
+            //
+            // cmiResetKillSwitch
+            //
+            this.cmiResetKillSwitch.Name = "cmiResetKillSwitch";
+            this.resMenu.SetResourceKey(this.cmiResetKillSwitch, "MenuResetKillSwitch");
+            this.cmiResetKillSwitch.Size = new System.Drawing.Size(210, 22);
+            this.cmiResetKillSwitch.Text = "Reset Kill Switch";
+            this.cmiResetKillSwitch.Click += new System.EventHandler(this.OnResetKillSwitchClick);
             // 
             // cmiManageTunnels
             // 
@@ -567,6 +577,7 @@ namespace WireSockUI.Forms
         private ContextMenuStrip mnuContext;
         private ToolStripMenuItem cmiExit;
         private ToolStripMenuItem cmiDeactivateTunnel;
+        private ToolStripMenuItem cmiResetKillSwitch;
         private ToolStripMenuItem cmiManageTunnels;
         private ToolStripSeparator cmiSepBottom;
         private ToolStripMenuItem cmiOpenTunnel;

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -1452,8 +1452,7 @@ namespace WireSockUI.Forms
         {
             var shouldApplyNativeState =
                 requestedEnableKillSwitch != previousEnableKillSwitch ||
-                _wiresock.HasTunnelHandle ||
-                !requestedEnableKillSwitch;
+                _wiresock.HasTunnelHandle;
 
             if (shouldApplyNativeState && !ApplyKillSwitchSetting(requestedEnableKillSwitch))
             {
@@ -1547,8 +1546,7 @@ namespace WireSockUI.Forms
                 return;
             }
 
-            if (!IsNativeRecoveryRequired())
-                Global.TryDeleteNativeRecoveryMarker();
+            Global.TryDeleteNativeRecoveryMarker();
 
             MessageBox.Show(Resources.KillSwitchResetSuccess, Resources.KillSwitchResetTitle,
                 MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -253,6 +253,7 @@ namespace WireSockUI.Forms
         {
             Interlocked.Exchange(ref _timedOutConnectCleanupInProgress, 1);
             SetActivateButtonEnabled(false);
+            cmiResetKillSwitch.Enabled = false;
         }
 
         private void EndTimedOutConnectCleanup(string profile)
@@ -267,6 +268,7 @@ namespace WireSockUI.Forms
                 if (_currentState == ConnectionState.Disconnected)
                 {
                     SetActivateButtonEnabled(true);
+                    cmiResetKillSwitch.Enabled = true;
                     if (TryGetProfileItem(profile, out var profileItem))
                         profileItem.ImageKey = ConnectionState.Disconnected.ToString();
                 }
@@ -312,6 +314,7 @@ namespace WireSockUI.Forms
                 txtStatus.Text = Resources.InterfaceStatusRecoveryRequired;
 
             cmiDeactivateTunnel.Enabled = false;
+            cmiResetKillSwitch.Enabled = true;
         }
 
         private void ShowTunnelOperationBlockedMessage(string message)
@@ -329,24 +332,27 @@ namespace WireSockUI.Forms
             _tunnelStateWorker.CancelAsync();
         }
 
-        private bool TryBeginTunnelOperation()
+        private bool TryBeginTunnelOperation(bool showBlockedMessage = true)
         {
             if (IsTimedOutConnectCleanupInProgress())
             {
-                ShowTunnelOperationBlockedMessage(Resources.TunnelConnectCleanupPending);
+                if (showBlockedMessage)
+                    ShowTunnelOperationBlockedMessage(Resources.TunnelConnectCleanupPending);
                 return false;
             }
 
             if (IsNativeRecoveryRequired())
             {
-                ShowTunnelOperationBlockedMessage(Resources.TunnelNativeRecoveryRequired);
+                if (showBlockedMessage)
+                    ShowTunnelOperationBlockedMessage(Resources.TunnelNativeRecoveryRequired);
                 return false;
             }
 
             if (Interlocked.CompareExchange(ref _tunnelOperationInProgress, 1, 0) == 0)
                 return true;
 
-            ShowTunnelOperationBlockedMessage(Resources.TunnelOperationPending);
+            if (showBlockedMessage)
+                ShowTunnelOperationBlockedMessage(Resources.TunnelOperationPending);
             return false;
         }
 
@@ -712,7 +718,7 @@ namespace WireSockUI.Forms
 
         private async Task HandleTunnelConnectionTimeoutAsync(int generation)
         {
-            if (!RequestTunnelConnectionTimeout(generation) || !TryBeginTunnelOperation())
+            if (!RequestTunnelConnectionTimeout(generation) || !TryBeginTunnelOperation(false))
                 return;
 
             try
@@ -1071,6 +1077,8 @@ namespace WireSockUI.Forms
 
                     trayIcon.Text = Resources.TrayActivating;
 
+                    cmiResetKillSwitch.Enabled = false;
+
                     StartTunnelConnectionWorker();
                     break;
                 case ConnectionState.Connected:
@@ -1095,6 +1103,7 @@ namespace WireSockUI.Forms
                     cmiAddresses.Visible = true;
 
                     cmiDeactivateTunnel.Enabled = true;
+                    cmiResetKillSwitch.Enabled = false;
 
                     foreach (ToolStripItem item in mnuContext.Items)
                         if (item is ToolStripMenuItem menuItem && Equals(menuItem.Tag, "tunnel"))
@@ -1150,6 +1159,7 @@ namespace WireSockUI.Forms
                     cmiAddresses.Visible = false;
 
                     cmiDeactivateTunnel.Enabled = false;
+                    cmiResetKillSwitch.Enabled = true;
 
                     foreach (ToolStripItem item in mnuContext.Items)
                         if (item is ToolStripMenuItem menuItem && Equals(menuItem.Tag, "tunnel"))
@@ -1425,27 +1435,61 @@ namespace WireSockUI.Forms
         {
             using (var form = new FrmSettings())
             {
+                var previousEnableKillSwitch = Settings.Default.EnableKillSwitch;
+
                 // set the owner of the child form to the main form instance
                 form.Owner = this;
 
                 if (form.ShowDialog() == DialogResult.OK)
                 {
                     _wiresock.LogLevel = _wiresock.LogLevelSetting;
-                    ApplyKillSwitchSetting();
+                    ApplyAndSaveKillSwitchSetting(form.RequestedEnableKillSwitch, previousEnableKillSwitch);
                 }
             }
         }
 
-        private void ApplyKillSwitchSetting()
+        private bool ApplyAndSaveKillSwitchSetting(bool requestedEnableKillSwitch, bool previousEnableKillSwitch)
+        {
+            var shouldApplyNativeState =
+                requestedEnableKillSwitch != previousEnableKillSwitch ||
+                _wiresock.HasTunnelHandle ||
+                !requestedEnableKillSwitch;
+
+            if (shouldApplyNativeState && !ApplyKillSwitchSetting(requestedEnableKillSwitch))
+            {
+                Settings.Default.EnableKillSwitch = previousEnableKillSwitch;
+                return false;
+            }
+
+            Settings.Default.EnableKillSwitch = requestedEnableKillSwitch;
+            try
+            {
+                Settings.Default.Save();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(string.Format(Resources.SettingsSaveError, ex.Message), Resources.TunnelErrorTitle,
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+
+                Settings.Default.EnableKillSwitch = previousEnableKillSwitch;
+                if (requestedEnableKillSwitch != previousEnableKillSwitch)
+                    ApplyKillSwitchSetting(previousEnableKillSwitch);
+
+                return false;
+            }
+        }
+
+        private bool ApplyKillSwitchSetting(bool enableKillSwitch)
         {
             try
             {
                 if (_wiresock.HasTunnelHandle)
                 {
-                    if (Settings.Default.EnableKillSwitch)
+                    if (enableKillSwitch)
                     {
-                        _wiresock.KillSwitchEnabled = Settings.Default.EnableKillSwitch;
-                        return;
+                        _wiresock.KillSwitchEnabled = true;
+                        return true;
                     }
 
                     if (!_wiresock.TryGetKillSwitchEnabled(out var killSwitchEnabled, out var diagnostic))
@@ -1453,35 +1497,61 @@ namespace WireSockUI.Forms
                         MessageBox.Show(
                             $"{Resources.TunnelKillSwitchStateError}{Environment.NewLine}{Environment.NewLine}{diagnostic}",
                             Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                        return;
+                        return false;
                     }
 
                     if (killSwitchEnabled)
                         _wiresock.KillSwitchEnabled = false;
 
-                    return;
+                    return true;
                 }
 
-                if (!Settings.Default.EnableKillSwitch)
+                if (!enableKillSwitch)
                 {
                     if (!WireSockManager.TryIsNetworkLockActive(out var networkLockActive, out var queryDiagnostic))
                     {
                         MessageBox.Show(
                             $"{Resources.TunnelKillSwitchQueryError}{Environment.NewLine}{Environment.NewLine}{queryDiagnostic}",
                             Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                        return;
+                        return false;
                     }
 
                     if (networkLockActive && !WireSockManager.TryResetNetworkLock(out var resetDiagnostic))
+                    {
                         MessageBox.Show(
                             $"{Resources.KillSwitchResetError}{Environment.NewLine}{Environment.NewLine}{resetDiagnostic}",
                             Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        return false;
+                    }
                 }
+
+                return true;
             }
             catch (Exception ex)
             {
                 MessageBox.Show(ex.Message, Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
             }
+        }
+
+        private void OnResetKillSwitchClick(object sender, EventArgs e)
+        {
+            if (_currentState != ConnectionState.Disconnected || IsTimedOutConnectCleanupInProgress())
+                return;
+
+            if (!WireSockManager.TryResetNetworkLock(out var diagnostic))
+            {
+                MessageBox.Show(
+                    $"{Resources.KillSwitchResetError}{Environment.NewLine}{Environment.NewLine}{diagnostic}",
+                    Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            if (!IsNativeRecoveryRequired())
+                Global.TryDeleteNativeRecoveryMarker();
+
+            MessageBox.Show(Resources.KillSwitchResetSuccess, Resources.KillSwitchResetTitle,
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
         /// <summary>

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -230,7 +230,7 @@ namespace WireSockUI.Forms
             }
             catch (Exception ex)
             {
-                Trace.TraceWarning($"Failed to delete legacy autorun task '{taskName}': {ex.Message}");
+                Trace.TraceWarning($"Failed to delete legacy autorun task '{taskName}': {ex}");
             }
         }
 

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -33,6 +33,8 @@ namespace WireSockUI.Forms
                 ddlLogLevel.SelectedItem = "Error";
         }
 
+        public bool RequestedEnableKillSwitch => chkEnableKillSwitch.Checked;
+
         private void OnProfilesFolderClick(object sender, EventArgs e)
         {
             try
@@ -164,7 +166,7 @@ namespace WireSockUI.Forms
                         false; // Do not stop the task when the computer ceases to be idle
 
                     ts.RootFolder.RegisterTaskDefinition(GetAutoRunTaskName(), td);
-                    DeleteAutoRunTaskIfOwned(ts, GetLegacyAutoRunTaskName());
+                    TryDeleteAutoRunTaskIfOwned(ts, GetLegacyAutoRunTaskName());
                 }
 
                 DeleteLegacyStartupShortcutIfPresent();
@@ -218,6 +220,18 @@ namespace WireSockUI.Forms
             }
 
             ts.RootFolder.DeleteTask(taskName, false);
+        }
+
+        private static void TryDeleteAutoRunTaskIfOwned(TaskService ts, string taskName)
+        {
+            try
+            {
+                DeleteAutoRunTaskIfOwned(ts, taskName);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Failed to delete legacy autorun task '{taskName}': {ex.Message}");
+            }
         }
 
         private static bool IsTaskOwnedByCurrentExecutable(Microsoft.Win32.TaskScheduler.Task task)
@@ -288,7 +302,6 @@ namespace WireSockUI.Forms
             Settings.Default.AutoUpdate = chkAutoUpdate.Checked;
             Settings.Default.UseAdapter = chkUseAdapter.Checked;
             Settings.Default.EnableNotifications = chkNotify.Checked;
-            Settings.Default.EnableKillSwitch = chkEnableKillSwitch.Checked;
             Settings.Default.LogLevel = ddlLogLevel.SelectedItem as string;
 
             try

--- a/WireSockUI/Properties/Resources.Designer.cs
+++ b/WireSockUI/Properties/Resources.Designer.cs
@@ -469,6 +469,24 @@ namespace WireSockUI.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Kill Switch network lock was reset. Restart WireSock UI before reconnecting if recovery mode is active..
+        /// </summary>
+        internal static string KillSwitchResetSuccess {
+            get {
+                return ResourceManager.GetString("KillSwitchResetSuccess", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Kill Switch Reset.
+        /// </summary>
+        internal static string KillSwitchResetTitle {
+            get {
+                return ResourceManager.GetString("KillSwitchResetTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Duplicate [{0}] sections are not supported by WireSock UI..
         /// </summary>
         internal static string ParserDuplicateSectionError {
@@ -519,6 +537,15 @@ namespace WireSockUI.Properties {
         internal static string MenuImportTunnel {
             get {
                 return ResourceManager.GetString("MenuImportTunnel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Reset Kill Switch.
+        /// </summary>
+        internal static string MenuResetKillSwitch {
+            get {
+                return ResourceManager.GetString("MenuResetKillSwitch", resourceCulture);
             }
         }
 
@@ -1254,7 +1281,7 @@ namespace WireSockUI.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to WireSock UI could not finish cleaning up a native tunnel operation. New tunnel operations are disabled to avoid unsafe network state. Restart WireSock UI as administrator; if network access remains blocked, use Reset Kill Switch from the tray menu..
+        ///   Looks up a localized string similar to WireSock UI could not finish cleaning up a native tunnel operation. New tunnel operations are disabled to avoid unsafe network state. Restart WireSock UI as administrator; if network access remains blocked, use Reset Kill Switch from the tray menu while disconnected or in recovery mode..
         /// </summary>
         internal static string TunnelNativeRecoveryRequired {
             get {

--- a/WireSockUI/Properties/Resources.resx
+++ b/WireSockUI/Properties/Resources.resx
@@ -259,6 +259,12 @@
   <data name="KillSwitchResetError" xml:space="preserve">
     <value>Kill Switch network lock is active, but WireSock UI could not reset it. Disconnect or restart WireSock UI and try again.</value>
   </data>
+  <data name="KillSwitchResetSuccess" xml:space="preserve">
+    <value>Kill Switch network lock was reset. Restart WireSock UI before reconnecting if recovery mode is active.</value>
+  </data>
+  <data name="KillSwitchResetTitle" xml:space="preserve">
+    <value>Kill Switch Reset</value>
+  </data>
   <data name="ParserDuplicateSectionError" xml:space="preserve">
     <value>Duplicate [{0}] sections are not supported by WireSock UI.</value>
   </data>
@@ -276,6 +282,9 @@
   </data>
   <data name="MenuImportTunnel" xml:space="preserve">
     <value>Import tunnel from file...</value>
+  </data>
+  <data name="MenuResetKillSwitch" xml:space="preserve">
+    <value>Reset Kill Switch</value>
   </data>
   <data name="MenuSettings" xml:space="preserve">
     <value>Settings</value>
@@ -515,7 +524,7 @@
     <value>Error</value>
   </data>
   <data name="TunnelNativeRecoveryRequired" xml:space="preserve">
-    <value>WireSock UI could not finish cleaning up a native tunnel operation. New tunnel operations are disabled to avoid unsafe network state. Restart WireSock UI as administrator; if network access remains blocked, use Reset Kill Switch from the tray menu.</value>
+    <value>WireSock UI could not finish cleaning up a native tunnel operation. New tunnel operations are disabled to avoid unsafe network state. Restart WireSock UI as administrator; if network access remains blocked, use Reset Kill Switch from the tray menu while disconnected or in recovery mode.</value>
   </data>
   <data name="TunnelOperationPending" xml:space="preserve">
     <value>A WireSock tunnel operation is already in progress. Wait for it to finish before trying again.</value>


### PR DESCRIPTION
Summary
- Apply the Kill Switch native state before persisting the setting, with rollback on save/apply failure.
- Add a disconnected/recovery tray command to reset the wgbooster network lock.
- Share Amnezia interface-extension validation between profile loading and editor highlighting.
- Harden malformed profile-path diagnostics and make legacy autorun cleanup best-effort after successful enable.

Validation
- dotnet run --project WireSockUI.Tests\WireSockUI.Tests.csproj --configuration Release --framework net472-windows
- dotnet build WireSockUI.sln --configuration Release -p:Platform=x64 -p:UseSharedCompilation=false -m:1
- dotnet build WireSockUI.sln --configuration "Release UWP" -p:Platform=x64 -p:UseSharedCompilation=false -m:1
- git diff --check

Review
- Completed an ultra review pass after implementation; found and fixed the recovery-message/marker handling issue before pushing.
