### PR TITLE
Harden elevated native loading and config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ WireSockUI does not talk to the newer WireSock Secure Connect service API. Keep 
 
 At startup WireSockUI looks for `wgbooster.dll` in this order:
 
-1. The application directory, unless that directory is writable by non-administrative users.
+1. The application directory, unless that directory is writable by or owned by non-administrative users.
 2. WireSock Secure Connect SDK registry install locations under `HKLM\Software\WireSock Foundation\WireSock Secure Connect`.
 3. WireSock Secure Connect Pro SDK registry install locations under `HKLM\Software\WireSock Foundation\WireSock Secure Connect Pro`.
 4. The legacy WireSock VPN Client registry location under `HKLM\SOFTWARE\NTKernelResources\WinpkFilterForVPNClient`.
 
-For each registered install location it checks `sdk`, `bin`, and the install root. The discovered directory is registered with the process through `SetDllDirectory` so the native library can be loaded without changing the machine-wide environment.
+For each registered install location it checks `sdk`, `bin`, and the install root. WireSockUI validates the directory and `wgbooster.dll` ownership/ACLs, then loads the exact validated DLL with a restricted DLL search path instead of changing the machine-wide environment or relying on `PATH`.
 
 ## Configuration Notes
 
@@ -37,6 +37,8 @@ Plain WireGuard keys are still parsed normally. WireSockUI validates common SDK 
 Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are moved into the secured folder on startup when no secured profile with the same name exists. Legacy migration and manual import use bounded temporary copies and reject reparse-point sources; profiles larger than 1 MiB must be moved or trimmed manually. If a secured profile already exists, the legacy copy is deleted only when its content matches. Profile files that are reparse points are not loaded, imported, saved over, or activated; app-owned reparse-point files in the secured profile tree are removed during startup hardening when possible. Legacy profiles containing script hooks are not auto-migrated; import them manually so the hook warning can be reviewed.
 
 Runtime state that can be written by the elevated process, including the native recovery marker, is kept under the secured `%ProgramData%\WireSockUI` folder rather than per-user AppData. The UWP notification icon is stored under a dedicated `%ProgramData%\WireSockUI-Notifications` folder with a read-only Users ACL so the toast platform can load it without allowing unelevated writes.
+
+Elevated autorun is available only when `WireSockUI.exe` and its containing folder are not writable by or owned by non-administrative users. Install WireSockUI into an administrator-owned location before enabling autorun.
 
 Profiles containing `PreUp`, `PostUp`, `PreDown`, or `PostDown` script hooks require confirmation before import/save and again before activation. Treat script-hook profiles as privileged code.
 

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -50,6 +50,7 @@ namespace WireSockUI.Tests
                 { "Parser rejects malformed lines", ParserRejectsMalformedLines },
                 { "Parser rejects keys before sections", ParserRejectsKeysBeforeSections },
                 { "Parser rejects empty section names", ParserRejectsEmptySectionNames },
+                { "Parser trims section names", ParserTrimsSectionNames },
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
                 { "Profile rejects invalid Amnezia passthrough options", ProfileRejectsInvalidAmneziaPassthroughOptions },
                 { "Interface extension validation rules are shared", InterfaceExtensionValidationRulesAreShared },
@@ -367,6 +368,33 @@ namespace WireSockUI.Tests
             try
             {
                 AssertThrows<FormatException>(() => new WireguardConfigParser.ConfigParser(path), "section name is empty");
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+        }
+
+        private static void ParserTrimsSectionNames()
+        {
+            var path = WriteConfig(
+                "[Interface ]\n" +
+                $"PrivateKey = {PrivateKey}\n" +
+                "Address = 10.0.0.2/32\n" +
+                "\n" +
+                "[ Peer ]\n" +
+                $"PublicKey = {PublicKey}\n" +
+                "Endpoint = example.com:51820\n" +
+                "AllowedIPs = 0.0.0.0/0\n");
+
+            try
+            {
+                var parser = new WireguardConfigParser.ConfigParser(path);
+                AssertTrue(parser.GetSectionNames().Contains("Interface", StringComparer.OrdinalIgnoreCase),
+                    "Expected parser to trim trailing whitespace in section names.");
+                AssertTrue(parser.GetSectionNames().Contains("Peer", StringComparer.OrdinalIgnoreCase),
+                    "Expected parser to trim leading and trailing whitespace in section names.");
+                new Profile(path);
             }
             finally
             {

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -64,6 +64,7 @@ namespace WireSockUI.Tests
                 { "Program path normalization preserves drive roots", ProgramPathNormalizationPreservesDriveRoots },
                 { "Program rejects user-writable WireSock library directories", ProgramRejectsUserWritableWireSockLibraryDirectories },
                 { "Program detects user-writable WireSock library files", ProgramDetectsUserWritableWireSockLibraryFiles },
+                { "Program recognizes administrative owner SIDs", ProgramRecognizesAdministrativeOwnerSids },
                 { "Autorun rejects untrusted executable paths", AutoRunRejectsUntrustedExecutablePaths },
                 { "Autorun rejects reparse point executable folders", AutoRunRejectsReparsePointExecutableFolders },
                 { "Profile import rejects oversized files", ProfileImportRejectsOversizedFiles },
@@ -673,6 +674,36 @@ namespace WireSockUI.Tests
                     // Best-effort cleanup must not hide the original test failure.
                 }
             }
+        }
+
+        private static void ProgramRecognizesAdministrativeOwnerSids()
+        {
+            var hasTrustedOwner = typeof(WireSockUI.Program).GetMethod("HasTrustedOwner",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (hasTrustedOwner == null)
+                throw new InvalidOperationException("HasTrustedOwner helper was not found.");
+
+            var accountDomainSid = new SecurityIdentifier("S-1-5-21-1000000001-1000000002-1000000003");
+            var administratorSid = new SecurityIdentifier(
+                WellKnownSidType.AccountAdministratorSid,
+                accountDomainSid);
+            var domainAdminsSid = new SecurityIdentifier(
+                WellKnownSidType.AccountDomainAdminsSid,
+                accountDomainSid);
+            var ordinaryUserSid = new SecurityIdentifier($"{accountDomainSid.Value}-1100");
+
+            var security = new DirectorySecurity();
+            security.SetOwner(administratorSid);
+            AssertTrue((bool)hasTrustedOwner.Invoke(null, new object[] { security }),
+                "Expected the built-in account-domain Administrator owner to be trusted.");
+
+            security.SetOwner(domainAdminsSid);
+            AssertTrue((bool)hasTrustedOwner.Invoke(null, new object[] { security }),
+                "Expected the account-domain Domain Admins owner to be trusted.");
+
+            security.SetOwner(ordinaryUserSid);
+            AssertFalse((bool)hasTrustedOwner.Invoke(null, new object[] { security }),
+                "Expected an ordinary account-domain owner to remain untrusted.");
         }
 
         private static void AutoRunRejectsUntrustedExecutablePaths()

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -65,6 +65,7 @@ namespace WireSockUI.Tests
                 { "Program rejects user-writable WireSock library directories", ProgramRejectsUserWritableWireSockLibraryDirectories },
                 { "Program detects user-writable WireSock library files", ProgramDetectsUserWritableWireSockLibraryFiles },
                 { "Autorun rejects untrusted executable paths", AutoRunRejectsUntrustedExecutablePaths },
+                { "Autorun rejects reparse point executable folders", AutoRunRejectsReparsePointExecutableFolders },
                 { "Profile import rejects oversized files", ProfileImportRejectsOversizedFiles },
                 { "Profile import preserves pre-existing destination on copy failure", ProfileImportPreservesExistingDestinationOnCopyFailure },
                 { "Profile import rejects reparse point sources", ProfileImportRejectsReparsePointSources },
@@ -328,6 +329,7 @@ namespace WireSockUI.Tests
                 "Endpoint = backup.example.com:51820\n" +
                 "AllowedIPs = ::/0\n");
 
+            AssertThrows<FormatException>(() => new WireguardConfigParser.ConfigParser(path), "line 10");
             AssertThrows<FormatException>(() => new WireguardConfigParser.ConfigParser(path), "Duplicate [Peer]");
         }
 
@@ -698,6 +700,45 @@ namespace WireSockUI.Tests
             finally
             {
                 TryDeleteFile(file);
+            }
+        }
+
+        private static void AutoRunRejectsReparsePointExecutableFolders()
+        {
+            var validate = typeof(FrmSettings).GetMethod("IsExecutablePathTrustedForAutoRun",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (validate == null)
+                throw new InvalidOperationException("IsExecutablePathTrustedForAutoRun helper was not found.");
+
+            var root = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+            var targetDirectory = Path.Combine(root, "target");
+            var linkDirectory = Path.Combine(root, "link");
+            var targetFile = Path.Combine(targetDirectory, "WireSockUI.exe");
+            var linkedFile = Path.Combine(linkDirectory, "WireSockUI.exe");
+
+            try
+            {
+                Directory.CreateDirectory(targetDirectory);
+                File.WriteAllText(targetFile, string.Empty);
+
+                if (!TryCreateDirectoryJunction(linkDirectory, targetDirectory))
+                {
+                    SkipOrFail("autorun directory reparse point creation unavailable; autorun reparse check not exercised.");
+                    return;
+                }
+
+                var args = new object[] { linkedFile, null };
+                var trusted = (bool)validate.Invoke(null, args);
+
+                AssertFalse(trusted, "Expected elevated autorun to reject executable paths through reparse point folders.");
+                AssertTrue(args[1] is string diagnostic &&
+                           diagnostic.IndexOf("reparse point", StringComparison.OrdinalIgnoreCase) >= 0,
+                    $"Expected an actionable autorun reparse diagnostic, got '{args[1]}'.");
+            }
+            finally
+            {
+                TryDeleteDirectory(linkDirectory, false);
+                TryDeleteDirectory(root, true);
             }
         }
 
@@ -1303,6 +1344,19 @@ namespace WireSockUI.Tests
             {
                 if (File.Exists(path))
                     File.Delete(path);
+            }
+            catch
+            {
+                // Best-effort cleanup must not hide the original test failure.
+            }
+        }
+
+        private static void TryDeleteDirectory(string path, bool recursive)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive);
             }
             catch
             {

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -47,6 +47,9 @@ namespace WireSockUI.Tests
                 { "Profile reports malformed profile paths consistently", ProfileReportsMalformedProfilePathsConsistently },
                 { "Parser strips WireSock directive prefixes", ParserStripsWireSockDirectivePrefixes },
                 { "Parser rejects duplicate sections", ParserRejectsDuplicateSections },
+                { "Parser rejects malformed lines", ParserRejectsMalformedLines },
+                { "Parser rejects keys before sections", ParserRejectsKeysBeforeSections },
+                { "Parser rejects empty section names", ParserRejectsEmptySectionNames },
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
                 { "Profile rejects invalid Amnezia passthrough options", ProfileRejectsInvalidAmneziaPassthroughOptions },
                 { "Interface extension validation rules are shared", InterfaceExtensionValidationRulesAreShared },
@@ -60,6 +63,7 @@ namespace WireSockUI.Tests
                 { "Program path normalization preserves drive roots", ProgramPathNormalizationPreservesDriveRoots },
                 { "Program rejects user-writable WireSock library directories", ProgramRejectsUserWritableWireSockLibraryDirectories },
                 { "Program detects user-writable WireSock library files", ProgramDetectsUserWritableWireSockLibraryFiles },
+                { "Autorun rejects untrusted executable paths", AutoRunRejectsUntrustedExecutablePaths },
                 { "Profile import rejects oversized files", ProfileImportRejectsOversizedFiles },
                 { "Profile import preserves pre-existing destination on copy failure", ProfileImportPreservesExistingDestinationOnCopyFailure },
                 { "Profile import rejects reparse point sources", ProfileImportRejectsReparsePointSources },
@@ -75,6 +79,7 @@ namespace WireSockUI.Tests
                 { "Autorun task name is path seeded", AutoRunTaskNameIsPathSeeded },
                 { "WireSock disconnect forwards network-lock preservation", WireSockDisconnectForwardsNetworkLockPreservation },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi },
+                { "WireSock exports use restricted DLL search", WireSockExportsUseRestrictedDllSearch },
                 { "Stats struct matches wgbooster ABI", StatsStructMatchesWgboosterAbi }
             };
 
@@ -323,6 +328,50 @@ namespace WireSockUI.Tests
                 "AllowedIPs = ::/0\n");
 
             AssertThrows<FormatException>(() => new WireguardConfigParser.ConfigParser(path), "Duplicate [Peer]");
+        }
+
+        private static void ParserRejectsMalformedLines()
+        {
+            var path = WriteConfig(
+                "[Interface]\n" +
+                "PrivateKey\n");
+
+            try
+            {
+                AssertThrows<FormatException>(() => new WireguardConfigParser.ConfigParser(path), "line 2");
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+        }
+
+        private static void ParserRejectsKeysBeforeSections()
+        {
+            var path = WriteConfig("PrivateKey = value\n");
+
+            try
+            {
+                AssertThrows<FormatException>(() => new WireguardConfigParser.ConfigParser(path), "before any section");
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+        }
+
+        private static void ParserRejectsEmptySectionNames()
+        {
+            var path = WriteConfig("[]\n");
+
+            try
+            {
+                AssertThrows<FormatException>(() => new WireguardConfigParser.ConfigParser(path), "section name is empty");
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
         }
 
         private static void ProfileAcceptsAmneziaPassthroughOptions()
@@ -593,6 +642,34 @@ namespace WireSockUI.Tests
                 {
                     // Best-effort cleanup must not hide the original test failure.
                 }
+            }
+        }
+
+        private static void AutoRunRejectsUntrustedExecutablePaths()
+        {
+            var validate = typeof(FrmSettings).GetMethod("IsExecutablePathTrustedForAutoRun",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (validate == null)
+                throw new InvalidOperationException("IsExecutablePathTrustedForAutoRun helper was not found.");
+
+            var file = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", $"{Guid.NewGuid():N}.exe");
+            Directory.CreateDirectory(Path.GetDirectoryName(file));
+
+            try
+            {
+                File.WriteAllText(file, string.Empty);
+
+                var args = new object[] { file, null };
+                var trusted = (bool)validate.Invoke(null, args);
+
+                AssertFalse(trusted, "Expected elevated autorun to reject a user-writable executable path.");
+                AssertTrue(args[1] is string diagnostic &&
+                           diagnostic.IndexOf("non-administrative", StringComparison.OrdinalIgnoreCase) >= 0,
+                    $"Expected an actionable autorun trust diagnostic, got '{args[1]}'.");
+            }
+            finally
+            {
+                TryDeleteFile(file);
             }
         }
 
@@ -1042,6 +1119,41 @@ namespace WireSockUI.Tests
         {
             AssertEqual(0, (int)WireguardBoosterExports.WgbNetworkLockMode.Disabled);
             AssertEqual(1, (int)WireguardBoosterExports.WgbNetworkLockMode.Enabled);
+        }
+
+        private static void WireSockExportsUseRestrictedDllSearch()
+        {
+            var methods = typeof(WireguardBoosterExports)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(method =>
+                {
+                    var dllImport = method.GetCustomAttributes(typeof(DllImportAttribute), false)
+                        .OfType<DllImportAttribute>()
+                        .SingleOrDefault();
+                    return string.Equals(dllImport?.Value, "wgbooster.dll", StringComparison.OrdinalIgnoreCase);
+                })
+                .ToList();
+
+            AssertTrue(methods.Count > 0, "Expected wgbooster export methods to be discovered.");
+
+            foreach (var method in methods)
+            {
+                var attribute = method.GetCustomAttributes(typeof(DefaultDllImportSearchPathsAttribute), false)
+                    .OfType<DefaultDllImportSearchPathsAttribute>()
+                    .SingleOrDefault();
+
+                if (attribute == null)
+                    throw new InvalidOperationException(
+                        $"Expected wgbooster export '{method.Name}' to declare restricted DLL search paths.");
+
+                var paths = attribute.Paths;
+                AssertTrue((paths & DllImportSearchPath.UserDirectories) != 0,
+                    $"Expected '{method.Name}' to search only explicitly added user directories.");
+                AssertTrue((paths & DllImportSearchPath.System32) != 0,
+                    $"Expected '{method.Name}' to allow System32 dependency resolution.");
+                AssertFalse((paths & DllImportSearchPath.AssemblyDirectory) != 0,
+                    $"Expected '{method.Name}' not to fall back to the executable directory.");
+            }
         }
 
         private static void StatsStructMatchesWgboosterAbi()

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -222,6 +222,9 @@ namespace WireSockUI.Forms
                     return false;
                 }
 
+                if (!IsPathFreeOfReparsePoints(fullPath, out diagnostic))
+                    return false;
+
                 if (Program.IsPotentiallyUserWritableFile(fullPath))
                 {
                     diagnostic =
@@ -245,6 +248,51 @@ namespace WireSockUI.Forms
                 diagnostic = $"Autorun executable path could not be validated: {ex.Message}";
                 return false;
             }
+        }
+
+        private static bool IsPathFreeOfReparsePoints(string fullPath, out string diagnostic)
+        {
+            if (IsReparsePointOrUnreadable(fullPath, "Autorun executable", out diagnostic))
+                return false;
+
+            var directory = Path.GetDirectoryName(fullPath);
+            while (!string.IsNullOrWhiteSpace(directory))
+            {
+                if (IsReparsePointOrUnreadable(directory, "Autorun executable folder", out diagnostic))
+                    return false;
+
+                var trimmed = directory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var parent = Path.GetDirectoryName(trimmed);
+                if (string.IsNullOrWhiteSpace(parent) ||
+                    string.Equals(parent, directory, StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                directory = parent;
+            }
+
+            diagnostic = null;
+            return true;
+        }
+
+        private static bool IsReparsePointOrUnreadable(string path, string label, out string diagnostic)
+        {
+            try
+            {
+                if ((File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0)
+                {
+                    diagnostic =
+                        $"{label} '{path}' is a reparse point. Install WireSock UI into a real administrator-owned folder before enabling elevated autorun.";
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                diagnostic = $"{label} '{path}' could not be inspected for reparse points: {ex.Message}";
+                return true;
+            }
+
+            diagnostic = null;
+            return false;
         }
 
         private static void DeleteAutoRunTaskIfOwned(TaskService ts, string taskName)

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -154,6 +154,9 @@ namespace WireSockUI.Forms
                     td.Triggers.Add(new LogonTrigger()); // Trigger on logon
 
                     var appPath = Application.ExecutablePath;
+                    if (!IsExecutablePathTrustedForAutoRun(appPath, out var trustDiagnostic))
+                        throw new InvalidOperationException(trustDiagnostic);
+
                     td.Actions.Add(new ExecAction(appPath)); // Path to the executable
 
                     // Set power and idle options
@@ -202,6 +205,44 @@ namespace WireSockUI.Forms
             catch (Exception ex)
             {
                 ShowSettingsError(Resources.SettingsAutoRunDisableAdminError, ex);
+                return false;
+            }
+        }
+
+        private static bool IsExecutablePathTrustedForAutoRun(string executablePath, out string diagnostic)
+        {
+            diagnostic = null;
+
+            try
+            {
+                var fullPath = Path.GetFullPath((executablePath ?? string.Empty).Trim().Trim('"'));
+                if (!File.Exists(fullPath))
+                {
+                    diagnostic = $"Autorun executable '{fullPath}' does not exist.";
+                    return false;
+                }
+
+                if (Program.IsPotentiallyUserWritableFile(fullPath))
+                {
+                    diagnostic =
+                        $"Autorun executable '{fullPath}' is writable by or owned by non-administrative users. Install WireSock UI into an administrator-owned folder before enabling elevated autorun.";
+                    return false;
+                }
+
+                var directory = Path.GetDirectoryName(fullPath);
+                if (string.IsNullOrWhiteSpace(directory) ||
+                    Program.IsPotentiallyUserWritableDirectory(directory))
+                {
+                    diagnostic =
+                        $"Autorun executable folder '{directory}' is writable by or owned by non-administrative users. Install WireSock UI into an administrator-owned folder before enabling elevated autorun.";
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                diagnostic = $"Autorun executable path could not be validated: {ex.Message}";
                 return false;
             }
         }

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -68,7 +68,7 @@ namespace WireSockUI
         {
             if (IsSameOrChildPath(ConfigsFolder, SecureMainFolder))
             {
-                EnsureAdministratorsOnlyDirectory(SecureMainFolder, false);
+                EnsureAdministratorsOnlyDirectory(SecureMainFolder, secureExistingChildren, ConfigsFolder);
                 EnsureAdministratorsOnlyDirectory(ConfigsFolder, secureExistingChildren);
                 return;
             }
@@ -82,6 +82,14 @@ namespace WireSockUI
 
         private static void EnsureAdministratorsOnlyDirectory(string path, bool secureExistingChildren)
         {
+            EnsureAdministratorsOnlyDirectory(path, secureExistingChildren, null);
+        }
+
+        private static void EnsureAdministratorsOnlyDirectory(
+            string path,
+            bool secureExistingChildren,
+            string excludedChildDirectory)
+        {
             try
             {
                 var security = CreateAdministratorsOnlyDirectorySecurity();
@@ -91,7 +99,7 @@ namespace WireSockUI
 
                 Directory.SetAccessControl(path, security);
                 if (secureExistingChildren)
-                    SecureExistingChildren(path);
+                    SecureExistingChildren(path, excludedChildDirectory);
             }
             catch (Exception ex)
             {
@@ -308,7 +316,7 @@ namespace WireSockUI
             return security;
         }
 
-        private static void SecureExistingChildren(string path)
+        private static void SecureExistingChildren(string path, string excludedDirectory = null)
         {
             var directories = new Stack<string>();
             directories.Push(path);
@@ -360,6 +368,10 @@ namespace WireSockUI
 
                 foreach (var childDirectory in childDirectories)
                 {
+                    if (!string.IsNullOrWhiteSpace(excludedDirectory) &&
+                        IsSameOrChildPath(childDirectory, excludedDirectory))
+                        continue;
+
                     if (IsReparsePoint(childDirectory))
                     {
                         Trace.TraceWarning($"Skipping WireSock UI configuration directory reparse point '{childDirectory}'.");

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -68,7 +68,7 @@ namespace WireSockUI
         {
             if (IsSameOrChildPath(ConfigsFolder, SecureMainFolder))
             {
-                EnsureAdministratorsOnlyDirectory(SecureMainFolder, secureExistingChildren);
+                EnsureAdministratorsOnlyDirectory(SecureMainFolder, false);
                 EnsureAdministratorsOnlyDirectory(ConfigsFolder, secureExistingChildren);
                 return;
             }

--- a/WireSockUI/Native/WireguardBoosterExports.cs
+++ b/WireSockUI/Native/WireguardBoosterExports.cs
@@ -23,97 +23,121 @@ namespace WireSockUI.Native
             Enabled = 1
         }
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern IntPtr wgb_get_handle(LogPrinter logPrinter, WgbLogLevel level, bool enableTrafficCapture);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern void wgb_set_log_level(IntPtr wgboosterHandle, WgbLogLevel level);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgb_create_tunnel_from_file(IntPtr wgboosterHandle,
             [MarshalAs(UnmanagedType.LPStr)] string fileName);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode,
             SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgb_create_tunnel_from_file_w(IntPtr wgboosterHandle,
             [MarshalAs(UnmanagedType.LPWStr)] string fileName);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgb_drop_tunnel(IntPtr wgboosterHandle, bool preserveNetworkLock);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgb_start_tunnel(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgb_stop_tunnel(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern WgbStats wgb_get_tunnel_state(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgb_get_tunnel_active(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgb_set_network_lock_mode(IntPtr wgboosterHandle, WgbNetworkLockMode mode);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern WgbNetworkLockMode wgb_get_network_lock_mode(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern IntPtr
             wgbp_get_handle(LogPrinter logPrinter, WgbLogLevel level, bool enableTrafficCapture);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern void wgbp_set_log_level(IntPtr wgboosterHandle, WgbLogLevel level);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgbp_create_tunnel_from_file(IntPtr wgboosterHandle,
             [MarshalAs(UnmanagedType.LPStr)] string fileName);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode,
             SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgbp_create_tunnel_from_file_w(IntPtr wgboosterHandle,
             [MarshalAs(UnmanagedType.LPWStr)] string fileName);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgbp_drop_tunnel(IntPtr wgboosterHandle, bool preserveNetworkLock);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgbp_start_tunnel(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgbp_stop_tunnel(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern WgbStats wgbp_get_tunnel_state(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgbp_get_tunnel_active(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wgbp_set_network_lock_mode(IntPtr wgboosterHandle, WgbNetworkLockMode mode);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         public static extern WgbNetworkLockMode wgbp_get_network_lock_mode(IntPtr wgboosterHandle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wg_reset_network_lock();
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.System32)]
         [DllImport("wgbooster.dll", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool wg_is_network_lock_active();

--- a/WireSockUI/Native/WireguardConfigParser.cs
+++ b/WireSockUI/Native/WireguardConfigParser.cs
@@ -48,18 +48,25 @@ namespace WireSockUI.Native
             {
                 string line;
                 string currentSection = null;
+                var lineNumber = 0;
 
                 while ((line = reader.ReadLine()) != null)
                 {
+                    lineNumber++;
                     line = line.Trim();
                     if (string.IsNullOrWhiteSpace(line) || IsComment(line))
                         continue;
 
                     line = StripWireSockPrefix(line);
+                    if (string.IsNullOrWhiteSpace(line))
+                        continue;
 
                     if (line.StartsWith("[") && line.EndsWith("]"))
                     {
                         currentSection = line.Substring(1, line.Length - 2);
+                        if (string.IsNullOrWhiteSpace(currentSection))
+                            throw new FormatException($"Invalid WireGuard configuration line {lineNumber}: section name is empty.");
+
                         if (Sections.ContainsKey(currentSection))
                             throw new FormatException(
                                 string.Format(Resources.ParserDuplicateSectionError, currentSection));
@@ -69,10 +76,20 @@ namespace WireSockUI.Native
                     else
                     {
                         var parts = line.Split(new[] { '=' }, 2);
-                        if (parts.Length != 2) continue;
+                        if (parts.Length != 2)
+                            throw new FormatException(
+                                $"Invalid WireGuard configuration line {lineNumber}: expected \"key = value\".");
+
                         var key = parts[0].Trim();
                         var value = parts[1].Trim();
-                        if (string.IsNullOrEmpty(currentSection)) continue;
+                        if (string.IsNullOrWhiteSpace(key))
+                            throw new FormatException(
+                                $"Invalid WireGuard configuration line {lineNumber}: key name is empty.");
+
+                        if (string.IsNullOrEmpty(currentSection))
+                            throw new FormatException(
+                                $"Invalid WireGuard configuration line {lineNumber}: key \"{key}\" appears before any section.");
+
                         if (!Sections.ContainsKey(currentSection))
                             Sections[currentSection] = new Section();
                         if (!Sections[currentSection].KeyValues.ContainsKey(key))

--- a/WireSockUI/Native/WireguardConfigParser.cs
+++ b/WireSockUI/Native/WireguardConfigParser.cs
@@ -63,8 +63,8 @@ namespace WireSockUI.Native
 
                     if (line.StartsWith("[") && line.EndsWith("]"))
                     {
-                        currentSection = line.Substring(1, line.Length - 2);
-                        if (string.IsNullOrWhiteSpace(currentSection))
+                        currentSection = line.Substring(1, line.Length - 2).Trim();
+                        if (string.IsNullOrEmpty(currentSection))
                             throw new FormatException($"Invalid WireGuard configuration line {lineNumber}: section name is empty.");
 
                         if (Sections.ContainsKey(currentSection))

--- a/WireSockUI/Native/WireguardConfigParser.cs
+++ b/WireSockUI/Native/WireguardConfigParser.cs
@@ -69,7 +69,7 @@ namespace WireSockUI.Native
 
                         if (Sections.ContainsKey(currentSection))
                             throw new FormatException(
-                                string.Format(Resources.ParserDuplicateSectionError, currentSection));
+                                $"Invalid WireGuard configuration line {lineNumber}: {string.Format(Resources.ParserDuplicateSectionError, currentSection)}");
 
                         Sections[currentSection] = new Section();
                     }

--- a/WireSockUI/Notifications/Notifications.cs
+++ b/WireSockUI/Notifications/Notifications.cs
@@ -28,9 +28,6 @@ namespace WireSockUI.Notifications
 
                 Global.EnsureNotificationAssetsFolderExists();
 
-                if (TryUseExistingNotificationIcon(icon))
-                    return icon;
-
                 DeleteExistingNotificationIcon(icon);
 
                 using (var stream = new FileStream(icon, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
@@ -49,38 +46,6 @@ namespace WireSockUI.Notifications
         {
             return TryGetAttributes(icon, out var attributes) &&
                    (attributes & (FileAttributes.Directory | FileAttributes.ReparsePoint)) == 0;
-        }
-
-        private static bool TryUseExistingNotificationIcon(string icon)
-        {
-            if (!IsRegularNotificationIcon(icon))
-                return false;
-
-            try
-            {
-                File.SetAccessControl(icon, CreateNotificationIconFileSecurity());
-                _notificationIconReady = true;
-            }
-            catch (FileNotFoundException)
-            {
-                return false;
-            }
-            catch (DirectoryNotFoundException)
-            {
-                return false;
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                Debug.WriteLine($"Unable to refresh notification icon ACL: {ex.Message}");
-                return false;
-            }
-            catch (IOException ex)
-            {
-                Debug.WriteLine($"Unable to refresh notification icon ACL: {ex.Message}");
-                return false;
-            }
-
-            return true;
         }
 
         private static void DeleteExistingNotificationIcon(string icon)

--- a/WireSockUI/Notifications/Notifications.cs
+++ b/WireSockUI/Notifications/Notifications.cs
@@ -28,11 +28,19 @@ namespace WireSockUI.Notifications
 
                 Global.EnsureNotificationAssetsFolderExists();
 
-                DeleteExistingNotificationIcon(icon);
-
-                using (var stream = new FileStream(icon, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+                var iconBytes = CreateNotificationIconBytes();
+                if (!TryCreateFreshNotificationIcon(icon, iconBytes, out var replaceDiagnostic))
                 {
-                    Resources.ico.Save(stream);
+                    if (TryReuseExistingNotificationIcon(icon, iconBytes, out var reuseDiagnostic))
+                    {
+                        Trace.TraceWarning(
+                            $"Reusing verified notification icon '{icon}' because it could not be replaced: {replaceDiagnostic}");
+                        _notificationIconReady = true;
+                        return icon;
+                    }
+
+                    throw new IOException(
+                        $"Could not prepare notification icon '{icon}'. Replace failed: {replaceDiagnostic}; reuse failed: {reuseDiagnostic}");
                 }
 
                 File.SetAccessControl(icon, CreateNotificationIconFileSecurity());
@@ -40,6 +48,92 @@ namespace WireSockUI.Notifications
             }
 
             return icon;
+        }
+
+        private static byte[] CreateNotificationIconBytes()
+        {
+            using (var stream = new MemoryStream())
+            {
+                Resources.ico.Save(stream);
+                return stream.ToArray();
+            }
+        }
+
+        private static bool TryCreateFreshNotificationIcon(string icon, byte[] iconBytes, out string diagnostic)
+        {
+            try
+            {
+                DeleteExistingNotificationIcon(icon);
+
+                using (var stream = new FileStream(icon, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+                {
+                    stream.Write(iconBytes, 0, iconBytes.Length);
+                }
+
+                diagnostic = null;
+                return true;
+            }
+            catch (IOException ex)
+            {
+                diagnostic = ex.Message;
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                diagnostic = ex.Message;
+                return false;
+            }
+        }
+
+        private static bool TryReuseExistingNotificationIcon(string icon, byte[] expectedIconBytes, out string diagnostic)
+        {
+            if (!IsRegularNotificationIcon(icon))
+            {
+                diagnostic = "existing icon is missing, a directory, or a reparse point";
+                return false;
+            }
+
+            if (Program.IsPotentiallyUserWritableFile(icon))
+            {
+                diagnostic = "existing icon is writable by or owned by non-administrative users";
+                return false;
+            }
+
+            try
+            {
+                if (!FileContentsEqual(icon, expectedIconBytes))
+                {
+                    diagnostic = "existing icon contents do not match the bundled icon";
+                    return false;
+                }
+
+                File.SetAccessControl(icon, CreateNotificationIconFileSecurity());
+                diagnostic = null;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                diagnostic = ex.Message;
+                return false;
+            }
+        }
+
+        private static bool FileContentsEqual(string path, byte[] expectedBytes)
+        {
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
+                       FileShare.ReadWrite | FileShare.Delete))
+            {
+                if (stream.Length != expectedBytes.Length)
+                    return false;
+
+                for (var i = 0; i < expectedBytes.Length; i++)
+                {
+                    if (stream.ReadByte() != expectedBytes[i])
+                        return false;
+                }
+
+                return true;
+            }
         }
 
         private static bool IsRegularNotificationIcon(string icon)

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -22,8 +22,25 @@ namespace WireSockUI
         private const long MaxMigratedProfileSizeBytes = 1024 * 1024;
         private static readonly string[] ScriptHookKeys = { "PreUp", "PostUp", "PreDown", "PostDown" };
 
+        private const uint LoadLibrarySearchDllLoadDir = 0x00000100;
+        private const uint LoadLibrarySearchSystem32 = 0x00000800;
+        private const uint LoadLibrarySearchUserDirs = 0x00000400;
+
+        private static IntPtr _wireSockLibraryHandle = IntPtr.Zero;
+        private static IntPtr _wireSockLibraryDirectoryCookie = IntPtr.Zero;
+        private static bool _restrictedDllSearchPathConfigured;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool SetDefaultDllDirectories(uint directoryFlags);
+
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool SetDllDirectory(string lpPathName);
+        private static extern IntPtr AddDllDirectory(string newDirectory);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool RemoveDllDirectory(IntPtr cookie);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr LoadLibraryEx(string fileName, IntPtr file, uint flags);
 
         [STAThread]
         private static void Main()
@@ -131,31 +148,27 @@ namespace WireSockUI
         /// <returns><c>true</c> if installed, otherwise <c>false</c></returns>
         private static bool IsWireSockInstalled()
         {
-            string libraryDirectory;
-            if (!TryFindWireSockLibraryDirectory(out libraryDirectory))
-                return false;
+            foreach (var candidate in EnumerateWireSockLibraryDirectoryCandidates())
+            {
+                if (!TryValidateWireSockLibraryDirectory(candidate, out var libraryDirectory))
+                    continue;
 
-            return ConfigureWireSockLibraryDirectory(libraryDirectory);
+                if (ConfigureWireSockLibraryDirectory(libraryDirectory))
+                    return true;
+            }
+
+            return false;
         }
 
-        private static bool TryFindWireSockLibraryDirectory(out string libraryDirectory)
+        private static IEnumerable<string> EnumerateWireSockLibraryDirectoryCandidates()
         {
-            libraryDirectory = null;
-
-            var localDirectory = AppDomain.CurrentDomain.BaseDirectory;
-            if (TryValidateWireSockLibraryDirectory(localDirectory, out libraryDirectory))
-                return true;
+            yield return AppDomain.CurrentDomain.BaseDirectory;
 
             foreach (var installLocation in GetInstallLocations())
             {
                 foreach (var candidate in GetLibraryDirectories(installLocation))
-                {
-                    if (TryValidateWireSockLibraryDirectory(candidate, out libraryDirectory))
-                        return true;
-                }
+                    yield return candidate;
             }
-
-            return false;
         }
 
         private static bool TryValidateWireSockLibraryDirectory(string directory, out string libraryDirectory)
@@ -178,7 +191,7 @@ namespace WireSockUI
             if (IsPotentiallyUserWritableDirectory(fullDirectory))
             {
                 Trace.TraceWarning(
-                    $"Skipping WireSock library directory '{fullDirectory}' because it is writable by non-administrative users.");
+                    $"Skipping WireSock library directory '{fullDirectory}' because it is writable by or owned by non-administrative users.");
                 return false;
             }
 
@@ -203,7 +216,7 @@ namespace WireSockUI
             if (IsPotentiallyUserWritableFile(libraryPath))
             {
                 Trace.TraceWarning(
-                    $"Skipping WireSock library '{libraryPath}' because it is writable by non-administrative users.");
+                    $"Skipping WireSock library '{libraryPath}' because it is writable by or owned by non-administrative users.");
                 return false;
             }
 
@@ -290,23 +303,106 @@ namespace WireSockUI
             if (fullDirectory == null)
                 return false;
 
-            var appDirectory = NormalizePathDirectory(AppDomain.CurrentDomain.BaseDirectory);
-            var isAppLocalDirectory = string.Equals(fullDirectory, appDirectory, StringComparison.OrdinalIgnoreCase);
+            var libraryPath = Path.Combine(fullDirectory, "wgbooster.dll");
 
             try
             {
-                if (SetDllDirectory(fullDirectory))
+                if (TryConfigureRestrictedDllSearchPath(fullDirectory, libraryPath, out var diagnostic))
                     return true;
 
                 Trace.TraceWarning(
-                    $"Failed to set WireSock library directory '{fullDirectory}': {new Win32Exception(Marshal.GetLastWin32Error()).Message}");
+                    $"Failed to configure WireSock library '{libraryPath}': {diagnostic}");
             }
             catch (Exception ex)
             {
-                Trace.TraceWarning($"Failed to set WireSock library directory '{fullDirectory}': {ex.Message}");
+                Trace.TraceWarning($"Failed to load WireSock library '{libraryPath}': {ex.Message}");
             }
 
-            return isAppLocalDirectory;
+            return false;
+        }
+
+        private static bool TryConfigureRestrictedDllSearchPath(
+            string fullDirectory,
+            string libraryPath,
+            out string diagnostic)
+        {
+            diagnostic = null;
+
+            if (_wireSockLibraryHandle != IntPtr.Zero && _wireSockLibraryDirectoryCookie != IntPtr.Zero)
+                return true;
+
+            if (!TryEnsureRestrictedDllSearchPath(out diagnostic))
+                return false;
+
+            var cookie = AddDllDirectory(fullDirectory);
+            if (cookie == IntPtr.Zero)
+            {
+                diagnostic = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                return false;
+            }
+
+            if (TryLoadWireSockLibrary(libraryPath, out diagnostic))
+            {
+                _wireSockLibraryDirectoryCookie = cookie;
+                return true;
+            }
+
+            TryRemoveDllDirectory(cookie);
+            return false;
+        }
+
+        private static bool TryEnsureRestrictedDllSearchPath(out string diagnostic)
+        {
+            diagnostic = null;
+
+            if (_restrictedDllSearchPathConfigured)
+                return true;
+
+            if (!SetDefaultDllDirectories(LoadLibrarySearchSystem32 | LoadLibrarySearchUserDirs))
+            {
+                diagnostic = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                return false;
+            }
+
+            _restrictedDllSearchPathConfigured = true;
+            return true;
+        }
+
+        private static bool TryLoadWireSockLibrary(string libraryPath, out string diagnostic)
+        {
+            diagnostic = null;
+
+            if (_wireSockLibraryHandle != IntPtr.Zero)
+                return true;
+
+            var handle = LoadLibraryEx(
+                libraryPath,
+                IntPtr.Zero,
+                LoadLibrarySearchDllLoadDir | LoadLibrarySearchSystem32);
+
+            if (handle == IntPtr.Zero)
+            {
+                diagnostic = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                return false;
+            }
+
+            _wireSockLibraryHandle = handle;
+            return true;
+        }
+
+        private static void TryRemoveDllDirectory(IntPtr cookie)
+        {
+            try
+            {
+                if (cookie != IntPtr.Zero && !RemoveDllDirectory(cookie))
+                    Trace.TraceWarning(
+                        $"Failed to remove unsuccessful WireSock library directory from the process search path: {new Win32Exception(Marshal.GetLastWin32Error()).Message}");
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning(
+                    $"Failed to remove unsuccessful WireSock library directory from the process search path: {ex.Message}");
+            }
         }
 
         private static void MigrateLegacyProfiles()
@@ -541,7 +637,7 @@ namespace WireSockUI
             }
         }
 
-        private static bool IsPotentiallyUserWritableDirectory(string directory)
+        internal static bool IsPotentiallyUserWritableDirectory(string directory)
         {
             var normalizedDirectory = NormalizePathDirectory(directory);
             if (normalizedDirectory == null)
@@ -550,8 +646,7 @@ namespace WireSockUI
             try
             {
                 var security = Directory.GetAccessControl(normalizedDirectory);
-                var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
-                return ContainsPotentiallyUserWritableRule(rules);
+                return IsPotentiallyUserWritableSecurity(security);
             }
             catch (Exception ex)
             {
@@ -560,7 +655,7 @@ namespace WireSockUI
             }
         }
 
-        private static bool IsPotentiallyUserWritableFile(string file)
+        internal static bool IsPotentiallyUserWritableFile(string file)
         {
             var normalizedFile = NormalizePathFile(file);
             if (normalizedFile == null)
@@ -569,13 +664,33 @@ namespace WireSockUI
             try
             {
                 var security = File.GetAccessControl(normalizedFile);
-                var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
-                return ContainsPotentiallyUserWritableRule(rules);
+                return IsPotentiallyUserWritableSecurity(security);
             }
             catch (Exception ex)
             {
                 Trace.TraceWarning($"Unable to inspect ACL for '{normalizedFile}': {ex.Message}");
                 return true;
+            }
+        }
+
+        private static bool IsPotentiallyUserWritableSecurity(FileSystemSecurity security)
+        {
+            return !HasTrustedOwner(security) ||
+                   ContainsPotentiallyUserWritableRule(
+                       security.GetAccessRules(true, true, typeof(SecurityIdentifier)));
+        }
+
+        private static bool HasTrustedOwner(FileSystemSecurity security)
+        {
+            try
+            {
+                return security.GetOwner(typeof(SecurityIdentifier)) is SecurityIdentifier owner &&
+                       IsAdministrativeOrServiceSid(owner);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Unable to inspect owner for a WireSock library path: {ex.Message}");
+                return false;
             }
         }
 

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -334,7 +334,18 @@ namespace WireSockUI
             if (!TryEnsureRestrictedDllSearchPath(out diagnostic))
                 return false;
 
-            var cookie = AddDllDirectory(fullDirectory);
+            IntPtr cookie;
+            try
+            {
+                cookie = AddDllDirectory(fullDirectory);
+            }
+            catch (EntryPointNotFoundException ex)
+            {
+                diagnostic =
+                    $"This Windows installation does not support AddDllDirectory. Install KB2533623 or use a supported Windows version. {ex.Message}";
+                return false;
+            }
+
             if (cookie == IntPtr.Zero)
             {
                 diagnostic = new Win32Exception(Marshal.GetLastWin32Error()).Message;
@@ -358,9 +369,18 @@ namespace WireSockUI
             if (_restrictedDllSearchPathConfigured)
                 return true;
 
-            if (!SetDefaultDllDirectories(LoadLibrarySearchSystem32 | LoadLibrarySearchUserDirs))
+            try
             {
-                diagnostic = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                if (!SetDefaultDllDirectories(LoadLibrarySearchSystem32 | LoadLibrarySearchUserDirs))
+                {
+                    diagnostic = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                    return false;
+                }
+            }
+            catch (EntryPointNotFoundException ex)
+            {
+                diagnostic =
+                    $"This Windows installation does not support SetDefaultDllDirectories. Install KB2533623 or use a supported Windows version. {ex.Message}";
                 return false;
             }
 

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -705,7 +705,7 @@ namespace WireSockUI
             try
             {
                 return security.GetOwner(typeof(SecurityIdentifier)) is SecurityIdentifier owner &&
-                       IsAdministrativeOrServiceSid(owner);
+                       IsTrustedOwnerSid(owner);
             }
             catch (Exception ex)
             {
@@ -761,6 +761,23 @@ namespace WireSockUI
                    sid.IsWellKnown(WellKnownSidType.NetworkServiceSid) ||
                    sid.Value.StartsWith("S-1-5-80-", StringComparison.OrdinalIgnoreCase) ||
                    sid.Value.StartsWith("S-1-5-83-", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsTrustedOwnerSid(SecurityIdentifier sid)
+        {
+            if (IsAdministrativeOrServiceSid(sid))
+                return true;
+
+            var accountDomainSid = sid.AccountDomainSid;
+            if (accountDomainSid == null)
+                return false;
+
+            return sid.Equals(new SecurityIdentifier(
+                       WellKnownSidType.AccountAdministratorSid,
+                       accountDomainSid)) ||
+                   sid.Equals(new SecurityIdentifier(
+                       WellKnownSidType.AccountDomainAdminsSid,
+                       accountDomainSid));
         }
 
         private static string NormalizePathDirectory(string directory)


### PR DESCRIPTION
## Summary
- load the validated wgbooster.dll with restricted DLL search paths and reject non-admin-owned/writable native library paths
- refuse elevated autorun from untrusted executable locations and recreate notification toast assets instead of reusing pre-existing files
- reject malformed WireGuard config lines with line-numbered diagnostics and avoid double-recursive profile folder hardening
- document the updated native loading and autorun trust behavior

## Verification
- dotnet run --project WireSockUI.Tests\WireSockUI.Tests.csproj --configuration Release --framework net472-windows
- dotnet build WireSockUI.sln --configuration Release -p:Platform=x64 -p:UseSharedCompilation=false -m:1
- dotnet build WireSockUI.sln --configuration "Release UWP" -p:Platform=x64 -p:UseSharedCompilation=false -m:1
- git diff --check