### PR TITLE
Harden direct wgbooster integration and SDK compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.x'
+          dotnet-version: '10.x'
 
       - name: Run focused tests
         run: dotnet run --project WireSockUI.Tests/WireSockUI.Tests.csproj --configuration Release --framework net472-windows
@@ -41,7 +41,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.x'
+          dotnet-version: '10.x'
 
       - name: Publish WireSockUI
         run: >

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.x'
+          dotnet-version: '10.x'
 
       - name: Test
         run: dotnet run --project WireSockUI.Tests/WireSockUI.Tests.csproj --configuration Release --framework net472-windows
@@ -49,7 +49,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.x'
+          dotnet-version: '10.x'
 
       - name: Parse Version
         shell: bash

--- a/README.md
+++ b/README.md
@@ -18,27 +18,36 @@ At startup WireSockUI looks for `wgbooster.dll` in this order:
 3. WireSock Secure Connect Pro SDK registry install locations under `HKLM\Software\WireSock Foundation\WireSock Secure Connect Pro`.
 4. The legacy WireSock VPN Client registry location under `HKLM\SOFTWARE\NTKernelResources\WinpkFilterForVPNClient`.
 
-For each registered install location it checks `sdk`, `bin`, and the install root. WireSockUI validates the directory and `wgbooster.dll` ownership/ACLs, then loads the exact validated DLL with a restricted DLL search path instead of changing the machine-wide environment or relying on `PATH`.
+For each registered install location it checks `sdk`, `bin`, and the install root. WireSockUI validates the directory, `wgbooster.dll`, and executable/DLL companion ownership and ACLs, then loads the exact validated DLL with a restricted DLL search path instead of changing the machine-wide environment or relying on `PATH`.
 
 ## Configuration Notes
 
-WireSock-specific directives may use the current SDK comment-extension syntax:
+WireSock-specific directives use the current SDK's exact, case-sensitive `#@ws:` comment-extension syntax:
 
 ```ini
 #@ws:AllowedApps = app.exe
 #@ws:DisallowedIPs = 192.168.1.0/24
 #@ws:VirtualAdapterMode = false
-#@ws:BypassLanTraffic = false
 #@ws:Socks5ProxyAllTraffic = false
 ```
 
-Plain WireGuard keys are still parsed normally. WireSockUI validates common SDK fields such as script hooks, masking parameters, SOCKS5 settings, `BypassLanTraffic`, and profile-level `VirtualAdapterMode` while preserving the file-based profile workflow.
+Plain WireGuard keys are still parsed normally. WireSockUI validates current SDK fields such as script hooks, masking parameters, SOCKS5 settings, and profile-level `VirtualAdapterMode` while preserving the file-based profile workflow. Direct `wgbooster.dll` integration does not implement `BypassLanTraffic`; specify the LAN prefixes to bypass with `#@ws:DisallowedIPs` in `[Peer]` instead.
 
-Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are moved into the secured folder on startup when no secured profile with the same name exists. Legacy migration and manual import use bounded temporary copies and reject reparse-point sources; profiles larger than 1 MiB must be moved or trimmed manually. If a secured profile already exists, the legacy copy is deleted only when its content matches. Profile files that are reparse points are not loaded, imported, saved over, or activated; app-owned reparse-point files in the secured profile tree are removed during startup hardening when possible. Legacy profiles containing script hooks are not auto-migrated; import them manually so the hook warning can be reviewed.
+Amnezia 2.0 padding values `S1` through `S4` must be in the range `0..1279`. When any Amnezia padding/header option is present, `S1`, `S2`, and `H1` through `H4` are required; `S3` and `S4` remain optional. `H1` through `H4` accept fixed decimal values or inclusive decimal ranges and must not overlap after blank/zero values resolve to their WireGuard defaults. `Jmin` and `Jmax` must be specified together with `Jmin < Jmax`, and pre-handshake size/delay settings require either `Jc` or `Id`. Protocol imitation accepts the SDK's short and long protocol names, such as `quic`/`quic_initial` and `stun`/`stun_request`.
+
+## Migration Notes
+
+- Configuration section names, recognized key names, and `#@ws:` are validated with the same casing as the current SDK. Correct older lowercase or colon-less directives before activation.
+- Save profiles as valid UTF-8 without a byte-order mark (BOM), matching the current SDK parser.
+- `BypassLanTraffic`, `Table`, legacy `I1` through `I5`, and `Socks5Username` are rejected because the direct current `wgbooster.dll` parser does not apply them. Use `DisallowedIPs` and `Socks5ProxyUsername` where applicable.
+- User-scoped settings are upgraded once after installing a new application version, preserving autorun, profile, adapter, notification, logging, and Kill Switch preferences.
+- Profiles that remain writable by non-administrative users after startup hardening are not listed or activated. ACL hardening failures now stop initialization instead of continuing with a privileged, mutable configuration.
+
+Profiles are stored in `%ProgramData%\WireSockUI\Configs` with an administrators-only ACL because WireSockUI runs elevated. Existing profiles from the older per-user `%AppData%\WireSockUI\Configs` folder are moved into the secured folder on startup when no secured profile with the same name exists. Legacy migration and manual import use bounded temporary copies and reject reparse-point sources; profiles larger than 1 MiB must be moved or trimmed manually. If a secured profile already exists, the legacy copy is deleted only when its content matches. Profile files that are reparse points are not loaded, imported, saved over, or activated; app-owned reparse-point files in the secured profile tree are removed during startup hardening, and unsafe directories or failed ACL updates stop startup. Legacy profiles containing script hooks are not auto-migrated; import them manually so the hook warning can be reviewed.
 
 Runtime state that can be written by the elevated process, including the native recovery marker, is kept under the secured `%ProgramData%\WireSockUI` folder rather than per-user AppData. The UWP notification icon is stored under a dedicated `%ProgramData%\WireSockUI-Notifications` folder with a read-only Users ACL so the toast platform can load it without allowing unelevated writes.
 
-Elevated autorun is available only when `WireSockUI.exe` and its containing folder are not writable by or owned by non-administrative users. Install WireSockUI into an administrator-owned location before enabling autorun.
+Elevated autorun and SDK DLL loading are available only when the target file, containing directory, and replacement-sensitive ancestor path are administrator-owned. Install WireSockUI and the SDK into administrator-owned locations.
 
 Profiles containing `PreUp`, `PostUp`, `PreDown`, or `PostDown` script hooks require confirmation before import/save and again before activation. Treat script-hook profiles as privileged code.
 
@@ -67,7 +76,7 @@ The single-node `-m:1` solution build avoids a silent MSBuild failure that can h
 
 - A clean build does not prove that the installed driver and SDK DLL are present or compatible on the target machine.
 - Tunnel start/stop still depends on driver state and Windows networking permissions after elevation succeeds.
-- The `WireSockUI.Tests` harness covers focused parser/profile validation scenarios, including reparse-point rejection through file symlinks or junction fallback, but native driver and `wgbooster.dll` lifecycle behavior still needs runtime validation on a machine with the SDK installed.
+- The `WireSockUI.Tests` harness covers parser/profile validation, native error-sentinel handling, lifecycle cleanup through a deterministic native facade, ACL checks, and reparse-point rejection. Actual driver and `wgbooster.dll` operation still needs runtime validation on a machine with the SDK installed.
 
 ## License
 

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using System.Text;
 using WireSockUI;
 using WireSockUI.Config;
 using WireSockUI.Extensions;
@@ -21,7 +22,6 @@ namespace WireSockUI.Tests
         private static readonly string PublicKey = Convert.ToBase64String(Enumerable.Repeat((byte)2, 32).ToArray());
         private const int SymbolicLinkFlagFile = 0;
         private const int SymbolicLinkFlagAllowUnprivilegedCreate = 2;
-        private static bool? LastDropTunnelPreserveNetworkLock;
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.I1)]
@@ -29,6 +29,9 @@ namespace WireSockUI.Tests
             string lpSymlinkFileName,
             string lpTargetFileName,
             int dwFlags);
+
+        [DllImport("kernel32.dll", EntryPoint = "SetLastError", SetLastError = true)]
+        private static extern void SetLastErrorForTest(uint errorCode);
 
         private static int Main()
         {
@@ -45,14 +48,23 @@ namespace WireSockUI.Tests
                 { "Profile rejects reparse point profile files", ProfileRejectsReparsePointProfileFiles },
                 { "Profile reports missing profile paths clearly", ProfileReportsMissingProfilePathsClearly },
                 { "Profile reports malformed profile paths consistently", ProfileReportsMalformedProfilePathsConsistently },
-                { "Parser strips WireSock directive prefixes", ParserStripsWireSockDirectivePrefixes },
+                { "Parser accepts only exact WireSock directive prefixes", ParserAcceptsOnlyExactWireSockDirectivePrefixes },
+                { "Parser matches SDK casing", ParserMatchesSdkCasing },
                 { "Parser rejects duplicate sections", ParserRejectsDuplicateSections },
                 { "Parser rejects malformed lines", ParserRejectsMalformedLines },
+                { "Parser matches SDK duplicate-key projection", ParserMatchesSdkDuplicateKeyProjection },
+                { "Parser rejects SDK-incompatible byte-order marks", ParserRejectsSdkIncompatibleByteOrderMarks },
+                { "Parser rejects malformed UTF-8", ParserRejectsMalformedUtf8 },
                 { "Parser rejects keys before sections", ParserRejectsKeysBeforeSections },
                 { "Parser rejects empty section names", ParserRejectsEmptySectionNames },
                 { "Parser trims section names", ParserTrimsSectionNames },
                 { "Profile accepts Amnezia passthrough options", ProfileAcceptsAmneziaPassthroughOptions },
                 { "Profile rejects invalid Amnezia passthrough options", ProfileRejectsInvalidAmneziaPassthroughOptions },
+                { "Profile validates Amnezia option groups", ProfileValidatesAmneziaOptionGroups },
+                { "Profile validates protocol imitation combinations", ProfileValidatesProtocolImitationCombinations },
+                { "Profile validates current SDK numeric ranges", ProfileValidatesCurrentSdkNumericRanges },
+                { "Profile rejects SDK casing mismatches", ProfileRejectsSdkCasingMismatches },
+                { "Profile rejects unsupported direct-DLL directives", ProfileRejectsUnsupportedDirectDllDirectives },
                 { "Interface extension validation rules are shared", InterfaceExtensionValidationRulesAreShared },
                 { "Stats formatting handles extreme values", StatsFormattingHandlesExtremeValues },
                 { "Time formatting uses plural hours", TimeFormattingUsesPluralHours },
@@ -60,11 +72,16 @@ namespace WireSockUI.Tests
                 { "Time formatting handles future values", TimeFormattingHandlesFutureValues },
                 { "Global config folder containment handles drive roots", GlobalConfigFolderContainmentHandlesDriveRoots },
                 { "Global rejects unsecured config folder overrides by default", GlobalRejectsUnsecuredConfigFolderOverridesByDefault },
+                { "Global fails closed on configuration directory reparse points", GlobalFailsClosedOnConfigurationDirectoryReparsePoints },
+                { "Profile rejects user-writable secured files", ProfileRejectsUserWritableSecuredFiles },
                 { "Release version parser handles SemVer tags", ReleaseVersionParserHandlesSemVerTags },
                 { "Program path normalization preserves drive roots", ProgramPathNormalizationPreservesDriveRoots },
                 { "Program rejects user-writable WireSock library directories", ProgramRejectsUserWritableWireSockLibraryDirectories },
                 { "Program detects user-writable WireSock library files", ProgramDetectsUserWritableWireSockLibraryFiles },
+                { "Program rejects an untrusted WireSock crash handler", ProgramRejectsUntrustedWireSockCrashHandler },
+                { "Program distinguishes read-only and writable ACLs", ProgramDistinguishesReadOnlyAndWritableAcls },
                 { "Program recognizes administrative owner SIDs", ProgramRecognizesAdministrativeOwnerSids },
+                { "Program rejects replaceable trusted path ancestors", ProgramRejectsReplaceableTrustedPathAncestors },
                 { "Autorun rejects untrusted executable paths", AutoRunRejectsUntrustedExecutablePaths },
                 { "Autorun rejects reparse point executable folders", AutoRunRejectsReparsePointExecutableFolders },
                 { "Profile import rejects oversized files", ProfileImportRejectsOversizedFiles },
@@ -77,12 +94,19 @@ namespace WireSockUI.Tests
                 { "Legacy migration rejects script hooks", LegacyMigrationRejectsScriptHooks },
                 { "Legacy migration script-hook check is narrow", LegacyMigrationScriptHookCheckIsNarrow },
                 { "Native recovery marker cleanup removes directory markers", NativeRecoveryMarkerCleanupRemovesDirectoryMarkers },
+                { "Native query distinguishes error sentinels", NativeQueryDistinguishesErrorSentinels },
+                { "Settings upgrade runs exactly once", SettingsUpgradeRunsExactlyOnce },
                 { "Editor validates Amnezia options", EditorValidatesAmneziaOptions },
                 { "AppUserModelID is path seeded", AppUserModelIdIsPathSeeded },
+                { "Notification shortcut name is path seeded", NotificationShortcutNameIsPathSeeded },
                 { "Autorun task name is path seeded", AutoRunTaskNameIsPathSeeded },
                 { "WireSock disconnect forwards network-lock preservation", WireSockDisconnectForwardsNetworkLockPreservation },
+                { "WireSock manager surfaces native query failures", WireSockManagerSurfacesNativeQueryFailures },
+                { "WireSock manager cleans up failed starts", WireSockManagerCleansUpFailedStarts },
+                { "WireSock manager retains handles when cleanup fails", WireSockManagerRetainsHandlesWhenCleanupFails },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi },
                 { "WireSock exports use restricted DLL search", WireSockExportsUseRestrictedDllSearch },
+                { "WireSock log callback uses UTF-8", WireSockLogCallbackUsesUtf8 },
                 { "Stats struct matches wgbooster ABI", StatsStructMatchesWgboosterAbi }
             };
 
@@ -298,19 +322,35 @@ namespace WireSockUI.Tests
             AssertThrows<IOException>(() => Profile.EnsureRegularProfileFile(malformedPath), "profile");
         }
 
-        private static void ParserStripsWireSockDirectivePrefixes()
+        private static void ParserAcceptsOnlyExactWireSockDirectivePrefixes()
         {
             var path = WriteConfig(
                 "[Interface]\n" +
                 "#@ws:BypassLanTraffic = true\n" +
-                "#@ws VirtualAdapterMode = false\n");
+                "#@ws VirtualAdapterMode = false\n" +
+                "#@WS:VirtualAdapterMode = true\n");
 
             var section = new WireguardConfigParser.ConfigParser(path).GetSection("Interface");
 
             AssertTrue(section.ContainsKey("BypassLanTraffic"), "Expected #@ws: directive to become a normal key.");
-            AssertTrue(section.ContainsKey("VirtualAdapterMode"), "Expected #@ws directive to become a normal key.");
+            AssertFalse(section.ContainsKey("VirtualAdapterMode"),
+                "Expected non-SDK WireSock directive prefixes to remain comments.");
             AssertEqual("true", section["BypassLanTraffic"]);
-            AssertEqual("false", section["VirtualAdapterMode"]);
+        }
+
+        private static void ParserMatchesSdkCasing()
+        {
+            var path = WriteConfig("[interface]\nprivatekey = value\n");
+            var parser = new WireguardConfigParser.ConfigParser(path);
+
+            AssertTrue(parser.GetSectionNames().Contains("interface", StringComparer.Ordinal),
+                "Expected the parser to preserve section casing.");
+            AssertFalse(parser.GetSectionNames().Contains("Interface", StringComparer.Ordinal),
+                "Expected section lookup to match the case-sensitive SDK parser.");
+            AssertTrue(parser.GetSection("interface").ContainsKey("privatekey"),
+                "Expected the parser to preserve key casing.");
+            AssertFalse(parser.GetSection("interface").ContainsKey("PrivateKey"),
+                "Expected key lookup to match the case-sensitive SDK parser.");
         }
 
         private static void ParserRejectsDuplicateSections()
@@ -411,14 +451,16 @@ namespace WireSockUI.Tests
                 "[Interface]\n" +
                 $"PrivateKey = {PrivateKey}\n" +
                 "Address = 10.0.0.2/32\n" +
-                "#@ws:H1 = 1-4\n" +
-                "#@ws:H2 = 0x10-0x20\n" +
+                "#@ws:H1 = 10-14\n" +
+                "#@ws:H2 = 16-32\n" +
+                "#@ws:H3 = 40\n" +
+                "#@ws:H4 =\n" +
                 "#@ws:Jmin = 4\n" +
                 "#@ws:Jmax = 10\n" +
-                "#@ws:S1 = 1280\n" +
+                "#@ws:S1 = 1279\n" +
                 "#@ws:S2 = 0\n" +
-                "#@ws:S3 = 4294967295\n" +
-                "#@ws:S4 = 0x20\n" +
+                "#@ws:S3 = 1279\n" +
+                "#@ws:S4 = 32\n" +
                 "#@ws:Id = example.com\n" +
                 "#@ws:Ib = chrome\n" +
                 "#@ws:Ip = quic\n" +
@@ -431,9 +473,10 @@ namespace WireSockUI.Tests
             var parser = new WireguardConfigParser.ConfigParser(path);
             var interfaceSection = parser.GetSection("Interface");
 
-            AssertEqual("1-4", interfaceSection["H1"]);
-            AssertEqual("0x10-0x20", interfaceSection["H2"]);
-            AssertEqual("1280", interfaceSection["S1"]);
+            AssertEqual("10-14", interfaceSection["H1"]);
+            AssertEqual("16-32", interfaceSection["H2"]);
+            AssertEqual(string.Empty, interfaceSection["H4"]);
+            AssertEqual("1279", interfaceSection["S1"]);
             AssertEqual("chrome", interfaceSection["Ib"]);
             new Profile(path);
         }
@@ -441,11 +484,205 @@ namespace WireSockUI.Tests
         private static void ProfileRejectsInvalidAmneziaPassthroughOptions()
         {
             AssertProfileRejectsInterfaceOption("#@ws:H1 = 4-1", "H1");
-            AssertProfileRejectsInterfaceOption("#@ws:S1 = 1281", "S1");
-            AssertProfileRejectsInterfaceOption("#@ws:Id = ***", "Id");
+            AssertProfileRejectsInterfaceOption("#@ws:H1 = 0x10", "H1");
+            AssertProfileRejectsInterfaceOption("#@ws:S1 = 1280", "S1");
+            AssertProfileRejectsInterfaceOption("#@ws:S1 = 0x20", "S1");
+            AssertProfileRejectsInterfaceOption("#@ws:Jc = +1", "Jc");
+            AssertProfileRejectsInterfaceOption("#@ws:S3 = 1280", "S3");
             AssertProfileRejectsInterfaceOption("#@ws:Ip = ftp", "Ip");
             AssertProfileRejectsInterfaceOption("#@ws:Ib = safari", "Ib");
             AssertProfileRejectsInterfaceOption("#@ws:Jmin = 10\n#@ws:Jmax = 4", "Jmin");
+            AssertProfileRejectsInterfaceOption("#@ws:Jmin = 10\n#@ws:Jmax = 10", "less than");
+        }
+
+        private static void ParserRejectsSdkIncompatibleByteOrderMarks()
+        {
+            var path = WriteConfig(string.Empty);
+            try
+            {
+                File.WriteAllText(path, ValidConfig(), new UTF8Encoding(true));
+                AssertThrows<FormatException>(() => new WireguardConfigParser.ConfigParser(path), "BOM");
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+        }
+
+        private static void ParserMatchesSdkDuplicateKeyProjection()
+        {
+            var path = WriteConfig(
+                "[Interface]\n" +
+                "PrivateKey = invalid-first-value\n" +
+                $"PrivateKey = {PrivateKey}\n" +
+                "Address = 10.0.0.2/32\n" +
+                "Address = fd00::2/128\n" +
+                "MTU = invalid-first-value\n" +
+                "MTU = 1400\n" +
+                "PreUp = first.cmd\n" +
+                "PreUp = second.cmd\n\n" +
+                "[Peer]\n" +
+                $"PublicKey = {PublicKey}\n" +
+                "Endpoint = invalid-first-value\n" +
+                "Endpoint = example.com:51820\n" +
+                "AllowedIPs = 0.0.0.0/0\n" +
+                "AllowedIPs = ::/0\n");
+
+            try
+            {
+                var parser = new WireguardConfigParser.ConfigParser(path);
+                var interfaceSection = parser.GetSection("Interface");
+                var peerSection = parser.GetSection("Peer");
+
+                AssertEqual(PrivateKey, interfaceSection["PrivateKey"]);
+                AssertEqual("1400", interfaceSection["MTU"]);
+                AssertEqual("10.0.0.2/32, fd00::2/128", interfaceSection["Address"]);
+                AssertEqual("first.cmd, second.cmd", interfaceSection["PreUp"]);
+                AssertEqual("example.com:51820", peerSection["Endpoint"]);
+                AssertEqual("0.0.0.0/0, ::/0", peerSection["AllowedIPs"]);
+                new Profile(path);
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+        }
+
+        private static void ParserRejectsMalformedUtf8()
+        {
+            var path = WriteConfig(string.Empty);
+            try
+            {
+                var validPrefix = Encoding.UTF8.GetBytes("[Interface]\nPrivateKey = ");
+                var bytes = validPrefix.Concat(new byte[] { 0xc3, 0x28 }).ToArray();
+                File.WriteAllBytes(path, bytes);
+                AssertThrows<DecoderFallbackException>(
+                    () => new WireguardConfigParser.ConfigParser(path), null);
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+        }
+
+        private static void ProfileValidatesAmneziaOptionGroups()
+        {
+            AssertProfileRejectsInterfaceOption("#@ws:S1 = 1", "incomplete");
+            AssertProfileRejectsInterfaceOption("#@ws:S3 = 1", "incomplete");
+            AssertProfileRejectsInterfaceOption("#@ws:Jmin = 10", "specified together");
+            AssertProfileRejectsInterfaceOption("#@ws:Jd = 10", "require");
+        }
+
+        private static void ProfileValidatesProtocolImitationCombinations()
+        {
+            var chromiumPath = WriteProfileWithInterfaceOptions(
+                "#@ws:Id = ***\n#@ws:Ip = quic\n#@ws:Ib = chromium");
+            var firefoxPath = WriteProfileWithInterfaceOptions(
+                "#@ws:Id = example.com\n#@ws:Ip = quic\n#@ws:Ib = ff");
+            var aliasPath = WriteProfileWithInterfaceOptions(
+                "#@ws:Id = example.com\n#@ws:Ip = stun_request");
+
+            try
+            {
+                new Profile(chromiumPath);
+                new Profile(firefoxPath);
+                new Profile(aliasPath);
+            }
+            finally
+            {
+                TryDeleteFile(chromiumPath);
+                TryDeleteFile(firefoxPath);
+                TryDeleteFile(aliasPath);
+            }
+
+            AssertProfileRejectsInterfaceOption("#@ws:Ip = quic", "require");
+            AssertProfileRejectsInterfaceOption("#@ws:Id = a..b\n#@ws:Ip = sip", "SIP imitation host");
+            AssertProfileRejectsInterfaceOption("#@ws:Id = a..b\n#@ws:Ip = sip_request", "SIP imitation host");
+            AssertProfileRejectsInterfaceOption(
+                $"#@ws:Id = {new string('a', 64)}.com\n#@ws:Ip = sip", "SIP imitation host");
+
+            AssertProfileRejectsInterfaceOption(
+                "#@ws:S1 = 0\n#@ws:S2 = 0\n#@ws:H1 = 10-20\n#@ws:H2 = 20-30\n#@ws:H3 = 40\n#@ws:H4 = 50",
+                "overlapping");
+            AssertProfileRejectsInterfaceOption(
+                "#@ws:S1 = 0\n#@ws:S2 = 0\n#@ws:H1 =\n#@ws:H2 = 1\n#@ws:H3 = 3\n#@ws:H4 = 4",
+                "overlapping");
+        }
+
+        private static void ProfileRejectsUnsupportedDirectDllDirectives()
+        {
+            AssertProfileRejectsInterfaceOption("#@ws:BypassLanTraffic = true", "DisallowedIPs");
+            AssertProfileRejectsInterfaceOption("Table = auto", "not supported");
+            AssertProfileRejectsInterfaceOption("#@ws:I1 = value", "not supported");
+
+            var legacyUsernamePath = WriteConfig(
+                "[Interface]\n" +
+                $"PrivateKey = {PrivateKey}\n" +
+                "Address = 10.0.0.2/32\n\n" +
+                "[Peer]\n" +
+                $"PublicKey = {PublicKey}\n" +
+                "Endpoint = example.com:51820\n" +
+                "AllowedIPs = 0.0.0.0/0\n" +
+                "#@ws:Socks5Username = user\n");
+            try
+            {
+                AssertThrows<FormatException>(() => new Profile(legacyUsernamePath), "Socks5ProxyUsername");
+            }
+            finally
+            {
+                TryDeleteFile(legacyUsernamePath);
+            }
+        }
+
+        private static void ProfileValidatesCurrentSdkNumericRanges()
+        {
+            var path = WriteConfig(
+                "[Interface]\n" +
+                $"PrivateKey = {PrivateKey}\n" +
+                "Address = 10.0.0.2/32\n" +
+                "ListenPort = 0\n" +
+                "ScriptExecTimeout = 4294967295\n" +
+                "EnableDefaultGateway = true\n\n" +
+                "[Peer]\n" +
+                $"PublicKey = {PublicKey}\n" +
+                "Endpoint = example.com:51820\n" +
+                "AllowedIPs = 0.0.0.0/0\n" +
+                "PersistentKeepalive = 4294967295\n");
+
+            try
+            {
+                new Profile(path);
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+
+            AssertProfileRejectsInterfaceOption("ScriptExecTimeout = 4294967296", "4294967295");
+            AssertProfileRejectsInterfaceOption("ListenPort = 65536", "65535");
+            AssertProfileRejectsInterfaceOption("EnableDefaultGateway = TRUE", "exactly");
+        }
+
+        private static void ProfileRejectsSdkCasingMismatches()
+        {
+            AssertProfileRejectsInterfaceOption("#@ws:jc = 1", "expects \"Jc\"");
+
+            var path = WriteConfig(
+                "[interface]\n" +
+                $"PrivateKey = {PrivateKey}\n" +
+                "Address = 10.0.0.2/32\n\n" +
+                "[Peer]\n" +
+                $"PublicKey = {PublicKey}\n" +
+                "Endpoint = example.com:51820\n" +
+                "AllowedIPs = 0.0.0.0/0\n");
+            try
+            {
+                AssertThrows<ArgumentException>(() => new Profile(path), "Interface");
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
         }
 
         private static void InterfaceExtensionValidationRulesAreShared()
@@ -458,25 +695,18 @@ namespace WireSockUI.Tests
             AssertTrue(ConfigValueValidator.TryGetInterfaceExtensionRule("Ib", out var ib),
                 "Expected Ib to be registered as a shared interface extension rule.");
             AssertTrue(ib.IsValid("chrome"), "Expected Ib to accept supported browser profiles.");
+            AssertTrue(ib.IsValid("chromium"), "Expected Ib to accept the SDK Chromium alias.");
+            AssertTrue(ib.IsValid("ff"), "Expected Ib to accept the SDK Firefox alias.");
             AssertFalse(ib.IsValid("safari"), "Expected Ib to reject unsupported browser profiles.");
 
             AssertTrue(ConfigValueValidator.TryGetInterfaceExtensionRule("Id", out var id),
                 "Expected Id to be registered as a shared interface extension rule.");
-            AssertFalse(id.IsValid("***"), "Expected Id to reject invalid host names.");
+            AssertTrue(id.IsValid("***"), "Expected non-SIP Id values to follow the SDK byte-length contract.");
         }
 
         private static void AssertProfileRejectsInterfaceOption(string optionLine, string messagePart)
         {
-            var path = WriteConfig(
-                "[Interface]\n" +
-                $"PrivateKey = {PrivateKey}\n" +
-                "Address = 10.0.0.2/32\n" +
-                optionLine + "\n" +
-                "\n" +
-                "[Peer]\n" +
-                $"PublicKey = {PublicKey}\n" +
-                "Endpoint = example.com:51820\n" +
-                "AllowedIPs = 0.0.0.0/0\n");
+            var path = WriteProfileWithInterfaceOptions(optionLine);
 
             try
             {
@@ -486,6 +716,20 @@ namespace WireSockUI.Tests
             {
                 TryDeleteFile(path);
             }
+        }
+
+        private static string WriteProfileWithInterfaceOptions(string optionLines)
+        {
+            return WriteConfig(
+                "[Interface]\n" +
+                $"PrivateKey = {PrivateKey}\n" +
+                "Address = 10.0.0.2/32\n" +
+                optionLines + "\n" +
+                "\n" +
+                "[Peer]\n" +
+                $"PublicKey = {PublicKey}\n" +
+                "Endpoint = example.com:51820\n" +
+                "AllowedIPs = 0.0.0.0/0\n");
         }
 
         private static void StatsFormattingHandlesExtremeValues()
@@ -704,6 +948,146 @@ namespace WireSockUI.Tests
             security.SetOwner(ordinaryUserSid);
             AssertFalse((bool)hasTrustedOwner.Invoke(null, new object[] { security }),
                 "Expected an ordinary account-domain owner to remain untrusted.");
+        }
+
+        private static void GlobalFailsClosedOnConfigurationDirectoryReparsePoints()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+            var target = root + ".target";
+            var link = Path.Combine(root, "unsafe-child");
+            Directory.CreateDirectory(root);
+            Directory.CreateDirectory(target);
+
+            try
+            {
+                if (!TryCreateDirectoryJunction(link, target))
+                {
+                    SkipOrFail("configuration directory reparse point creation unavailable; fail-closed check not exercised.");
+                    return;
+                }
+
+                var secureChildren = typeof(Global).GetMethod("SecureExistingChildren",
+                    BindingFlags.NonPublic | BindingFlags.Static);
+                if (secureChildren == null)
+                    throw new InvalidOperationException("SecureExistingChildren helper was not found.");
+
+                AssertInvocationThrows<IOException>(
+                    () => secureChildren.Invoke(null, new object[] { root, null }), "reparse point");
+            }
+            finally
+            {
+                TryDeleteDirectory(link, false);
+                TryDeleteDirectory(root, true);
+                TryDeleteDirectory(target, true);
+            }
+        }
+
+        private static void ProgramRejectsUntrustedWireSockCrashHandler()
+        {
+            var validate = typeof(WireSockUI.Program).GetMethod("TryValidateTrustedWireSockCompanionFiles",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (validate == null)
+                throw new InvalidOperationException("TryValidateTrustedWireSockCompanionFiles helper was not found.");
+
+            var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            try
+            {
+                File.WriteAllText(Path.Combine(directory, "crashpad_handler.exe"), string.Empty);
+                var args = new object[] { directory, Path.Combine(directory, "wgbooster.dll"), null };
+
+                AssertFalse((bool)validate.Invoke(null, args),
+                    "Expected an explicitly user-writable crash handler to be rejected.");
+                AssertTrue(args[2] is string diagnostic &&
+                           diagnostic.IndexOf("non-administrative", StringComparison.OrdinalIgnoreCase) >= 0,
+                    $"Expected an actionable crash-handler trust diagnostic, got '{args[2]}'.");
+            }
+            finally
+            {
+                TryDeleteDirectory(directory, true);
+            }
+        }
+
+        private static void ProgramDistinguishesReadOnlyAndWritableAcls()
+        {
+            var inspect = typeof(WireSockUI.Program).GetMethod("IsPotentiallyUserWritableSecurity",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (inspect == null)
+                throw new InvalidOperationException("IsPotentiallyUserWritableSecurity helper was not found.");
+
+            var administrators = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+            var users = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+            var readOnlySecurity = new DirectorySecurity();
+            readOnlySecurity.SetOwner(administrators);
+            readOnlySecurity.AddAccessRule(new FileSystemAccessRule(
+                users,
+                FileSystemRights.ReadAndExecute,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                PropagationFlags.None,
+                AccessControlType.Allow));
+            readOnlySecurity.AddAccessRule(new FileSystemAccessRule(
+                users,
+                FileSystemRights.FullControl,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                PropagationFlags.InheritOnly,
+                AccessControlType.Allow));
+
+            AssertFalse((bool)inspect.Invoke(null, new object[] { readOnlySecurity }),
+                "Expected read-only and inherited-only non-administrative ACEs to remain trusted.");
+
+            readOnlySecurity.AddAccessRule(new FileSystemAccessRule(
+                users, FileSystemRights.Modify, AccessControlType.Allow));
+            AssertTrue((bool)inspect.Invoke(null, new object[] { readOnlySecurity }),
+                "Expected a non-administrative modify ACE to be rejected.");
+        }
+
+        private static void ProfileRejectsUserWritableSecuredFiles()
+        {
+            var originalConfigsFolder = Global.ConfigsFolder;
+            var originalOverride = Global.AllowUnsecuredConfigFolderOverrideForTests;
+            var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+
+            try
+            {
+                Directory.CreateDirectory(directory);
+                Global.ConfigsFolder = directory;
+                Global.AllowUnsecuredConfigFolderOverrideForTests = false;
+                var profilePath = Profile.GetProfilePath("unsafe");
+                File.WriteAllText(profilePath, ValidConfig());
+
+                AssertFalse(Profile.IsRegularProfileFile(profilePath, out var diagnostic),
+                    "Expected elevated activation to reject a user-writable profile.");
+                AssertTrue(diagnostic?.IndexOf("non-administrative", StringComparison.OrdinalIgnoreCase) >= 0,
+                    $"Expected an ACL diagnostic, got '{diagnostic}'.");
+            }
+            finally
+            {
+                Global.ConfigsFolder = originalConfigsFolder;
+                Global.AllowUnsecuredConfigFolderOverrideForTests = originalOverride;
+                TryDeleteDirectory(directory, true);
+            }
+        }
+
+        private static void ProgramRejectsReplaceableTrustedPathAncestors()
+        {
+            var inspectAncestor = typeof(WireSockUI.Program).GetMethod("IsPotentiallyUserReplaceableAncestor",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (inspectAncestor == null)
+                throw new InvalidOperationException("IsPotentiallyUserReplaceableAncestor helper was not found.");
+
+            var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            try
+            {
+                AssertTrue((bool)inspectAncestor.Invoke(null, new object[] { directory }),
+                    "Expected a user-owned temporary ancestor to be replaceable and therefore untrusted.");
+            }
+            finally
+            {
+                TryDeleteDirectory(directory, true);
+            }
         }
 
         private static void AutoRunRejectsUntrustedExecutablePaths()
@@ -1032,22 +1416,82 @@ namespace WireSockUI.Tests
             });
         }
 
+        private static void NativeQueryDistinguishesErrorSentinels()
+        {
+            var cleared = false;
+            var succeeded = NativeCall.TryQuery(
+                () => false,
+                result => !result,
+                () => cleared = true,
+                () => 5,
+                out var queryValue,
+                out var diagnostic);
+
+            AssertTrue(cleared, "Expected stale native error state to be cleared before the query.");
+            AssertFalse(succeeded, "Expected a false sentinel accompanied by a native error to fail.");
+            AssertFalse(queryValue, "Expected the original query value to be preserved.");
+            AssertTrue(diagnostic?.Contains("5") == true, "Expected the native error code in the diagnostic.");
+
+            succeeded = NativeCall.TryQuery(
+                () => false,
+                result => !result,
+                () => { },
+                () => 0,
+                out queryValue,
+                out diagnostic);
+            AssertTrue(succeeded, "Expected an error sentinel with ERROR_SUCCESS to remain a valid inactive state.");
+            AssertTrue(diagnostic == null, "Expected no diagnostic for a valid inactive state.");
+
+            succeeded = NativeCall.TryQuery(
+                () => true,
+                result => !result,
+                () => { },
+                () => 5,
+                out queryValue,
+                out diagnostic);
+            AssertTrue(succeeded, "Expected a non-sentinel value to ignore stale native error state.");
+        }
+
+        private static void SettingsUpgradeRunsExactlyOnce()
+        {
+            var calls = new List<string>();
+            WireSockUI.Program.RunSettingsUpgrade(
+                true,
+                () => calls.Add("upgrade"),
+                () => calls.Add("complete"),
+                () => calls.Add("save"));
+
+            AssertEqual("upgrade,complete,save", string.Join(",", calls));
+
+            WireSockUI.Program.RunSettingsUpgrade(
+                false,
+                () => throw new InvalidOperationException("Upgrade should not run."),
+                () => throw new InvalidOperationException("Completion should not run."),
+                () => throw new InvalidOperationException("Save should not run."));
+        }
+
         private static void EditorValidatesAmneziaOptions()
         {
             AssertTrue(ConfigValueValidator.IsUIntOrRange("1-4", 0, uint.MaxValue),
                 "Expected decimal H ranges to be accepted.");
-            AssertTrue(ConfigValueValidator.IsUIntOrRange("0x10-0x20", 0, uint.MaxValue),
-                "Expected hexadecimal H ranges to be accepted.");
+            AssertFalse(ConfigValueValidator.IsUIntOrRange("0x10-0x20", 0, uint.MaxValue),
+                "Expected hexadecimal H ranges to be rejected like the SDK parser.");
             AssertFalse(ConfigValueValidator.IsUIntOrRange("4-1", 0, uint.MaxValue),
                 "Expected descending H ranges to be rejected.");
-            AssertTrue(ConfigValueValidator.IsUIntInRange("1280", 0, 1280),
-                "Expected maximum S1/S2 padding to be accepted.");
-            AssertFalse(ConfigValueValidator.IsUIntInRange("1281", 0, 1280),
+            AssertTrue(ConfigValueValidator.IsUIntDecimalInRange("1279", 0, ConfigValueValidator.MaximumAmneziaPadding),
+                "Expected maximum Amnezia padding to be accepted.");
+            AssertFalse(ConfigValueValidator.IsUIntDecimalInRange("1280", 0, ConfigValueValidator.MaximumAmneziaPadding),
                 "Expected oversized S1/S2 padding to be rejected.");
+            AssertFalse(ConfigValueValidator.IsUIntDecimalInRange("+1", 0, uint.MaxValue),
+                "Expected signed unsigned values to be rejected like std::from_chars.");
             AssertTrue(ConfigValueValidator.IsOneOf("quic", "quic", "dns", "sip", "stun"),
                 "Expected known Ip values to be accepted.");
             AssertFalse(ConfigValueValidator.IsOneOf("invalid", "chrome", "firefox", "curl", "random"),
                 "Expected unknown Ib values to be rejected.");
+            AssertTrue(ConfigValueValidator.IsSipImitationHost("xn--e1afmkfd.xn--p1ai"),
+                "Expected an ACE/Punycode SIP host to be accepted.");
+            AssertFalse(ConfigValueValidator.IsSipImitationHost("a..b"),
+                "Expected empty SIP hostname labels to be rejected.");
         }
 
         private static void LegacyMigrationRejectsScriptHooks()
@@ -1118,6 +1562,25 @@ namespace WireSockUI.Tests
             AssertTrue(first.Length <= 128, "Expected AppUserModelID to fit the Windows shell length limit.");
         }
 
+        private static void NotificationShortcutNameIsPathSeeded()
+        {
+            var first = WindowsApplicationContext.BuildShortcutFileName(
+                "WireSockUI", @"C:\Program Files\WireSockUI\WireSockUI.exe");
+            var second = WindowsApplicationContext.BuildShortcutFileName(
+                "WireSockUI", @"D:\Tools\WireSockUI\WireSockUI.exe");
+
+            AssertFalse(string.Equals(first, second, StringComparison.Ordinal),
+                "Expected side-by-side installs to use different notification shortcuts.");
+            AssertTrue(first.EndsWith(".lnk", StringComparison.OrdinalIgnoreCase),
+                "Expected a shell shortcut filename.");
+
+            var untrustedName = WindowsApplicationContext.BuildShortcutFileName(
+                @"..\WireSockUI/Bad:Name", @"C:\Program Files\WireSockUI\WireSockUI.exe");
+            AssertFalse(untrustedName.Contains("..") || untrustedName.Contains("\\") || untrustedName.Contains("/") ||
+                        untrustedName.Contains(":"),
+                "Expected shortcut filenames to remove path and device-name metacharacters.");
+        }
+
         private static void AutoRunTaskNameIsPathSeeded()
         {
             var buildAutoRunTaskName = typeof(FrmSettings).GetMethod(
@@ -1158,61 +1621,166 @@ namespace WireSockUI.Tests
 
         private static void WireSockDisconnectForwardsNetworkLockPreservation()
         {
-            var manager = new WireSockManager();
-            try
+            WithTemporaryConfigFolder(() =>
             {
-                ConfigureFakeNativeTunnelHandle(manager);
+                var originalKillSwitch = WireSockUI.Properties.Settings.Default.EnableKillSwitch;
+                var nativeApi = new FakeWireSockNativeApi();
+                using (var manager = new WireSockManager(nativeApi))
+                {
+                    try
+                    {
+                        WireSockUI.Properties.Settings.Default.EnableKillSwitch = false;
+                        File.WriteAllText(Profile.GetProfilePath("office"), ValidConfig());
 
-                LastDropTunnelPreserveNetworkLock = null;
-                AssertTrue(manager.Disconnect(true), "Expected fake disconnect with preserved network lock to succeed.");
-                AssertTrue(LastDropTunnelPreserveNetworkLock == true,
-                    "Expected preserved reconnect cleanup to pass preserveNetworkLock=true to wgbooster.");
+                        AssertTrue(manager.Connect("office"), "Expected the fake tunnel to connect.");
+                        AssertTrue(manager.Disconnect(true),
+                            "Expected fake disconnect with preserved network lock to succeed.");
+                        AssertTrue(nativeApi.LastPreserveNetworkLock == true,
+                            "Expected preserved reconnect cleanup to pass preserveNetworkLock=true to wgbooster.");
 
-                ConfigureFakeNativeTunnelHandle(manager);
+                        AssertTrue(manager.Connect("office"), "Expected the fake tunnel to reconnect.");
+                        AssertTrue(manager.Disconnect(), "Expected fake default disconnect to succeed.");
+                        AssertTrue(nativeApi.LastPreserveNetworkLock == false,
+                            "Expected explicit disconnect cleanup to pass preserveNetworkLock=false to wgbooster.");
+                    }
+                    finally
+                    {
+                        WireSockUI.Properties.Settings.Default.EnableKillSwitch = originalKillSwitch;
+                    }
+                }
+            });
+        }
 
-                LastDropTunnelPreserveNetworkLock = null;
-                AssertTrue(manager.Disconnect(), "Expected fake default disconnect to succeed.");
-                AssertTrue(LastDropTunnelPreserveNetworkLock == false,
-                    "Expected explicit disconnect cleanup to pass preserveNetworkLock=false to wgbooster.");
-            }
-            finally
+        private static void WireSockManagerSurfacesNativeQueryFailures()
+        {
+            WithTemporaryConfigFolder(() =>
             {
-                manager.Dispose();
-            }
+                var originalKillSwitch = WireSockUI.Properties.Settings.Default.EnableKillSwitch;
+                var nativeApi = new FakeWireSockNativeApi();
+                using (var manager = new WireSockManager(nativeApi))
+                {
+                    try
+                    {
+                        WireSockUI.Properties.Settings.Default.EnableKillSwitch = false;
+                        File.WriteAllText(Profile.GetProfilePath("office"), ValidConfig());
+                        AssertTrue(manager.Connect("office"), "Expected the fake tunnel to connect.");
+
+                        nativeApi.TunnelActive = false;
+                        nativeApi.TunnelActiveError = 5;
+                        AssertFalse(manager.TryGetConnected(out _, out var activeDiagnostic),
+                            "Expected the manager to reject a false tunnel sentinel with a native error.");
+                        AssertTrue(activeDiagnostic?.Contains("5") == true,
+                            "Expected the tunnel query diagnostic to retain the native error.");
+
+                        nativeApi.NetworkLockMode = WireguardBoosterExports.WgbNetworkLockMode.Disabled;
+                        nativeApi.NetworkLockModeError = 6;
+                        AssertFalse(manager.TryGetKillSwitchEnabled(out _, out var lockDiagnostic),
+                            "Expected the manager to reject a disabled lock sentinel with a native error.");
+                        AssertTrue(lockDiagnostic?.Contains("6") == true,
+                            "Expected the lock query diagnostic to retain the native error.");
+
+                        nativeApi.NetworkLockMode = (WireguardBoosterExports.WgbNetworkLockMode)99;
+                        nativeApi.NetworkLockModeError = 0;
+                        AssertFalse(manager.TryGetKillSwitchEnabled(out _, out var invalidModeDiagnostic),
+                            "Expected the manager to reject unknown SDK network-lock enum values.");
+                        AssertTrue(invalidModeDiagnostic?.Contains("99") == true,
+                            "Expected the invalid SDK enum value in the diagnostic.");
+
+                        nativeApi.TunnelState = new WireguardBoosterExports.WgbStats();
+                        nativeApi.TunnelStateError = 21;
+                        AssertFalse(manager.TryGetState(out _, out var statsDiagnostic),
+                            "Expected the manager to reject empty statistics with a native error.");
+                        AssertTrue(statsDiagnostic?.Contains("21") == true,
+                            "Expected the statistics diagnostic to retain the native error.");
+                    }
+                    finally
+                    {
+                        nativeApi.TunnelActiveError = 0;
+                        nativeApi.NetworkLockModeError = 0;
+                        nativeApi.TunnelStateError = 0;
+                        WireSockUI.Properties.Settings.Default.EnableKillSwitch = originalKillSwitch;
+                    }
+                }
+            });
         }
 
-        private static void ConfigureFakeNativeTunnelHandle(WireSockManager manager)
+        private static void WireSockManagerCleansUpFailedStarts()
         {
-            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+            WithTemporaryConfigFolder(() =>
+            {
+                var originalKillSwitch = WireSockUI.Properties.Settings.Default.EnableKillSwitch;
+                var nativeApi = new FakeWireSockNativeApi
+                {
+                    StartResult = false,
+                    StartError = 31
+                };
 
-            var handleField = typeof(WireSockManager).GetField("_handle", flags);
-            var stopTunnelField = typeof(WireSockManager).GetField("_stopTunnel", flags);
-            var dropTunnelField = typeof(WireSockManager).GetField("_dropTunnel", flags);
+                using (var manager = new WireSockManager(nativeApi))
+                {
+                    try
+                    {
+                        WireSockUI.Properties.Settings.Default.EnableKillSwitch = false;
+                        File.WriteAllText(Profile.GetProfilePath("office"), ValidConfig());
 
-            if (handleField == null || stopTunnelField == null || dropTunnelField == null)
-                throw new InvalidOperationException("WireSockManager native delegate fields were not found.");
-
-            var successfulTunnelAction = typeof(Program).GetMethod(nameof(SuccessfulTunnelAction),
-                BindingFlags.NonPublic | BindingFlags.Static);
-            var recordingDropTunnel = typeof(Program).GetMethod(nameof(RecordingDropTunnel),
-                BindingFlags.NonPublic | BindingFlags.Static);
-
-            stopTunnelField.SetValue(manager,
-                Delegate.CreateDelegate(stopTunnelField.FieldType, successfulTunnelAction));
-            dropTunnelField.SetValue(manager,
-                Delegate.CreateDelegate(dropTunnelField.FieldType, recordingDropTunnel));
-            handleField.SetValue(manager, new IntPtr(1234));
+                        AssertFalse(manager.Connect("office"), "Expected the failed native start to fail connect.");
+                        AssertFalse(manager.HasTunnelHandle, "Expected failed connect cleanup to clear the handle.");
+                        AssertTrue(nativeApi.DropCount == 1, "Expected failed connect cleanup to drop the tunnel once.");
+                        AssertTrue(manager.LastError?.Contains("31") == true,
+                            "Expected the native start error in the connection diagnostic.");
+                    }
+                    finally
+                    {
+                        WireSockUI.Properties.Settings.Default.EnableKillSwitch = originalKillSwitch;
+                    }
+                }
+            });
         }
 
-        private static bool SuccessfulTunnelAction(IntPtr handle)
+        private static void WireSockManagerRetainsHandlesWhenCleanupFails()
         {
-            return true;
-        }
+            WithTemporaryConfigFolder(() =>
+            {
+                var originalKillSwitch = WireSockUI.Properties.Settings.Default.EnableKillSwitch;
+                var nativeApi = new FakeWireSockNativeApi
+                {
+                    StartResult = false,
+                    StartError = 31,
+                    DropResult = false,
+                    DropError = 32
+                };
+                var manager = new WireSockManager(nativeApi);
 
-        private static bool RecordingDropTunnel(IntPtr handle, bool preserveNetworkLock)
-        {
-            LastDropTunnelPreserveNetworkLock = preserveNetworkLock;
-            return true;
+                try
+                {
+                    WireSockUI.Properties.Settings.Default.EnableKillSwitch = false;
+                    File.WriteAllText(Profile.GetProfilePath("office"), ValidConfig());
+
+                    AssertFalse(manager.Connect("office"), "Expected the failed native start to fail connect.");
+                    AssertTrue(manager.HasTunnelHandle,
+                        "Expected failed cleanup to retain the native handle and prevent duplicate ownership.");
+                    AssertTrue(manager.LastError?.Contains("blocked") == true,
+                        "Expected the connection diagnostic to explain that replacement connections are blocked.");
+                    AssertTrue(manager.LastError?.Contains("32") == true,
+                        "Expected the native drop error in the retained-handle diagnostic.");
+
+                    AssertFalse(manager.Connect("office"),
+                        "Expected a second connect to stop when the retained handle still cannot be dropped.");
+                    AssertTrue(nativeApi.GetHandleCount == 1,
+                        "Expected the manager not to allocate a replacement native handle after failed cleanup.");
+
+                    nativeApi.DropResult = true;
+                    nativeApi.DropError = 0;
+                    AssertTrue(manager.Disconnect(), "Expected retained-handle cleanup to be retryable.");
+                    AssertFalse(manager.HasTunnelHandle, "Expected successful retry cleanup to clear the handle.");
+                }
+                finally
+                {
+                    nativeApi.DropResult = true;
+                    nativeApi.DropError = 0;
+                    manager.Dispose();
+                    WireSockUI.Properties.Settings.Default.EnableKillSwitch = originalKillSwitch;
+                }
+            });
         }
 
         private static void NetworkLockEnumMatchesWgboosterAbi()
@@ -1256,6 +1824,18 @@ namespace WireSockUI.Tests
             }
         }
 
+        private static void WireSockLogCallbackUsesUtf8()
+        {
+            var parameter = typeof(WireguardBoosterExports.LogPrinter).GetMethod("Invoke")?.GetParameters().Single();
+            var marshalAs = parameter?.GetCustomAttributes(typeof(MarshalAsAttribute), false)
+                .OfType<MarshalAsAttribute>()
+                .SingleOrDefault();
+
+            AssertTrue(marshalAs != null, "Expected the native log callback parameter to declare marshaling.");
+            AssertTrue(marshalAs.Value == UnmanagedType.LPUTF8Str,
+                $"Expected UTF-8 log marshaling, got {marshalAs.Value}.");
+        }
+
         private static void StatsStructMatchesWgboosterAbi()
         {
             AssertEqual(32, Marshal.SizeOf<WireguardBoosterExports.WgbStats>());
@@ -1264,6 +1844,91 @@ namespace WireSockUI.Tests
             AssertEqual(16, Marshal.OffsetOf<WireguardBoosterExports.WgbStats>("rx_bytes").ToInt32());
             AssertEqual(24, Marshal.OffsetOf<WireguardBoosterExports.WgbStats>("estimated_loss").ToInt32());
             AssertEqual(28, Marshal.OffsetOf<WireguardBoosterExports.WgbStats>("estimated_rtt").ToInt32());
+        }
+
+        private sealed class FakeWireSockNativeApi : IWireSockNativeApi
+        {
+            public bool StartResult { get; set; } = true;
+            public int StartError { get; set; }
+            public bool TunnelActive { get; set; } = true;
+            public int TunnelActiveError { get; set; }
+            public WireguardBoosterExports.WgbStats TunnelState { get; set; } =
+                new WireguardBoosterExports.WgbStats { time_since_last_handshake = -1, estimated_rtt = -1 };
+            public int TunnelStateError { get; set; }
+            public WireguardBoosterExports.WgbNetworkLockMode NetworkLockMode { get; set; }
+            public int NetworkLockModeError { get; set; }
+            public bool DropResult { get; set; } = true;
+            public int DropError { get; set; }
+            public bool? LastPreserveNetworkLock { get; private set; }
+            public int DropCount { get; private set; }
+            public int GetHandleCount { get; private set; }
+
+            public IntPtr GetHandle(WireSockManager.Mode mode, WireguardBoosterExports.LogPrinter logPrinter,
+                WireguardBoosterExports.WgbLogLevel logLevel, bool enableTrafficCapture)
+            {
+                SetLastErrorForTest(0);
+                GetHandleCount++;
+                return new IntPtr(1234);
+            }
+
+            public void SetLogLevel(WireSockManager.Mode mode, IntPtr handle,
+                WireguardBoosterExports.WgbLogLevel logLevel)
+            {
+                SetLastErrorForTest(0);
+            }
+
+            public bool CreateTunnelFromFile(WireSockManager.Mode mode, IntPtr handle, string fileName)
+            {
+                SetLastErrorForTest(0);
+                return true;
+            }
+
+            public bool StartTunnel(WireSockManager.Mode mode, IntPtr handle)
+            {
+                SetLastErrorForTest((uint)StartError);
+                return StartResult;
+            }
+
+            public bool StopTunnel(WireSockManager.Mode mode, IntPtr handle)
+            {
+                SetLastErrorForTest(0);
+                return true;
+            }
+
+            public bool DropTunnel(WireSockManager.Mode mode, IntPtr handle, bool preserveNetworkLock)
+            {
+                SetLastErrorForTest((uint)DropError);
+                LastPreserveNetworkLock = preserveNetworkLock;
+                DropCount++;
+                return DropResult;
+            }
+
+            public bool GetTunnelActive(WireSockManager.Mode mode, IntPtr handle)
+            {
+                SetLastErrorForTest((uint)TunnelActiveError);
+                return TunnelActive;
+            }
+
+            public WireguardBoosterExports.WgbStats GetTunnelState(WireSockManager.Mode mode, IntPtr handle)
+            {
+                SetLastErrorForTest((uint)TunnelStateError);
+                return TunnelState;
+            }
+
+            public bool SetNetworkLockMode(WireSockManager.Mode mode, IntPtr handle,
+                WireguardBoosterExports.WgbNetworkLockMode networkLockMode)
+            {
+                SetLastErrorForTest(0);
+                NetworkLockMode = networkLockMode;
+                return true;
+            }
+
+            public WireguardBoosterExports.WgbNetworkLockMode GetNetworkLockMode(WireSockManager.Mode mode,
+                IntPtr handle)
+            {
+                SetLastErrorForTest((uint)NetworkLockModeError);
+                return NetworkLockMode;
+            }
         }
 
         private static string WriteConfig(string contents)

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -106,7 +106,7 @@ namespace WireSockUI.Tests
                 { "WireSock manager retains handles when cleanup fails", WireSockManagerRetainsHandlesWhenCleanupFails },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi },
                 { "WireSock exports use restricted DLL search", WireSockExportsUseRestrictedDllSearch },
-                { "WireSock log callback uses UTF-8", WireSockLogCallbackUsesUtf8 },
+                { "WireSock log callback decodes UTF-8 explicitly", WireSockLogCallbackDecodesUtf8Explicitly },
                 { "Stats struct matches wgbooster ABI", StatsStructMatchesWgboosterAbi }
             };
 
@@ -1824,16 +1824,44 @@ namespace WireSockUI.Tests
             }
         }
 
-        private static void WireSockLogCallbackUsesUtf8()
+        private static void WireSockLogCallbackDecodesUtf8Explicitly()
         {
             var parameter = typeof(WireguardBoosterExports.LogPrinter).GetMethod("Invoke")?.GetParameters().Single();
-            var marshalAs = parameter?.GetCustomAttributes(typeof(MarshalAsAttribute), false)
-                .OfType<MarshalAsAttribute>()
-                .SingleOrDefault();
 
-            AssertTrue(marshalAs != null, "Expected the native log callback parameter to declare marshaling.");
-            AssertTrue(marshalAs.Value == UnmanagedType.LPUTF8Str,
-                $"Expected UTF-8 log marshaling, got {marshalAs.Value}.");
+            AssertTrue(parameter?.ParameterType == typeof(IntPtr),
+                "Expected the native log callback to receive the char* as an IntPtr on .NET Framework.");
+            AssertFalse(parameter.GetCustomAttributes(typeof(MarshalAsAttribute), false).Any(),
+                "Expected UTF-8 callback decoding to avoid runtime string marshaling.");
+
+            const string expected = "wgbooster: \u041F\u0440\u0438\u0432\u0435\u0442 \u4E16\u754C";
+            var bytes = Encoding.UTF8.GetBytes(expected);
+            var message = Marshal.AllocHGlobal(bytes.Length + 1);
+            try
+            {
+                Marshal.Copy(bytes, 0, message, bytes.Length);
+                Marshal.WriteByte(message, bytes.Length, 0);
+                AssertEqual(expected, WireguardBoosterExports.DecodeLogMessage(message));
+                AssertEqual(string.Empty, WireguardBoosterExports.DecodeLogMessage(IntPtr.Zero));
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(message);
+            }
+
+            var unterminatedBytes = Enumerable.Repeat((byte)'x',
+                WireguardBoosterExports.MaxLogMessageBytes + 1).ToArray();
+            var unterminatedMessage = Marshal.AllocHGlobal(unterminatedBytes.Length);
+            try
+            {
+                Marshal.Copy(unterminatedBytes, 0, unterminatedMessage, unterminatedBytes.Length);
+                AssertThrows<ArgumentException>(
+                    () => WireguardBoosterExports.DecodeLogMessage(unterminatedMessage),
+                    "not null-terminated");
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(unterminatedMessage);
+            }
         }
 
         private static void StatsStructMatchesWgboosterAbi()

--- a/WireSockUI.Tests/WireSockUI.Tests.csproj
+++ b/WireSockUI.Tests/WireSockUI.Tests.csproj
@@ -11,5 +11,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WireSockUI\WireSockUI.csproj" />
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 </Project>

--- a/WireSockUI/Config/ConfigValueValidator.cs
+++ b/WireSockUI/Config/ConfigValueValidator.cs
@@ -1,21 +1,27 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
+using System.Text;
 
 namespace WireSockUI.Config
 {
     internal static class ConfigValueValidator
     {
+        public const uint MaximumAmneziaPadding = 1279;
+
         private static readonly ConfigValueRule[] InterfaceExtensionRuleList =
         {
-            new ConfigValueRule("Jc", value => IsUIntInRange(value, 0, 128), "0...128"),
-            new ConfigValueRule("Jd", value => IsUIntInRange(value, 0, 200), "0...200"),
-            new ConfigValueRule("Jmin", value => IsUIntInRange(value, 0, 1280), "0...1280"),
-            new ConfigValueRule("Jmax", value => IsUIntInRange(value, 0, 1280), "0...1280"),
-            new ConfigValueRule("S1", value => IsUIntInRange(value, 0, 1280), "0...1280"),
-            new ConfigValueRule("S2", value => IsUIntInRange(value, 0, 1280), "0...1280"),
-            new ConfigValueRule("S3", value => IsUIntInRange(value, 0, uint.MaxValue), $"0...{uint.MaxValue}"),
-            new ConfigValueRule("S4", value => IsUIntInRange(value, 0, uint.MaxValue), $"0...{uint.MaxValue}"),
+            new ConfigValueRule("Jc", value => IsUIntDecimalInRange(value, 0, 128), "0...128"),
+            new ConfigValueRule("Jd", value => IsUIntDecimalInRange(value, 0, 200), "0...200"),
+            new ConfigValueRule("Jmin", value => IsUIntDecimalInRange(value, 0, 1280), "0...1280"),
+            new ConfigValueRule("Jmax", value => IsUIntDecimalInRange(value, 0, 1280), "0...1280"),
+            new ConfigValueRule("S1", value => IsUIntDecimalInRange(value, 0, MaximumAmneziaPadding),
+                $"0...{MaximumAmneziaPadding}"),
+            new ConfigValueRule("S2", value => IsUIntDecimalInRange(value, 0, MaximumAmneziaPadding),
+                $"0...{MaximumAmneziaPadding}"),
+            new ConfigValueRule("S3", value => IsUIntDecimalInRange(value, 0, MaximumAmneziaPadding),
+                $"0...{MaximumAmneziaPadding}"),
+            new ConfigValueRule("S4", value => IsUIntDecimalInRange(value, 0, MaximumAmneziaPadding),
+                $"0...{MaximumAmneziaPadding}"),
             new ConfigValueRule("H1", value => IsUIntOrRange(value, 0, uint.MaxValue),
                 $"0...{uint.MaxValue} or an ascending range"),
             new ConfigValueRule("H2", value => IsUIntOrRange(value, 0, uint.MaxValue),
@@ -24,11 +30,14 @@ namespace WireSockUI.Config
                 $"0...{uint.MaxValue} or an ascending range"),
             new ConfigValueRule("H4", value => IsUIntOrRange(value, 0, uint.MaxValue),
                 $"0...{uint.MaxValue} or an ascending range"),
-            new ConfigValueRule("Id", IsHostName, "a valid host name"),
-            new ConfigValueRule("Ip", value => IsOneOf(value, "quic", "dns", "sip", "stun"),
-                "one of: quic, dns, sip, stun"),
-            new ConfigValueRule("Ib", value => IsOneOf(value, "chrome", "firefox", "curl", "random"),
-                "one of: chrome, firefox, curl, random")
+            new ConfigValueRule("Id", IsProtocolImitationId, "1...253 UTF-8 bytes"),
+            new ConfigValueRule("Ip",
+                value => IsOneOf(value, "quic", "quic_initial", "dns", "dns_request", "sip", "sip_request",
+                    "stun", "stun_request"),
+                "one of: quic, quic_initial, dns, dns_request, sip, sip_request, stun, stun_request"),
+            new ConfigValueRule("Ib",
+                value => IsOneOf(value, "chrome", "chromium", "firefox", "ff", "curl", "random"),
+                "one of: chrome, chromium, firefox, ff, curl, random")
         };
 
         private static readonly Dictionary<string, ConfigValueRule> InterfaceExtensionRuleLookup =
@@ -41,22 +50,12 @@ namespace WireSockUI.Config
             return InterfaceExtensionRuleLookup.TryGetValue(key ?? string.Empty, out rule);
         }
 
-        public static bool IsIntInRange(string value, int minValue, int maxValue)
+        public static bool IsUIntDecimalInRange(string value, uint minValue, uint maxValue)
         {
             if (string.IsNullOrWhiteSpace(value))
                 return true;
 
-            return int.TryParse(value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue) &&
-                   intValue >= minValue &&
-                   intValue <= maxValue;
-        }
-
-        public static bool IsUIntInRange(string value, uint minValue, uint maxValue)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-                return true;
-
-            return TryParseUInt(value, out var intValue) &&
+            return TryParseUIntDecimal(value, out var intValue) &&
                    intValue >= minValue &&
                    intValue <= maxValue;
         }
@@ -70,13 +69,13 @@ namespace WireSockUI.Config
             if (parts.Length == 0 || parts.Length > 2)
                 return false;
 
-            if (!TryParseUInt(parts[0], out var first) || first < minValue || first > maxValue)
+            if (!TryParseUIntDecimal(parts[0], out var first) || first < minValue || first > maxValue)
                 return false;
 
             if (parts.Length == 1)
                 return true;
 
-            return TryParseUInt(parts[1], out var second) &&
+            return TryParseUIntDecimal(parts[1], out var second) &&
                    second >= minValue &&
                    second <= maxValue &&
                    first <= second;
@@ -106,12 +105,50 @@ namespace WireSockUI.Config
             return false;
         }
 
-        public static bool IsHostName(string value)
+        public static bool IsProtocolImitationId(string value)
         {
             if (string.IsNullOrWhiteSpace(value))
                 return true;
 
-            return Uri.CheckHostName(value.Trim()) != UriHostNameType.Unknown;
+            return Encoding.UTF8.GetByteCount(value.Trim()) <= 253;
+        }
+
+        public static bool IsSipImitationHost(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            var host = value.Trim();
+            if (Encoding.UTF8.GetByteCount(host) > 253 || host[0] == '.' || host[0] == '-' ||
+                host[host.Length - 1] == '.' || host[host.Length - 1] == '-')
+                return false;
+
+            var labelLength = 0;
+            for (var index = 0; index < host.Length; index++)
+            {
+                var character = host[index];
+                var valid = character >= 'A' && character <= 'Z' ||
+                            character >= 'a' && character <= 'z' ||
+                            character >= '0' && character <= '9' ||
+                            character == '.' || character == '-';
+                if (!valid || labelLength == 0 && character == '-')
+                    return false;
+
+                if (character == '.')
+                {
+                    if (labelLength == 0 || labelLength > 63 || host[index - 1] == '-')
+                        return false;
+
+                    labelLength = 0;
+                    continue;
+                }
+
+                labelLength++;
+                if (labelLength > 63)
+                    return false;
+            }
+
+            return labelLength > 0 && labelLength <= 63;
         }
 
         private static Dictionary<string, ConfigValueRule> BuildInterfaceExtensionRuleLookup()
@@ -124,14 +161,21 @@ namespace WireSockUI.Config
             return rules;
         }
 
-        internal static bool TryParseUInt(string value, out uint result)
+        internal static bool TryParseUIntDecimal(string value, out uint result)
         {
-            var trimmed = value.Trim();
-            if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
-                return uint.TryParse(trimmed.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture,
-                    out result);
+            result = 0;
+            if (value == null)
+                return false;
 
-            return uint.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+            var trimmed = value.Trim();
+            if (trimmed.Length == 0)
+                return false;
+
+            foreach (var character in trimmed)
+                if (character < '0' || character > '9')
+                    return false;
+
+            return uint.TryParse(trimmed, out result);
         }
 
         internal sealed class ConfigValueRule

--- a/WireSockUI/Config/Profile.cs
+++ b/WireSockUI/Config/Profile.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using WireSockUI.Extensions;
@@ -15,6 +14,21 @@ namespace WireSockUI.Config
     /// </summary>
     internal class Profile
     {
+        private static readonly string[] InterfaceKeys =
+        {
+            "PrivateKey", "Address", "DNS", "MTU", "ListenPort", "Table", "ScriptExecTimeout", "PreUp",
+            "PostUp", "PreDown", "PostDown", "BypassLanTraffic", "VirtualAdapterMode", "EnableDefaultGateway",
+            "Jc", "Jmin", "Jmax", "Jd", "S1", "S2", "S3", "S4", "H1", "H2", "H3", "H4", "Id", "Ip",
+            "Ib"
+        };
+
+        private static readonly string[] PeerKeys =
+        {
+            "PublicKey", "PresharedKey", "AllowedIPs", "Endpoint", "PersistentKeepalive", "AllowedApps",
+            "DisallowedApps", "DisallowedIPs", "Socks5Proxy", "Socks5ProxyUsername", "Socks5ProxyPassword",
+            "Socks5ProxyAllTraffic", "Socks5Username"
+        };
+
         private string _address;
 
         // WireSock Extensions
@@ -26,7 +40,6 @@ namespace WireSockUI.Config
         private string _persistentKeepAlive;
         private string _scriptExecTimeout;
         private string _disallowedIPs;
-        private string _bypassLanTraffic;
         private string _virtualAdapterMode;
 
         private string _presharedKey;
@@ -61,32 +74,37 @@ namespace WireSockUI.Config
             var sections = parser.GetSectionNames();
 
             var configESections = sections as string[] ?? sections.ToArray();
-            if (!configESections.Contains("Interface", StringComparer.OrdinalIgnoreCase))
+            if (!configESections.Contains("Interface", StringComparer.Ordinal))
                 throw new ArgumentException(
                     $"Profile {GetProfileDisplayName(profilePath)} does not contain an \"Interface\" section.");
 
             var section = parser.GetSection("Interface");
+            ValidateKnownKeyCasing(section, InterfaceKeys);
+            ValidateUnsupportedInterfaceDirectives(section);
 
             PrivateKey = GetRequiredValue(profilePath, "Interface", section, "PrivateKey");
             Address = GetRequiredValue(profilePath, "Interface", section, "Address");
             Dns = section.Get("DNS");
             Mtu = section.Get("MTU");
             ListenPort = section.Get("ListenPort");
-            Table = section.Get("Table");
             ScriptExecTimeout = section.Get("ScriptExecTimeout");
             PreUpScript = section.Get("PreUp");
             PostUpScript = section.Get("PostUp");
             PreDownScript = section.Get("PreDown");
             PostDownScript = section.Get("PostDown");
-            BypassLanTraffic = section.Get("BypassLanTraffic");
             VirtualAdapterMode = section.Get("VirtualAdapterMode");
             ValidateInterfaceExtensions(section);
 
-            if (!configESections.Contains("Peer", StringComparer.OrdinalIgnoreCase))
+            if (!configESections.Contains("Peer", StringComparer.Ordinal))
                 throw new ArgumentException(
                     $"Profile {GetProfileDisplayName(profilePath)} does not contain a \"Peer\" section.");
 
             section = parser.GetSection("Peer");
+            ValidateKnownKeyCasing(section, PeerKeys);
+
+            if (section.ContainsKey("Socks5Username"))
+                throw new FormatException(
+                    "\"Socks5Username\" in \"Peer\" is not supported by the current SDK. Use \"Socks5ProxyUsername\".");
 
             PeerKey = GetRequiredValue(profilePath, "Peer", section, "PublicKey");
             PresharedKey = section.Get("PresharedKey");
@@ -99,8 +117,6 @@ namespace WireSockUI.Config
             DisallowedIPs = section.Get("DisallowedIPs");
             Socks5Proxy = section.Get("Socks5Proxy");
             Socks5ProxyUsername = section.Get("Socks5ProxyUsername");
-            if (string.IsNullOrEmpty(Socks5ProxyUsername))
-                Socks5ProxyUsername = section.Get("Socks5Username");
             Socks5ProxyPassword = section.Get("Socks5ProxyPassword");
             Socks5ProxyAllTraffic = section.Get("Socks5ProxyAllTraffic");
         }
@@ -170,20 +186,8 @@ namespace WireSockUI.Config
             get => _mtu;
             set
             {
-                if (!string.IsNullOrWhiteSpace(value))
-                {
-                    if (!int.TryParse(value, out var mtu))
-                        throw new FormatException("\"MTU\" in \"Interface\", is not a numerical value.");
-
-                    if (mtu < 576 || mtu > 65535)
-                        throw new FormatException("\"MTU\" in \"Interface\", invalid value. Expected 576...65535.");
-
-                    _mtu = value;
-                }
-                else
-                {
-                    _mtu = null;
-                }
+                ValidateUInt("Interface", "MTU", value, 576, ushort.MaxValue);
+                _mtu = string.IsNullOrWhiteSpace(value) ? null : value;
             }
         }
 
@@ -195,28 +199,10 @@ namespace WireSockUI.Config
             get => _listenport;
             set
             {
-                if (!string.IsNullOrWhiteSpace(value))
-                {
-                    if (!int.TryParse(value, out var listenPort))
-                        throw new FormatException("\"ListenPort\" in \"Interface\", is not a numerical value.");
-
-                    if (listenPort < 1 || listenPort > 65535)
-                        throw new FormatException(
-                            "\"ListenPort\" in \"Interface\", invalid value. Expected 1...65535.");
-
-                    _listenport = value;
-                }
-                else
-                {
-                    _listenport = null;
-                }
+                ValidateUInt("Interface", "ListenPort", value, 0, ushort.MaxValue);
+                _listenport = string.IsNullOrWhiteSpace(value) ? null : value;
             }
         }
-
-        /// <summary>
-        ///     Interface routing table setting.
-        /// </summary>
-        public string Table { get; set; }
 
         /// <summary>
         ///     Timeout for Pre/Post up/down scripts.
@@ -226,7 +212,7 @@ namespace WireSockUI.Config
             get => _scriptExecTimeout;
             set
             {
-                ValidateInt("Interface", "ScriptExecTimeout", value, 0, 65535);
+                ValidateUInt("Interface", "ScriptExecTimeout", value, 0, uint.MaxValue);
                 _scriptExecTimeout = string.IsNullOrWhiteSpace(value) ? null : value;
             }
         }
@@ -249,19 +235,6 @@ namespace WireSockUI.Config
             AddScriptHook(hooks, "PostDown", PostDownScript);
 
             return hooks;
-        }
-
-        /// <summary>
-        ///     Exclude local LAN traffic from the tunnel when supported by the SDK.
-        /// </summary>
-        public string BypassLanTraffic
-        {
-            get => _bypassLanTraffic;
-            set
-            {
-                ValidateBool("Interface", "BypassLanTraffic", value);
-                _bypassLanTraffic = string.IsNullOrWhiteSpace(value) ? null : value;
-            }
         }
 
         /// <summary>
@@ -340,21 +313,8 @@ namespace WireSockUI.Config
             get => _persistentKeepAlive;
             set
             {
-                if (!string.IsNullOrWhiteSpace(value))
-                {
-                    if (!int.TryParse(value, out var mtu))
-                        throw new FormatException("\"PersistentKeepalive\" in \"Peer\", is not a numerical value.");
-
-                    if (mtu < 0 || mtu > 65535)
-                        throw new FormatException(
-                            "\"PersistentKeepalive\" in \"Peer\", invalid value. Expected 0...65535.");
-
-                    _persistentKeepAlive = value;
-                }
-                else
-                {
-                    _persistentKeepAlive = null;
-                }
+                ValidateUInt("Peer", "PersistentKeepalive", value, 0, uint.MaxValue);
+                _persistentKeepAlive = string.IsNullOrWhiteSpace(value) ? null : value;
             }
         }
 
@@ -468,19 +428,6 @@ namespace WireSockUI.Config
             }
         }
 
-        internal static void ValidateInt(string section, string key, string keyValue, int minValue, int maxValue)
-        {
-            if (string.IsNullOrWhiteSpace(keyValue)) return;
-
-            var trimmedValue = keyValue.Trim();
-            if (!int.TryParse(trimmedValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
-                throw new FormatException($"\"{key}\" in \"{section}\", is not a numerical value.");
-
-            if (intValue < minValue || intValue > maxValue)
-                throw new FormatException(
-                    $"\"{key}\" in \"{section}\", invalid value. Expected {minValue}...{maxValue}.");
-        }
-
         internal static void ValidateBool(string section, string key, string keyValue)
         {
             if (string.IsNullOrWhiteSpace(keyValue)) return;
@@ -495,12 +442,169 @@ namespace WireSockUI.Config
         {
             foreach (var rule in ConfigValueValidator.InterfaceExtensionRules)
             {
-                if (!rule.IsValid(section.Get(rule.Key)))
+                var value = section.Get(rule.Key);
+                if (section.ContainsKey(rule.Key) && string.IsNullOrWhiteSpace(value) &&
+                    !IsBlankAmneziaHeaderAllowed(rule.Key))
+                    throw new FormatException($"\"{rule.Key}\" in \"Interface\" cannot be empty.");
+
+                if (!rule.IsValid(value))
                     throw new FormatException(
                         $"\"{rule.Key}\" in \"Interface\", invalid value. Expected {rule.ExpectedValueDescription}.");
             }
 
+            ValidateRequiredPair(section, "Jmin", "Jmax");
             ValidateUIntOrdering(section, "Jmin", "Jmax");
+            ValidatePreHandshakeActivation(section);
+            ValidateAmneziaGroup(section);
+            ValidateAmneziaHeaderRanges(section);
+            ValidateProtocolImitation(section);
+
+            if (section.ContainsKey("EnableDefaultGateway") &&
+                !string.Equals(section.Get("EnableDefaultGateway"), "true", StringComparison.Ordinal) &&
+                !string.Equals(section.Get("EnableDefaultGateway"), "false", StringComparison.Ordinal))
+                throw new FormatException(
+                    "\"EnableDefaultGateway\" in \"Interface\" must be exactly \"true\" or \"false\".");
+        }
+
+        private static bool IsBlankAmneziaHeaderAllowed(string key)
+        {
+            return string.Equals(key, "H1", StringComparison.Ordinal) ||
+                   string.Equals(key, "H2", StringComparison.Ordinal) ||
+                   string.Equals(key, "H3", StringComparison.Ordinal) ||
+                   string.Equals(key, "H4", StringComparison.Ordinal);
+        }
+
+        internal static void ValidateUInt(string section, string key, string keyValue, uint minValue, uint maxValue)
+        {
+            if (string.IsNullOrWhiteSpace(keyValue)) return;
+
+            if (!ConfigValueValidator.IsUIntDecimalInRange(keyValue, minValue, maxValue))
+                throw new FormatException(
+                    $"\"{key}\" in \"{section}\", invalid value. Expected {minValue}...{maxValue}.");
+        }
+
+        private static void ValidateKnownKeyCasing(Dictionary<string, string> section, IEnumerable<string> knownKeys)
+        {
+            var canonicalKeys = knownKeys.ToDictionary(key => key, key => key, StringComparer.OrdinalIgnoreCase);
+            foreach (var key in section.Keys)
+            {
+                if (canonicalKeys.TryGetValue(key, out var canonicalKey) &&
+                    !string.Equals(key, canonicalKey, StringComparison.Ordinal))
+                    throw new FormatException(
+                        $"Configuration key \"{key}\" has invalid casing. The current SDK expects \"{canonicalKey}\".");
+            }
+        }
+
+        private static void ValidateUnsupportedInterfaceDirectives(Dictionary<string, string> section)
+        {
+            if (section.ContainsKey("BypassLanTraffic"))
+                throw new FormatException(
+                    "\"BypassLanTraffic\" is not supported by direct wgbooster.dll integration. Specify LAN prefixes with \"DisallowedIPs\" in \"Peer\".");
+
+            if (section.ContainsKey("Table"))
+                throw new FormatException(
+                    "\"Table\" is not supported by the current wgbooster.dll configuration parser.");
+
+            for (var index = 1; index <= 5; index++)
+            {
+                var key = $"I{index}";
+                if (section.Keys.Any(existingKey =>
+                        string.Equals(existingKey, key, StringComparison.OrdinalIgnoreCase)))
+                    throw new FormatException(
+                        $"\"{key}\" is not supported by the current wgbooster.dll configuration parser.");
+            }
+        }
+
+        private static void ValidateRequiredPair(Dictionary<string, string> section, string firstKey, string secondKey)
+        {
+            if (section.ContainsKey(firstKey) == section.ContainsKey(secondKey))
+                return;
+
+            throw new FormatException(
+                $"\"{firstKey}\" and \"{secondKey}\" in \"Interface\" must be specified together.");
+        }
+
+        private static void ValidateAmneziaGroup(Dictionary<string, string> section)
+        {
+            var allKeys = new[] { "S1", "S2", "S3", "S4", "H1", "H2", "H3", "H4" };
+            if (!allKeys.Any(section.ContainsKey))
+                return;
+
+            var requiredKeys = new[] { "S1", "S2", "H1", "H2", "H3", "H4" };
+            var missingKeys = requiredKeys.Where(key => !section.ContainsKey(key)).ToArray();
+            if (missingKeys.Length > 0)
+                throw new FormatException(
+                    $"Amnezia configuration in \"Interface\" is incomplete. Missing: {string.Join(", ", missingKeys)}.");
+        }
+
+        private static void ValidatePreHandshakeActivation(Dictionary<string, string> section)
+        {
+            if (!(section.ContainsKey("Jmin") || section.ContainsKey("Jmax") || section.ContainsKey("Jd")))
+                return;
+
+            if (!section.ContainsKey("Jc") && !section.ContainsKey("Id"))
+                throw new FormatException(
+                    "\"Jmin\", \"Jmax\", and \"Jd\" in \"Interface\" require \"Jc\" or \"Id\" to enable pre-handshake configuration.");
+        }
+
+        private static void ValidateProtocolImitation(Dictionary<string, string> section)
+        {
+            if ((section.ContainsKey("Ip") || section.ContainsKey("Ib")) && !section.ContainsKey("Id"))
+                throw new FormatException("\"Ip\" and \"Ib\" in \"Interface\" require \"Id\".");
+
+            var protocol = section.Get("Ip")?.Trim();
+            if ((string.Equals(protocol, "sip", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(protocol, "sip_request", StringComparison.OrdinalIgnoreCase)) &&
+                !ConfigValueValidator.IsSipImitationHost(section.Get("Id")))
+                throw new FormatException(
+                    "\"Id\" in \"Interface\" is not a valid SIP imitation host. Use ASCII labels of at most 63 characters.");
+        }
+
+        private static void ValidateAmneziaHeaderRanges(Dictionary<string, string> section)
+        {
+            var keys = new[] { "H1", "H2", "H3", "H4" };
+            if (!keys.All(section.ContainsKey))
+                return;
+
+            var ranges = keys.Select((key, index) => ParseResolvedHeaderRange(section.Get(key), (uint)index + 1))
+                .ToArray();
+            for (var first = 0; first < ranges.Length; first++)
+            {
+                for (var second = first + 1; second < ranges.Length; second++)
+                {
+                    if (ranges[first].Start <= ranges[second].End && ranges[second].Start <= ranges[first].End)
+                        throw new FormatException(
+                            $"\"{keys[first]}\" and \"{keys[second]}\" in \"Interface\" resolve to overlapping header ranges.");
+                }
+            }
+        }
+
+        private static HeaderRange ParseResolvedHeaderRange(string value, uint defaultValue)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return new HeaderRange(defaultValue, defaultValue);
+
+            var parts = value.Split('-');
+            ConfigValueValidator.TryParseUIntDecimal(parts[0], out var start);
+            var end = start;
+            if (parts.Length == 2)
+                ConfigValueValidator.TryParseUIntDecimal(parts[1], out end);
+
+            return start == 0 && end == 0
+                ? new HeaderRange(defaultValue, defaultValue)
+                : new HeaderRange(start, end);
+        }
+
+        private struct HeaderRange
+        {
+            public HeaderRange(uint start, uint end)
+            {
+                Start = start;
+                End = end;
+            }
+
+            public uint Start { get; }
+            public uint End { get; }
         }
 
         private static void ValidateUIntOrdering(Dictionary<string, string> section, string minKey, string maxKey)
@@ -510,13 +614,13 @@ namespace WireSockUI.Config
             if (string.IsNullOrWhiteSpace(minValue) || string.IsNullOrWhiteSpace(maxValue))
                 return;
 
-            if (!ConfigValueValidator.TryParseUInt(minValue, out var min) ||
-                !ConfigValueValidator.TryParseUInt(maxValue, out var max))
+            if (!ConfigValueValidator.TryParseUIntDecimal(minValue, out var min) ||
+                !ConfigValueValidator.TryParseUIntDecimal(maxValue, out var max))
                 return;
 
-            if (min > max)
+            if (min >= max)
                 throw new FormatException(
-                    $"\"{minKey}\" in \"Interface\" must be less than or equal to \"{maxKey}\".");
+                    $"\"{minKey}\" in \"Interface\" must be less than \"{maxKey}\".");
         }
 
         public static IEnumerable<string> GetProfiles()
@@ -673,6 +777,10 @@ namespace WireSockUI.Config
                     return false;
                 }
 
+                if (!Global.AllowUnsecuredConfigFolderOverrideForTests && IsPathInConfigFolder(profilePath) &&
+                    !Program.TryValidateTrustedFilePath(profilePath, "Profile file", out diagnostic))
+                    return false;
+
                 return true;
             }
             catch (FileNotFoundException)
@@ -691,6 +799,14 @@ namespace WireSockUI.Config
                     $"Unable to inspect profile file '{GetProfileDisplayName(profilePath)}': {ex.Message}";
                 return false;
             }
+        }
+
+        private static bool IsPathInConfigFolder(string profilePath)
+        {
+            var configRoot = Path.GetFullPath(Global.ConfigsFolder)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            var fullProfilePath = Path.GetFullPath(profilePath);
+            return fullProfilePath.StartsWith(configRoot, StringComparison.OrdinalIgnoreCase);
         }
 
         private static string GetRequiredValue(string profilePath, string sectionName, Dictionary<string, string> section,

--- a/WireSockUI/Forms/frmEdit.cs
+++ b/WireSockUI/Forms/frmEdit.cs
@@ -14,7 +14,7 @@ namespace WireSockUI.Forms
     {
         private static readonly Regex ProfileMatch =
             new Regex(
-                @"^\s*((?<comment>[;#](?!@ws\b).*)|(?<section>\[[^\]\r\n]+\])|(?:(?<prefix>#@ws:?)\s*)?(?<key>[a-zA-Z0-9]+)[ \t]*=[ \t]*(?<value>.*?))\s*$",
+                @"^\s*((?<comment>[;#](?!(?-i:@ws:)).*)|(?<section>\[[^\]\r\n]+\])|(?:(?<prefix>(?-i:#@ws:))\s*)?(?<key>[a-zA-Z0-9]+)[ \t]*=[ \t]*(?<value>.*?))\s*$",
                 RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex MultiValueMatch =
@@ -130,10 +130,10 @@ namespace WireSockUI.Forms
                         txtEditor.SelectionColor = Color.DarkBlue;
                         txtEditor.SelectionFont = _editorBoldFont;
 
-                        switch (m.Groups["section"].Value.ToLowerInvariant())
+                        switch (m.Groups["section"].Value)
                         {
-                            case "[interface]":
-                            case "[peer]":
+                            case "[Interface]":
+                            case "[Peer]":
                                 break;
                             // Unrecognized sections
                             default:
@@ -270,14 +270,14 @@ namespace WireSockUI.Forms
                                 break;
                             // Numerical values
                             case "mtu":
-                                if (!ConfigValueValidator.IsIntInRange(value, 576, 65535))
+                                if (!ConfigValueValidator.IsUIntDecimalInRange(value, 576, ushort.MaxValue))
                                 {
                                     txtEditor.UnderlineSelection();
                                     hasErrors = true;
                                 }
                                 break;
                             case "listenport":
-                                if (!ConfigValueValidator.IsIntInRange(value, 1, 65535))
+                                if (!ConfigValueValidator.IsUIntDecimalInRange(value, 0, ushort.MaxValue))
                                 {
                                     txtEditor.UnderlineSelection();
                                     hasErrors = true;
@@ -285,7 +285,7 @@ namespace WireSockUI.Forms
                                 break;
                             case "persistentkeepalive":
                             case "scriptexectimeout":
-                                if (!ConfigValueValidator.IsIntInRange(value, 0, 65535))
+                                if (!ConfigValueValidator.IsUIntDecimalInRange(value, 0, uint.MaxValue))
                                 {
                                     txtEditor.UnderlineSelection();
                                     hasErrors = true;
@@ -313,6 +313,14 @@ namespace WireSockUI.Forms
                             case "virtualadaptermode":
                             case "socks5proxyalltraffic":
                                 if (!ConfigValueValidator.IsBool(value))
+                                {
+                                    txtEditor.UnderlineSelection();
+                                    hasErrors = true;
+                                }
+                                break;
+                            case "enabledefaultgateway":
+                                if (!string.Equals(value.Trim(), "true", StringComparison.Ordinal) &&
+                                    !string.Equals(value.Trim(), "false", StringComparison.Ordinal))
                                 {
                                     txtEditor.UnderlineSelection();
                                     hasErrors = true;
@@ -368,7 +376,7 @@ namespace WireSockUI.Forms
             // Insertion must be robust: it needs to handle incomplete or malformed configurations since
             // our user is in the middle of editing the file. Parsing isn't really an option.
             var possibleKeyValueMatch = new Regex(
-                $@"^\s*(?:(?<comment>[;#](?!@ws\b).*)|(?:(?<prefix>#@ws:?)\s*)?{Regex.Escape(key)}((?<afterkey>[ \t]*$)|[ \t]*(?<equals>=)?(?<afterkey>.*?)$))",
+                $@"^\s*(?:(?<comment>[;#](?!(?-i:@ws:)).*)|(?:(?<prefix>(?-i:#@ws:))\s*)?{Regex.Escape(key)}((?<afterkey>[ \t]*$)|[ \t]*(?<equals>=)?(?<afterkey>.*?)$))",
                 RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
             int textReplacementIndex = txtEditor.Text.Length;

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -42,7 +42,7 @@ namespace WireSockUI.Forms
 
         private ConnectionState _currentState = ConnectionState.Disconnected;
         private bool _exitRequested;
-        private bool _shutdownComplete;
+        private volatile bool _shutdownComplete;
         private int _tunnelOperationInProgress;
         private int _tunnelGeneration;
         private int _tunnelConnectionTimeoutGeneration = -1;
@@ -57,6 +57,7 @@ namespace WireSockUI.Forms
             public int Generation { get; set; }
             public bool Connected { get; set; }
             public bool TimedOut { get; set; }
+            public string Diagnostic { get; set; }
         }
 
         private sealed class ConnectAttemptResult
@@ -69,6 +70,7 @@ namespace WireSockUI.Forms
         {
             public int Generation { get; set; }
             public WgbStats Stats { get; set; }
+            public string Diagnostic { get; set; }
         }
 
         /**
@@ -295,6 +297,17 @@ namespace WireSockUI.Forms
                     MessageBox.Show(Resources.TunnelNativeRecoveryRequired, Resources.TunnelErrorTitle,
                         MessageBoxButtons.OK, MessageBoxIcon.Warning);
             });
+        }
+
+        private void HandleNativeCleanupFailure(string profile, string context, string diagnostic = null)
+        {
+            if (!string.IsNullOrWhiteSpace(diagnostic))
+                Trace.TraceWarning($"Native cleanup failure after {context}: {diagnostic}");
+
+            TryResetNetworkLockAfterNativeCleanupFailure(context);
+            MarkNativeRecoveryRequired(profile, string.IsNullOrWhiteSpace(diagnostic)
+                ? context
+                : $"{context}: {diagnostic}");
         }
 
         private void SetNativeRecoveryUi(string profile)
@@ -707,7 +720,17 @@ namespace WireSockUI.Forms
                         return;
                     }
 
-                    connected = _wiresock.Connected;
+                    if (!_wiresock.TryGetConnected(out connected, out var diagnostic))
+                    {
+                        worker.ReportProgress(0, new TunnelConnectionProgress
+                        {
+                            Generation = generation,
+                            Diagnostic = diagnostic ?? "Unable to query the native tunnel state."
+                        });
+                        e.Cancel = true;
+                        return;
+                    }
+
                     if (!connected && timeout.ElapsedMilliseconds >= TunnelConnectionTimeoutMilliseconds)
                     {
                         worker.ReportProgress(0, new TunnelConnectionProgress
@@ -739,6 +762,12 @@ namespace WireSockUI.Forms
                     return;
                 }
 
+                if (!string.IsNullOrWhiteSpace(progress.Diagnostic))
+                {
+                    _ = HandleTunnelQueryFailureAsync(progress.Generation, progress.Diagnostic);
+                    return;
+                }
+
                 if (_currentState == ConnectionState.Connecting && progress.Connected)
                     UpdateState(ConnectionState.Connected);
             };
@@ -751,14 +780,58 @@ namespace WireSockUI.Forms
                 if (e.Error != null)
                 {
                     Trace.TraceWarning($"Tunnel connection monitor stopped unexpectedly: {e.Error.Message}");
+                    _ = HandleTunnelQueryFailureAsync(CurrentTunnelGeneration(),
+                        $"Tunnel connection monitor stopped unexpectedly: {e.Error.Message}");
                     return;
                 }
 
-                if (_currentState == ConnectionState.Connecting && !_wiresock.Connected && !worker.IsBusy)
+                if (_currentState == ConnectionState.Connecting &&
+                    _wiresock.TryGetConnected(out var connected, out _) &&
+                    !connected && !worker.IsBusy)
                     worker.RunWorkerAsync(CurrentTunnelGeneration());
             };
 
             return worker;
+        }
+
+        private async Task HandleTunnelQueryFailureAsync(int generation, string diagnostic)
+        {
+            while (!TryBeginTunnelOperation(false))
+            {
+                if (ShouldStopTunnelFailureHandling(generation))
+                    return;
+
+                await Task.Delay(100);
+            }
+
+            try
+            {
+                if (ShouldStopTunnelFailureHandling(generation))
+                    return;
+
+                Trace.TraceWarning($"Native tunnel state query failed: {diagnostic}");
+                var profile = _wiresock.ProfileName;
+                if (!await DisconnectCurrentTunnelAsync(false))
+                {
+                    HandleNativeCleanupFailure(profile, "native tunnel query failure cleanup", _wiresock.LastError);
+                    return;
+                }
+
+                if (!_shutdownComplete)
+                    MessageBox.Show(
+                        $"WireSock UI could not query the native tunnel state.{Environment.NewLine}{Environment.NewLine}{diagnostic}",
+                        Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+            finally
+            {
+                EndTunnelOperation();
+            }
+        }
+
+        private bool ShouldStopTunnelFailureHandling(int generation)
+        {
+            return _shutdownComplete || IsDisposed || Disposing || IsNativeRecoveryRequired() ||
+                   generation != CurrentTunnelGeneration() || _currentState == ConnectionState.Disconnected;
         }
 
         private async Task HandleTunnelConnectionTimeoutAsync(int generation)
@@ -805,7 +878,12 @@ namespace WireSockUI.Forms
                 _currentState != ConnectionState.Connecting || !IsTunnelConnectionTimedOut(generation))
                 return;
 
-            await DisconnectCurrentTunnelAsync(false);
+            var profile = _wiresock.ProfileName;
+            if (!await DisconnectCurrentTunnelAsync(false))
+            {
+                HandleNativeCleanupFailure(profile, "tunnel connection timeout cleanup", _wiresock.LastError);
+                return;
+            }
 
             if (!_shutdownComplete)
                 MessageBox.Show(Resources.TunnelConnectTimeout, Resources.TunnelErrorTitle, MessageBoxButtons.OK,
@@ -906,7 +984,8 @@ namespace WireSockUI.Forms
 
             try
             {
-                if (TryGetCompletedConnectResult(connectTask, out result) && result.Connected)
+                var resultAvailable = TryGetCompletedConnectResult(connectTask, out result);
+                if (resultAvailable && result.Connected)
                 {
                     var disconnected = await DisconnectNativeTunnelAsync(result.ConnectionSequence, false);
                     if (!disconnected)
@@ -915,6 +994,13 @@ namespace WireSockUI.Forms
                             $"Timed-out tunnel sequence {result.ConnectionSequence} could not be disconnected. The tunnel may still be active.");
                         cleanupFailed = true;
                     }
+                }
+                else if (_wiresock.HasTunnelHandle &&
+                         !await DisconnectNativeTunnelAsync(null, false))
+                {
+                    Trace.TraceWarning(
+                        "A timed-out failed connect retained a native tunnel handle that could not be released.");
+                    cleanupFailed = true;
                 }
             }
             catch (Exception ex)
@@ -973,9 +1059,30 @@ namespace WireSockUI.Forms
                         return;
                     }
 
-                    if (!_wiresock.Connected) continue;
+                    if (!_wiresock.TryGetConnected(out var connected, out var stateDiagnostic))
+                    {
+                        worker.ReportProgress(0, new TunnelStateProgress
+                        {
+                            Generation = generation,
+                            Diagnostic = stateDiagnostic ?? "Unable to query the native tunnel state."
+                        });
+                        e.Cancel = true;
+                        return;
+                    }
 
-                    var stats = _wiresock.GetState();
+                    if (!connected) continue;
+
+                    if (!_wiresock.TryGetState(out var stats, out var statsDiagnostic))
+                    {
+                        worker.ReportProgress(0, new TunnelStateProgress
+                        {
+                            Generation = generation,
+                            Diagnostic = statsDiagnostic ?? "Unable to query native tunnel statistics."
+                        });
+                        e.Cancel = true;
+                        return;
+                    }
+
                     worker.ReportProgress(0, new TunnelStateProgress
                     {
                         Generation = generation,
@@ -989,6 +1096,12 @@ namespace WireSockUI.Forms
                 if (_shutdownComplete || !(e.UserState is TunnelStateProgress progress) ||
                     progress.Generation != CurrentTunnelGeneration() || _currentState != ConnectionState.Connected)
                     return;
+
+                if (!string.IsNullOrWhiteSpace(progress.Diagnostic))
+                {
+                    _ = HandleTunnelQueryFailureAsync(progress.Generation, progress.Diagnostic);
+                    return;
+                }
 
                 var stats = progress.Stats;
 
@@ -1015,10 +1128,14 @@ namespace WireSockUI.Forms
                 if (e.Error != null)
                 {
                     Trace.TraceWarning($"Tunnel state monitor stopped unexpectedly: {e.Error.Message}");
+                    _ = HandleTunnelQueryFailureAsync(CurrentTunnelGeneration(),
+                        $"Tunnel state monitor stopped unexpectedly: {e.Error.Message}");
                     return;
                 }
 
-                if (_currentState == ConnectionState.Connected && _wiresock.Connected && !worker.IsBusy)
+                if (_currentState == ConnectionState.Connected &&
+                    _wiresock.TryGetConnected(out var connected, out _) &&
+                    connected && !worker.IsBusy)
                     worker.RunWorkerAsync(CurrentTunnelGeneration());
             };
 
@@ -1318,58 +1435,78 @@ namespace WireSockUI.Forms
 
         private void OnNewProfileClick(object sender, EventArgs e)
         {
-            using (Form form = new FrmEdit())
+            if (!TryBeginTunnelOperation())
+                return;
+
+            try
             {
-                if (form.ShowDialog() == DialogResult.OK)
-                    LoadProfiles();
+                using (Form form = new FrmEdit())
+                {
+                    if (form.ShowDialog() == DialogResult.OK)
+                        LoadProfiles();
+                }
+            }
+            finally
+            {
+                EndTunnelOperation();
             }
         }
 
         private void OnAddProfileClick(object sender, EventArgs e)
         {
-            using (var openFileDialog = new OpenFileDialog())
+            if (!TryBeginTunnelOperation())
+                return;
+
+            try
             {
-                openFileDialog.Title = Resources.DialogOpenFileTitle;
-                openFileDialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Recent);
-                openFileDialog.Filter = Resources.DialogOpenFileFilter;
-                openFileDialog.RestoreDirectory = true;
-
-                if (openFileDialog.ShowDialog() != DialogResult.OK)
-                    return;
-
-                var filePath = openFileDialog.FileName;
-
-                var profileName = Path.GetFileNameWithoutExtension(filePath);
-
-                if (!Profile.IsValidProfileName(profileName))
+                using (var openFileDialog = new OpenFileDialog())
                 {
-                    MessageBox.Show(Resources.EditProfileNameError, Resources.ProfileError, MessageBoxButtons.OK,
-                        MessageBoxIcon.Error);
-                    return;
-                }
+                    openFileDialog.Title = Resources.DialogOpenFileTitle;
+                    openFileDialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Recent);
+                    openFileDialog.Filter = Resources.DialogOpenFileFilter;
+                    openFileDialog.RestoreDirectory = true;
 
-                var destinationPath = Profile.GetProfilePath(profileName);
-                if (Profile.ProfilePathExists(destinationPath))
-                {
-                    var message = Profile.IsRegularProfileFile(destinationPath, out var diagnostic)
-                        ? string.Format(Resources.AddProfileExistsMsg, profileName)
-                        : diagnostic;
+                    if (openFileDialog.ShowDialog() != DialogResult.OK)
+                        return;
 
-                    MessageBox.Show(message,
-                        Resources.AddProfileExistsTitle,
-                        MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return;
-                }
+                    var filePath = openFileDialog.FileName;
 
-                try
-                {
-                    if (ImportProfileFromFile(filePath, destinationPath))
-                        LoadProfiles(profileName);
+                    var profileName = Path.GetFileNameWithoutExtension(filePath);
+
+                    if (!Profile.IsValidProfileName(profileName))
+                    {
+                        MessageBox.Show(Resources.EditProfileNameError, Resources.ProfileError, MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
+                        return;
+                    }
+
+                    var destinationPath = Profile.GetProfilePath(profileName);
+                    if (Profile.ProfilePathExists(destinationPath))
+                    {
+                        var message = Profile.IsRegularProfileFile(destinationPath, out var diagnostic)
+                            ? string.Format(Resources.AddProfileExistsMsg, profileName)
+                            : diagnostic;
+
+                        MessageBox.Show(message,
+                            Resources.AddProfileExistsTitle,
+                            MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+
+                    try
+                    {
+                        if (ImportProfileFromFile(filePath, destinationPath))
+                            LoadProfiles(profileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show(ex.Message, Resources.ProfileError, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
                 }
-                catch (Exception ex)
-                {
-                    MessageBox.Show(ex.Message, Resources.ProfileError, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
+            }
+            finally
+            {
+                EndTunnelOperation();
             }
         }
 
@@ -1396,27 +1533,38 @@ namespace WireSockUI.Forms
 
         private void OnEditProfileClick(object sender, EventArgs e)
         {
-            if (lstProfiles.SelectedItems.Count == 0)
+            if (!TryBeginTunnelOperation())
                 return;
 
-            var profile = lstProfiles.SelectedItems[0].Text;
+            var reconnect = false;
 
             try
             {
+                if (lstProfiles.SelectedItems.Count == 0)
+                    return;
+
+                var profile = lstProfiles.SelectedItems[0].Text;
+
                 using (var form = new FrmEdit(profile))
                 {
                     if (form.ShowDialog() != DialogResult.OK) return;
 
                     LoadProfiles(form.ReturnValue);
 
-                    if (_wiresock.Connected && _wiresock.ProfileName == profile)
-                        OnProfileClick(lstProfiles, EventArgs.Empty);
+                    reconnect = _currentState == ConnectionState.Connected && _wiresock.ProfileName == profile;
                 }
             }
             catch (Exception ex)
             {
                 MessageBox.Show(ex.Message, Resources.ProfileError, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+            finally
+            {
+                EndTunnelOperation();
+            }
+
+            if (reconnect)
+                OnProfileClick(lstProfiles, EventArgs.Empty);
         }
 
         private async void OnDeleteProfileClick(object sender, EventArgs e)
@@ -1436,7 +1584,7 @@ namespace WireSockUI.Forms
                         MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) != DialogResult.Yes)
                     return;
 
-                if (_wiresock.Connected && _wiresock.ProfileName == selectedConf)
+                if (_currentState == ConnectionState.Connected && _wiresock.ProfileName == selectedConf)
                     if (!await DisconnectCurrentTunnelAsync())
                         return;
 
@@ -1457,18 +1605,33 @@ namespace WireSockUI.Forms
 
         private void OnSettingsClick(object sender, EventArgs e)
         {
-            using (var form = new FrmSettings())
+            if (!TryBeginTunnelOperation())
+                return;
+
+            try
             {
-                var previousEnableKillSwitch = Settings.Default.EnableKillSwitch;
-
-                // set the owner of the child form to the main form instance
-                form.Owner = this;
-
-                if (form.ShowDialog() == DialogResult.OK)
+                using (var form = new FrmSettings())
                 {
-                    _wiresock.LogLevel = _wiresock.LogLevelSetting;
-                    ApplyAndSaveKillSwitchSetting(form.RequestedEnableKillSwitch, previousEnableKillSwitch);
+                    var previousEnableKillSwitch = Settings.Default.EnableKillSwitch;
+
+                    // set the owner of the child form to the main form instance
+                    form.Owner = this;
+
+                    if (form.ShowDialog() == DialogResult.OK)
+                    {
+                        _wiresock.LogLevel = _wiresock.LogLevelSetting;
+                        ApplyAndSaveKillSwitchSetting(form.RequestedEnableKillSwitch, previousEnableKillSwitch);
+                    }
                 }
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Unable to apply WireSock UI settings: {ex.Message}");
+                MessageBox.Show(ex.Message, Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                EndTunnelOperation();
             }
         }
 
@@ -1676,10 +1839,15 @@ namespace WireSockUI.Forms
                     if (!_shutdownComplete && connectGeneration == CurrentTunnelGeneration() &&
                         IsTunnelConnectionTimedOut(connectGeneration))
                     {
-                        if (connected)
-                            await DisconnectNativeTunnelAsync(connectionSequence, false);
-                        else if (_wiresock.HasTunnelHandle)
-                            await DisconnectNativeTunnelAsync(null, false);
+                        var cleanupSucceeded = !connected && !_wiresock.HasTunnelHandle ||
+                                               await DisconnectNativeTunnelAsync(
+                                                   connected ? connectionSequence : (long?)null, false);
+
+                        if (!cleanupSucceeded)
+                        {
+                            HandleNativeCleanupFailure(profile, "late connection-timeout cleanup", _wiresock.LastError);
+                            return;
+                        }
 
                         UpdateState(ConnectionState.Disconnected, false, profile);
                         MessageBox.Show(Resources.TunnelConnectTimeout, Resources.TunnelErrorTitle,
@@ -1689,27 +1857,57 @@ namespace WireSockUI.Forms
 
                     if (connectGeneration != CurrentTunnelGeneration() || _shutdownComplete)
                     {
-                        if (connected)
-                            await DisconnectNativeTunnelAsync(connectionSequence, false);
+                        if ((connected || _wiresock.HasTunnelHandle) &&
+                            !await DisconnectNativeTunnelAsync(connected ? connectionSequence : (long?)null, false))
+                            HandleNativeCleanupFailure(profile, "stale connection cleanup", _wiresock.LastError);
 
                         return;
                     }
 
                     if (connected)
-                        UpdateState(_wiresock.Connected ? ConnectionState.Connected : ConnectionState.Connecting, true,
-                            profile);
+                    {
+                        if (_wiresock.TryGetConnected(out var tunnelActive, out var queryDiagnostic))
+                        {
+                            UpdateState(tunnelActive ? ConnectionState.Connected : ConnectionState.Connecting, true,
+                                profile);
+                        }
+                        else
+                        {
+                            Trace.TraceWarning($"Native tunnel state query failed after connect: {queryDiagnostic}");
+                            if (!await DisconnectNativeTunnelAsync(connectionSequence, false))
+                            {
+                                HandleNativeCleanupFailure(profile, "post-connect verification cleanup",
+                                    _wiresock.LastError ?? queryDiagnostic);
+                            }
+                            else
+                            {
+                                UpdateState(ConnectionState.Disconnected, false, profile);
+                                MessageBox.Show(
+                                    $"WireSock UI could not verify the native tunnel state.{Environment.NewLine}{Environment.NewLine}{queryDiagnostic}",
+                                    Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            }
+                        }
+                    }
                     else
                     {
                         UpdateState(ConnectionState.Disconnected, false, profile);
-                        MessageBox.Show(_wiresock.LastError ?? Resources.TunnelErrorManager, Resources.TunnelErrorTitle,
-                            MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        if (_wiresock.HasTunnelHandle)
+                            HandleNativeCleanupFailure(profile, "failed connection cleanup", _wiresock.LastError);
+                        else
+                            MessageBox.Show(_wiresock.LastError ?? Resources.TunnelErrorManager,
+                                Resources.TunnelErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
                 catch (Exception ex)
                 {
-                    UpdateState(ConnectionState.Disconnected, false, profile);
-                    MessageBox.Show(ex.Message, Resources.TunnelErrorTitle, MessageBoxButtons.OK,
-                        MessageBoxIcon.Error);
+                    if (_wiresock.HasTunnelHandle)
+                        HandleNativeCleanupFailure(profile, "unexpected connection workflow failure", ex.Message);
+                    else
+                    {
+                        UpdateState(ConnectionState.Disconnected, false, profile);
+                        MessageBox.Show(ex.Message, Resources.TunnelErrorTitle, MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
+                    }
                 }
                 finally
                 {
@@ -1869,7 +2067,7 @@ namespace WireSockUI.Forms
                     layoutState.RowStyles.Add(new RowStyle(SizeType.AutoSize));
 
                     // Only 1 profile can be active at a time, either show the active state or do not allow to activate
-                    if (_wiresock != null && _wiresock.Connected)
+                    if (_wiresock != null && _currentState == ConnectionState.Connected)
                     {
                         if (_wiresock.ProfileName == selectedConf)
                             UpdateState(ConnectionState.Connected, false);

--- a/WireSockUI/Forms/frmSettings.cs
+++ b/WireSockUI/Forms/frmSettings.cs
@@ -168,6 +168,9 @@ namespace WireSockUI.Forms
                     td.Settings.IdleSettings.StopOnIdleEnd =
                         false; // Do not stop the task when the computer ceases to be idle
 
+                    if (!IsExecutablePathTrustedForAutoRun(appPath, out trustDiagnostic))
+                        throw new InvalidOperationException(trustDiagnostic);
+
                     ts.RootFolder.RegisterTaskDefinition(GetAutoRunTaskName(), td);
                     TryDeleteAutoRunTaskIfOwned(ts, GetLegacyAutoRunTaskName());
                 }
@@ -225,19 +228,9 @@ namespace WireSockUI.Forms
                 if (!IsPathFreeOfReparsePoints(fullPath, out diagnostic))
                     return false;
 
-                if (Program.IsPotentiallyUserWritableFile(fullPath))
+                if (!Program.TryValidateTrustedFilePath(fullPath, "Autorun executable", out diagnostic))
                 {
-                    diagnostic =
-                        $"Autorun executable '{fullPath}' is writable by or owned by non-administrative users. Install WireSock UI into an administrator-owned folder before enabling elevated autorun.";
-                    return false;
-                }
-
-                var directory = Path.GetDirectoryName(fullPath);
-                if (string.IsNullOrWhiteSpace(directory) ||
-                    Program.IsPotentiallyUserWritableDirectory(directory))
-                {
-                    diagnostic =
-                        $"Autorun executable folder '{directory}' is writable by or owned by non-administrative users. Install WireSock UI into an administrator-owned folder before enabling elevated autorun.";
+                    diagnostic += " Install WireSock UI into an administrator-owned folder before enabling elevated autorun.";
                     return false;
                 }
 

--- a/WireSockUI/Global.cs
+++ b/WireSockUI/Global.cs
@@ -332,8 +332,8 @@ namespace WireSockUI
                 }
                 catch (Exception ex)
                 {
-                    Trace.TraceWarning($"Unable to enumerate WireSock UI configuration files in '{directory}': {ex.Message}");
-                    files = Array.Empty<string>();
+                    throw new IOException(
+                        $"Unable to enumerate WireSock UI configuration files in '{directory}'.", ex);
                 }
 
                 foreach (var file in files)
@@ -350,7 +350,8 @@ namespace WireSockUI
                     }
                     catch (Exception ex)
                     {
-                        Trace.TraceWarning($"Failed to secure WireSock UI configuration file '{file}': {ex.Message}");
+                        throw new UnauthorizedAccessException(
+                            $"Failed to secure WireSock UI configuration file '{file}'.", ex);
                     }
                 }
 
@@ -361,9 +362,8 @@ namespace WireSockUI
                 }
                 catch (Exception ex)
                 {
-                    Trace.TraceWarning(
-                        $"Unable to enumerate WireSock UI configuration directories in '{directory}': {ex.Message}");
-                    continue;
+                    throw new IOException(
+                        $"Unable to enumerate WireSock UI configuration directories in '{directory}'.", ex);
                 }
 
                 foreach (var childDirectory in childDirectories)
@@ -373,10 +373,8 @@ namespace WireSockUI
                         continue;
 
                     if (IsReparsePoint(childDirectory))
-                    {
-                        Trace.TraceWarning($"Skipping WireSock UI configuration directory reparse point '{childDirectory}'.");
-                        continue;
-                    }
+                        throw new IOException(
+                            $"Refusing to secure WireSock UI configuration directory reparse point '{childDirectory}'.");
 
                     try
                     {
@@ -385,8 +383,8 @@ namespace WireSockUI
                     }
                     catch (Exception ex)
                     {
-                        Trace.TraceWarning(
-                            $"Failed to secure WireSock UI configuration directory '{childDirectory}': {ex.Message}");
+                        throw new UnauthorizedAccessException(
+                            $"Failed to secure WireSock UI configuration directory '{childDirectory}'.", ex);
                     }
                 }
             }
@@ -454,17 +452,13 @@ namespace WireSockUI
             }
             catch (Exception ex)
             {
-                Trace.TraceWarning(
-                    $"Skipping WireSock UI configuration file reparse point '{file}' because its attributes could not be inspected: {ex.Message}");
-                return;
+                throw new IOException(
+                    $"Unable to inspect WireSock UI configuration file reparse point '{file}'.", ex);
             }
 
             if ((attributes & FileAttributes.ReparsePoint) == 0)
-            {
-                Trace.TraceWarning(
-                    $"Skipping WireSock UI configuration file '{file}' because it is no longer a reparse point.");
-                return;
-            }
+                throw new IOException(
+                    $"WireSock UI configuration file '{file}' changed while its reparse-point status was being validated.");
 
             try
             {
@@ -473,8 +467,8 @@ namespace WireSockUI
             }
             catch (Exception ex)
             {
-                Trace.TraceWarning(
-                    $"Skipping WireSock UI configuration file reparse point '{file}' because it could not be deleted: {ex.Message}");
+                throw new IOException(
+                    $"WireSock UI configuration file reparse point '{file}' could not be deleted.", ex);
             }
         }
     }

--- a/WireSockUI/Native/IWireSockNativeApi.cs
+++ b/WireSockUI/Native/IWireSockNativeApi.cs
@@ -1,0 +1,94 @@
+using System;
+using static WireSockUI.Native.WireguardBoosterExports;
+
+namespace WireSockUI.Native
+{
+    internal interface IWireSockNativeApi
+    {
+        IntPtr GetHandle(WireSockManager.Mode mode, LogPrinter logPrinter, WgbLogLevel logLevel,
+            bool enableTrafficCapture);
+
+        void SetLogLevel(WireSockManager.Mode mode, IntPtr handle, WgbLogLevel logLevel);
+        bool CreateTunnelFromFile(WireSockManager.Mode mode, IntPtr handle, string fileName);
+        bool StartTunnel(WireSockManager.Mode mode, IntPtr handle);
+        bool StopTunnel(WireSockManager.Mode mode, IntPtr handle);
+        bool DropTunnel(WireSockManager.Mode mode, IntPtr handle, bool preserveNetworkLock);
+        bool GetTunnelActive(WireSockManager.Mode mode, IntPtr handle);
+        WgbStats GetTunnelState(WireSockManager.Mode mode, IntPtr handle);
+        bool SetNetworkLockMode(WireSockManager.Mode mode, IntPtr handle, WgbNetworkLockMode networkLockMode);
+        WgbNetworkLockMode GetNetworkLockMode(WireSockManager.Mode mode, IntPtr handle);
+    }
+
+    internal sealed class WireSockNativeApi : IWireSockNativeApi
+    {
+        public IntPtr GetHandle(WireSockManager.Mode mode, LogPrinter logPrinter, WgbLogLevel logLevel,
+            bool enableTrafficCapture)
+        {
+            return IsVirtualAdapter(mode)
+                ? wgbp_get_handle(logPrinter, logLevel, enableTrafficCapture)
+                : wgb_get_handle(logPrinter, logLevel, enableTrafficCapture);
+        }
+
+        public void SetLogLevel(WireSockManager.Mode mode, IntPtr handle, WgbLogLevel logLevel)
+        {
+            if (IsVirtualAdapter(mode))
+                wgbp_set_log_level(handle, logLevel);
+            else
+                wgb_set_log_level(handle, logLevel);
+        }
+
+        public bool CreateTunnelFromFile(WireSockManager.Mode mode, IntPtr handle, string fileName)
+        {
+            return IsVirtualAdapter(mode)
+                ? wgbp_create_tunnel_from_file_w(handle, fileName)
+                : wgb_create_tunnel_from_file_w(handle, fileName);
+        }
+
+        public bool StartTunnel(WireSockManager.Mode mode, IntPtr handle)
+        {
+            return IsVirtualAdapter(mode) ? wgbp_start_tunnel(handle) : wgb_start_tunnel(handle);
+        }
+
+        public bool StopTunnel(WireSockManager.Mode mode, IntPtr handle)
+        {
+            return IsVirtualAdapter(mode) ? wgbp_stop_tunnel(handle) : wgb_stop_tunnel(handle);
+        }
+
+        public bool DropTunnel(WireSockManager.Mode mode, IntPtr handle, bool preserveNetworkLock)
+        {
+            return IsVirtualAdapter(mode)
+                ? wgbp_drop_tunnel(handle, preserveNetworkLock)
+                : wgb_drop_tunnel(handle, preserveNetworkLock);
+        }
+
+        public bool GetTunnelActive(WireSockManager.Mode mode, IntPtr handle)
+        {
+            return IsVirtualAdapter(mode) ? wgbp_get_tunnel_active(handle) : wgb_get_tunnel_active(handle);
+        }
+
+        public WgbStats GetTunnelState(WireSockManager.Mode mode, IntPtr handle)
+        {
+            return IsVirtualAdapter(mode) ? wgbp_get_tunnel_state(handle) : wgb_get_tunnel_state(handle);
+        }
+
+        public bool SetNetworkLockMode(WireSockManager.Mode mode, IntPtr handle,
+            WgbNetworkLockMode networkLockMode)
+        {
+            return IsVirtualAdapter(mode)
+                ? wgbp_set_network_lock_mode(handle, networkLockMode)
+                : wgb_set_network_lock_mode(handle, networkLockMode);
+        }
+
+        public WgbNetworkLockMode GetNetworkLockMode(WireSockManager.Mode mode, IntPtr handle)
+        {
+            return IsVirtualAdapter(mode)
+                ? wgbp_get_network_lock_mode(handle)
+                : wgb_get_network_lock_mode(handle);
+        }
+
+        private static bool IsVirtualAdapter(WireSockManager.Mode mode)
+        {
+            return mode == WireSockManager.Mode.VirtualAdapter;
+        }
+    }
+}

--- a/WireSockUI/Native/NativeCall.cs
+++ b/WireSockUI/Native/NativeCall.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace WireSockUI.Native
+{
+    internal static class NativeCall
+    {
+        [DllImport("kernel32.dll", EntryPoint = "SetLastError")]
+        private static extern void SetLastErrorNative(uint errorCode);
+
+        public static void ClearLastError()
+        {
+            SetLastErrorNative(0);
+        }
+
+        public static string GetLastErrorDiagnostic()
+        {
+            return FormatError(Marshal.GetLastWin32Error());
+        }
+
+        public static bool TryQuery<T>(Func<T> query, Func<T, bool> isErrorSentinel, out T value,
+            out string diagnostic)
+        {
+            return TryQuery(query, isErrorSentinel, ClearLastError, Marshal.GetLastWin32Error, out value,
+                out diagnostic);
+        }
+
+        internal static bool TryQuery<T>(Func<T> query, Func<T, bool> isErrorSentinel, Action clearLastError,
+            Func<int> getLastError, out T value, out string diagnostic)
+        {
+            if (query == null) throw new ArgumentNullException(nameof(query));
+            if (isErrorSentinel == null) throw new ArgumentNullException(nameof(isErrorSentinel));
+            if (clearLastError == null) throw new ArgumentNullException(nameof(clearLastError));
+            if (getLastError == null) throw new ArgumentNullException(nameof(getLastError));
+
+            clearLastError();
+            value = query();
+
+            if (!isErrorSentinel(value))
+            {
+                diagnostic = null;
+                return true;
+            }
+
+            diagnostic = FormatError(getLastError());
+            return diagnostic == null;
+        }
+
+        private static string FormatError(int error)
+        {
+            return error == 0 ? null : $"Native error {error}: {new Win32Exception(error).Message}";
+        }
+    }
+}

--- a/WireSockUI/Native/WindowsApplicationContext.cs
+++ b/WireSockUI/Native/WindowsApplicationContext.cs
@@ -22,8 +22,8 @@ namespace WireSockUI.Native
 
         public string AppUserModelId { get; }
 
-        [DllImport("shell32.dll", SetLastError = true)]
-        private static extern void SetCurrentProcessExplicitAppUserModelID(
+        [DllImport("shell32.dll")]
+        private static extern int SetCurrentProcessExplicitAppUserModelID(
             [MarshalAs(UnmanagedType.LPWStr)] string appId);
 
         public static WindowsApplicationContext FromCurrentProcess(
@@ -37,23 +37,136 @@ namespace WireSockUI.Native
             var appName = customName ?? Path.GetFileNameWithoutExtension(mainModule.FileName);
             var aumid = appUserModelId ?? BuildDefaultAppUserModelId(appName, mainModule.FileName);
 
-            SetCurrentProcessExplicitAppUserModelID(aumid);
+            var result = SetCurrentProcessExplicitAppUserModelID(aumid);
+            if (result < 0)
+                Marshal.ThrowExceptionForHR(result);
 
-            using (var shortcut = new ShellLink
-                   {
-                       TargetPath = mainModule.FileName,
-                       Arguments = string.Empty,
-                       AppUserModelId = aumid
-                   })
-            {
-                var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-                var startMenuPath = Path.Combine(appData, @"Microsoft\Windows\Start Menu\Programs");
-                var shortcutFile = Path.Combine(startMenuPath, $"{appName}.lnk");
-
-                shortcut.Save(shortcutFile);
-            }
+            EnsureNotificationShortcut(appName, aumid, mainModule.FileName);
 
             return new WindowsApplicationContext(appName, aumid);
+        }
+
+        private static void EnsureNotificationShortcut(string appName, string appUserModelId, string executablePath)
+        {
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var startMenuPath = Path.Combine(appData, @"Microsoft\Windows\Start Menu\Programs");
+            EnsureRegularDirectoryPath(startMenuPath);
+
+            var shortcutFile = Path.Combine(startMenuPath, BuildShortcutFileName(appName, executablePath));
+            if (TryGetAttributes(shortcutFile, out var shortcutAttributes))
+            {
+                if ((shortcutAttributes & (FileAttributes.Directory | FileAttributes.ReparsePoint)) != 0)
+                    throw new IOException($"Notification shortcut '{shortcutFile}' is not a regular file.");
+
+                EnsureShortcutMatches(shortcutFile, executablePath, appUserModelId);
+                return;
+            }
+
+            var stagingFile = Path.Combine(Global.SecureMainFolder,
+                $"notification-shortcut-{Guid.NewGuid():N}.lnk");
+            try
+            {
+                using (var shortcut = new ShellLink
+                {
+                    TargetPath = executablePath,
+                    Arguments = string.Empty,
+                    AppUserModelId = appUserModelId
+                })
+                {
+                    shortcut.Save(stagingFile);
+                }
+
+                try
+                {
+                    File.Copy(stagingFile, shortcutFile, false);
+                }
+                catch (IOException) when (File.Exists(shortcutFile))
+                {
+                    // Another process won the create race. Reuse it only if it is exactly ours.
+                }
+
+                EnsureShortcutMatches(shortcutFile, executablePath, appUserModelId);
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(stagingFile);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning($"Unable to delete staged notification shortcut '{stagingFile}': {ex.Message}");
+                }
+            }
+        }
+
+        private static void EnsureRegularDirectoryPath(string directory)
+        {
+            var current = Path.GetFullPath(directory);
+            while (!string.IsNullOrWhiteSpace(current))
+            {
+                var attributes = File.GetAttributes(current);
+                if ((attributes & FileAttributes.Directory) == 0)
+                    throw new IOException($"Notification shortcut ancestor '{current}' is not a directory.");
+                if ((attributes & FileAttributes.ReparsePoint) != 0)
+                    throw new IOException($"Notification shortcut ancestor '{current}' is a reparse point.");
+
+                var trimmed = current.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var parent = Path.GetDirectoryName(trimmed);
+                if (string.IsNullOrWhiteSpace(parent) ||
+                    string.Equals(parent, current, StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                current = parent;
+            }
+        }
+
+        private static void EnsureShortcutMatches(string shortcutFile, string executablePath, string appUserModelId)
+        {
+            var attributes = File.GetAttributes(shortcutFile);
+            if ((attributes & (FileAttributes.Directory | FileAttributes.ReparsePoint)) != 0)
+                throw new IOException($"Notification shortcut '{shortcutFile}' is not a regular file.");
+
+            using (var shortcut = new ShellLink(shortcutFile))
+            {
+                if (!PathsEqual(shortcut.TargetPath, executablePath) ||
+                    !string.IsNullOrEmpty(shortcut.Arguments) ||
+                    !string.Equals(shortcut.AppUserModelId, appUserModelId, StringComparison.Ordinal))
+                    throw new IOException(
+                        $"Existing notification shortcut '{shortcutFile}' does not belong to this WireSock UI installation.");
+            }
+        }
+
+        private static bool TryGetAttributes(string path, out FileAttributes attributes)
+        {
+            try
+            {
+                attributes = File.GetAttributes(path);
+                return true;
+            }
+            catch (FileNotFoundException)
+            {
+                attributes = default(FileAttributes);
+                return false;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                attributes = default(FileAttributes);
+                return false;
+            }
+        }
+
+        private static bool PathsEqual(string first, string second)
+        {
+            try
+            {
+                return string.Equals(Path.GetFullPath(first), Path.GetFullPath(second),
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static string BuildDefaultAppUserModelId(string appName, string executablePath)
@@ -78,6 +191,31 @@ namespace WireSockUI.Native
 
             var segment = builder.ToString().Trim('.');
             return string.IsNullOrWhiteSpace(segment) ? "WireSockUI" : segment;
+        }
+
+        internal static string BuildShortcutFileName(string appName, string executablePath)
+        {
+            return $"{SanitizeShortcutFileNameSegment(appName)}-{BuildPathSeed(executablePath)}.lnk";
+        }
+
+        private static string SanitizeShortcutFileNameSegment(string value)
+        {
+            const int maxSegmentLength = 80;
+            var builder = new StringBuilder();
+
+            foreach (var character in value ?? string.Empty)
+                builder.Append(char.IsLetterOrDigit(character) || character == ' ' || character == '-' ||
+                               character == '_'
+                    ? character
+                    : '_');
+
+            var segment = builder.ToString().Trim().TrimEnd('.');
+            if (string.IsNullOrWhiteSpace(segment))
+                segment = "WireSockUI";
+            if (segment.Length > maxSegmentLength)
+                segment = segment.Substring(0, maxSegmentLength).TrimEnd('.');
+
+            return segment;
         }
 
         internal static string BuildPathSeed(string path)

--- a/WireSockUI/Native/WireguardBoosterExports.cs
+++ b/WireSockUI/Native/WireguardBoosterExports.cs
@@ -6,7 +6,7 @@ namespace WireSockUI.Native
     internal static class WireguardBoosterExports
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void LogPrinter(string message);
+        public delegate void LogPrinter([MarshalAs(UnmanagedType.LPUTF8Str)] string message);
 
         public enum WgbLogLevel
         {

--- a/WireSockUI/Native/WireguardBoosterExports.cs
+++ b/WireSockUI/Native/WireguardBoosterExports.cs
@@ -1,12 +1,37 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace WireSockUI.Native
 {
     internal static class WireguardBoosterExports
     {
+        internal const int MaxLogMessageBytes = 64 * 1024;
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void LogPrinter([MarshalAs(UnmanagedType.LPUTF8Str)] string message);
+        public delegate void LogPrinter(IntPtr message);
+
+        internal static string DecodeLogMessage(IntPtr message)
+        {
+            if (message == IntPtr.Zero)
+                return string.Empty;
+
+            var length = 0;
+            while (length <= MaxLogMessageBytes && Marshal.ReadByte(message, length) != 0)
+                length++;
+
+            if (length > MaxLogMessageBytes)
+                throw new ArgumentException(
+                    $"The native log message exceeds {MaxLogMessageBytes} bytes or is not null-terminated.",
+                    nameof(message));
+
+            if (length == 0)
+                return string.Empty;
+
+            var bytes = new byte[length];
+            Marshal.Copy(message, bytes, 0, length);
+            return Encoding.UTF8.GetString(bytes);
+        }
 
         public enum WgbLogLevel
         {

--- a/WireSockUI/Native/WireguardConfigParser.cs
+++ b/WireSockUI/Native/WireguardConfigParser.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using WireSockUI.Properties;
 
 namespace WireSockUI.Native
@@ -11,7 +12,7 @@ namespace WireSockUI.Native
         public class Section
         {
             public Dictionary<string, List<string>> KeyValues { get; } =
-                new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+                new Dictionary<string, List<string>>(StringComparer.Ordinal);
 
             public bool Contains(string key)
             {
@@ -27,8 +28,15 @@ namespace WireSockUI.Native
 
         public class ConfigParser
         {
+            private static readonly HashSet<string> MultiValueKeys = new HashSet<string>(StringComparer.Ordinal)
+            {
+                "Interface\0Address", "Interface\0DNS", "Interface\0PreUp", "Interface\0PostUp",
+                "Interface\0PreDown", "Interface\0PostDown", "Peer\0AllowedIPs", "Peer\0AllowedApps",
+                "Peer\0DisallowedApps", "Peer\0DisallowedIPs"
+            };
+
             public Dictionary<string, Section> Sections { get; } =
-                new Dictionary<string, Section>(StringComparer.OrdinalIgnoreCase);
+                new Dictionary<string, Section>(StringComparer.Ordinal);
 
             public ConfigParser(string filePath)
             {
@@ -38,10 +46,31 @@ namespace WireSockUI.Native
             public void ParseConfig(string filePath)
             {
                 using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-                using (var reader = new StreamReader(fileStream))
                 {
-                    Parse(reader);
+                    RejectUnsupportedByteOrderMark(fileStream);
+                    using (var reader = new StreamReader(fileStream, new UTF8Encoding(false, true), false))
+                    {
+                        Parse(reader);
+                    }
                 }
+            }
+
+            private static void RejectUnsupportedByteOrderMark(FileStream stream)
+            {
+                var prefix = new byte[4];
+                var bytesRead = stream.Read(prefix, 0, prefix.Length);
+                stream.Position = 0;
+
+                var hasUtf8Bom = bytesRead >= 3 && prefix[0] == 0xef && prefix[1] == 0xbb && prefix[2] == 0xbf;
+                var hasUtf16Bom = bytesRead >= 2 &&
+                                  (prefix[0] == 0xff && prefix[1] == 0xfe ||
+                                   prefix[0] == 0xfe && prefix[1] == 0xff);
+                var hasUtf32BigEndianBom = bytesRead >= 4 && prefix[0] == 0 && prefix[1] == 0 &&
+                                           prefix[2] == 0xfe && prefix[3] == 0xff;
+
+                if (hasUtf8Bom || hasUtf16Bom || hasUtf32BigEndianBom)
+                    throw new FormatException(
+                        "The current wgbooster.dll parser requires a UTF-8 configuration without a byte-order mark (BOM).");
             }
 
             private void Parse(TextReader reader)
@@ -107,9 +136,12 @@ namespace WireSockUI.Native
             public Dictionary<string, string> GetSection(string sectionName)
             {
                 return Sections.TryGetValue(sectionName, out var section)
-                    ? section.KeyValues.ToDictionary(kv => kv.Key, kv => string.Join(", ", kv.Value),
-                        StringComparer.OrdinalIgnoreCase)
-                    : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    ? section.KeyValues.ToDictionary(kv => kv.Key,
+                        kv => MultiValueKeys.Contains(sectionName + "\0" + kv.Key)
+                            ? string.Join(", ", kv.Value)
+                            : kv.Value.Last(),
+                        StringComparer.Ordinal)
+                    : new Dictionary<string, string>(StringComparer.Ordinal);
             }
 
             private static bool IsComment(string line)
@@ -123,19 +155,12 @@ namespace WireSockUI.Native
                 if (!IsWireSockDirective(line))
                     return line;
 
-                var value = line.Substring(4).Trim();
-                if (value.StartsWith(":"))
-                    value = value.Substring(1).Trim();
-
-                return value;
+                return line.Substring(5).Trim();
             }
 
             private static bool IsWireSockDirective(string line)
             {
-                if (!line.StartsWith("#@ws", StringComparison.OrdinalIgnoreCase))
-                    return false;
-
-                return line.Length == 4 || line[4] == ':' || char.IsWhiteSpace(line[4]);
+                return line.StartsWith("#@ws:", StringComparison.Ordinal);
             }
         }
     }

--- a/WireSockUI/Notifications/Notifications.cs
+++ b/WireSockUI/Notifications/Notifications.cs
@@ -15,6 +15,8 @@ namespace WireSockUI.Notifications
     internal static class Notifications
     {
         private static readonly object IconSyncRoot = new object();
+        private static readonly Lazy<WindowsApplicationContext> ApplicationContext =
+            new Lazy<WindowsApplicationContext>(() => WindowsApplicationContext.FromCurrentProcess());
         private static bool _notificationIconReady;
 
         private static string EnsureNotificationIcon()
@@ -230,7 +232,7 @@ namespace WireSockUI.Notifications
         public static void Notify(string title, string body)
         {
             var icon = EnsureNotificationIcon();
-            var context = WindowsApplicationContext.FromCurrentProcess();
+            var context = ApplicationContext.Value;
             var notifier = ToastNotificationManager.CreateToastNotifier(context.AppUserModelId);
 
             var notification = new ToastNotification(GetXml(title, body, icon));

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -50,6 +50,18 @@ namespace WireSockUI
 
             try
             {
+                UpgradeUserSettings();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"Unable to migrate WireSock UI settings from the previous release.{Environment.NewLine}{Environment.NewLine}{ex.Message}",
+                    Resources.AppNoWireSockTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                Environment.Exit(1);
+            }
+
+            try
+            {
                 Global.EnsureApplicationFolders();
                 MigrateLegacyProfiles();
             }
@@ -78,6 +90,29 @@ namespace WireSockUI
             }
 
             Application.Run(new FrmMain());
+        }
+
+        private static void UpgradeUserSettings()
+        {
+            RunSettingsUpgrade(
+                Settings.Default.UpgradeRequired,
+                Settings.Default.Upgrade,
+                () => Settings.Default.UpgradeRequired = false,
+                Settings.Default.Save);
+        }
+
+        internal static void RunSettingsUpgrade(bool upgradeRequired, Action upgrade, Action markComplete, Action save)
+        {
+            if (!upgradeRequired)
+                return;
+
+            if (upgrade == null) throw new ArgumentNullException(nameof(upgrade));
+            if (markComplete == null) throw new ArgumentNullException(nameof(markComplete));
+            if (save == null) throw new ArgumentNullException(nameof(save));
+
+            upgrade();
+            markComplete();
+            save();
         }
 
         internal static void OpenBrowser(string url)
@@ -188,13 +223,6 @@ namespace WireSockUI
                 return false;
             }
 
-            if (IsPotentiallyUserWritableDirectory(fullDirectory))
-            {
-                Trace.TraceWarning(
-                    $"Skipping WireSock library directory '{fullDirectory}' because it is writable by or owned by non-administrative users.");
-                return false;
-            }
-
             var libraryPath = Path.Combine(fullDirectory, "wgbooster.dll");
             if (!TryGetExistingAttributes(libraryPath, out var libraryAttributes))
                 return false;
@@ -213,14 +241,53 @@ namespace WireSockUI
                 return false;
             }
 
-            if (IsPotentiallyUserWritableFile(libraryPath))
+            if (!TryValidateTrustedFilePath(libraryPath, "WireSock library", out var trustDiagnostic))
             {
-                Trace.TraceWarning(
-                    $"Skipping WireSock library '{libraryPath}' because it is writable by or owned by non-administrative users.");
+                Trace.TraceWarning(trustDiagnostic);
+                return false;
+            }
+
+            if (!TryValidateTrustedWireSockCompanionFiles(fullDirectory, libraryPath, out trustDiagnostic))
+            {
+                Trace.TraceWarning(trustDiagnostic);
                 return false;
             }
 
             libraryDirectory = fullDirectory;
+            return true;
+        }
+
+        private static bool TryValidateTrustedWireSockCompanionFiles(string directory, string libraryPath,
+            out string diagnostic)
+        {
+            diagnostic = null;
+            string[] files;
+
+            try
+            {
+                files = Directory.GetFiles(directory);
+            }
+            catch (Exception ex)
+            {
+                diagnostic = $"Unable to enumerate WireSock SDK companion files in '{directory}': {ex.Message}";
+                return false;
+            }
+
+            foreach (var file in files)
+            {
+                var extension = Path.GetExtension(file);
+                if (!string.Equals(extension, ".dll", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(extension, ".exe", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (string.Equals(file, libraryPath, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!TryValidateTrustedFilePath(file,
+                        $"WireSock SDK companion '{Path.GetFileName(file)}'", out diagnostic))
+                    return false;
+            }
+
             return true;
         }
 
@@ -277,15 +344,23 @@ namespace WireSockUI
                 {
                     foreach (var registryPath in registryPaths)
                     {
-                        using (var key = baseKey.OpenSubKey(registryPath))
+                        try
                         {
-                            var value = key?.GetValue("InstallLocation") as string;
-                            if (string.IsNullOrWhiteSpace(value))
-                                continue;
+                            using (var key = baseKey.OpenSubKey(registryPath))
+                            {
+                                var value = key?.GetValue("InstallLocation") as string;
+                                if (string.IsNullOrWhiteSpace(value))
+                                    continue;
 
-                            if (!locations.Exists(path =>
-                                    string.Equals(path, value, StringComparison.OrdinalIgnoreCase)))
-                                locations.Add(value);
+                                if (!locations.Exists(path =>
+                                        string.Equals(path, value, StringComparison.OrdinalIgnoreCase)))
+                                    locations.Add(value);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.TraceWarning(
+                                $"Unable to inspect WireSock install registry key '{registryPath}' in the {view} view: {ex.Message}");
                         }
                     }
                 }
@@ -693,6 +768,98 @@ namespace WireSockUI
             }
         }
 
+        internal static bool TryValidateTrustedFilePath(string file, string label, out string diagnostic)
+        {
+            diagnostic = null;
+            var normalizedFile = NormalizePathFile(file);
+            if (normalizedFile == null)
+            {
+                diagnostic = $"{label} path is invalid.";
+                return false;
+            }
+
+            if (!TryGetExistingAttributes(normalizedFile, out var fileAttributes) ||
+                (fileAttributes & FileAttributes.Directory) != 0)
+            {
+                diagnostic = $"{label} '{normalizedFile}' is not a regular file.";
+                return false;
+            }
+
+            if ((fileAttributes & FileAttributes.ReparsePoint) != 0)
+            {
+                diagnostic = $"{label} '{normalizedFile}' is a reparse point.";
+                return false;
+            }
+
+            if (IsPotentiallyUserWritableFile(normalizedFile))
+            {
+                diagnostic =
+                    $"{label} '{normalizedFile}' is writable by or owned by non-administrative users.";
+                return false;
+            }
+
+            var directory = Path.GetDirectoryName(normalizedFile);
+            var isContainingDirectory = true;
+            while (!string.IsNullOrWhiteSpace(directory))
+            {
+                if (!TryGetExistingAttributes(directory, out var directoryAttributes) ||
+                    (directoryAttributes & FileAttributes.Directory) == 0)
+                {
+                    diagnostic = $"{label} ancestor '{directory}' is not an accessible directory.";
+                    return false;
+                }
+
+                if ((directoryAttributes & FileAttributes.ReparsePoint) != 0)
+                {
+                    diagnostic = $"{label} ancestor '{directory}' is a reparse point.";
+                    return false;
+                }
+
+                var unsafeDirectory = isContainingDirectory
+                    ? IsPotentiallyUserWritableDirectory(directory)
+                    : IsPotentiallyUserReplaceableAncestor(directory);
+                if (unsafeDirectory)
+                {
+                    diagnostic =
+                        $"{label} ancestor '{directory}' can be replaced by or is owned by non-administrative users.";
+                    return false;
+                }
+
+                var trimmed = directory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var parent = Path.GetDirectoryName(trimmed);
+                if (string.IsNullOrWhiteSpace(parent) ||
+                    string.Equals(parent, directory, StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                directory = parent;
+                isContainingDirectory = false;
+            }
+
+            return true;
+        }
+
+        private static bool IsPotentiallyUserReplaceableAncestor(string directory)
+        {
+            try
+            {
+                var security = Directory.GetAccessControl(directory);
+                const FileSystemRights replacementRights =
+                    FileSystemRights.Delete |
+                    FileSystemRights.DeleteSubdirectoriesAndFiles |
+                    FileSystemRights.ChangePermissions |
+                    FileSystemRights.TakeOwnership;
+
+                return !HasTrustedOwner(security) ||
+                       ContainsPotentiallyUserWritableRule(
+                           security.GetAccessRules(true, true, typeof(SecurityIdentifier)), replacementRights);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Unable to inspect ancestor ACL for '{directory}': {ex.Message}");
+                return true;
+            }
+        }
+
         private static bool IsPotentiallyUserWritableSecurity(FileSystemSecurity security)
         {
             return !HasTrustedOwner(security) ||
@@ -717,9 +884,6 @@ namespace WireSockUI
         private static bool ContainsPotentiallyUserWritableRule(AuthorizationRuleCollection rules)
         {
             const FileSystemRights writeRights =
-                FileSystemRights.FullControl |
-                FileSystemRights.Modify |
-                FileSystemRights.Write |
                 FileSystemRights.WriteData |
                 FileSystemRights.CreateFiles |
                 FileSystemRights.AppendData |
@@ -731,6 +895,12 @@ namespace WireSockUI
                 FileSystemRights.Delete |
                 FileSystemRights.DeleteSubdirectoriesAndFiles;
 
+            return ContainsPotentiallyUserWritableRule(rules, writeRights);
+        }
+
+        private static bool ContainsPotentiallyUserWritableRule(AuthorizationRuleCollection rules,
+            FileSystemRights writeRights)
+        {
             foreach (FileSystemAccessRule rule in rules)
             {
                 if (rule.AccessControlType != AccessControlType.Allow ||
@@ -738,13 +908,11 @@ namespace WireSockUI
                     (rule.FileSystemRights & writeRights) == 0)
                     continue;
 
-                if (sid.IsWellKnown(WellKnownSidType.CreatorOwnerSid))
-                {
-                    if ((rule.PropagationFlags & PropagationFlags.InheritOnly) != 0)
-                        continue;
+                if ((rule.PropagationFlags & PropagationFlags.InheritOnly) != 0)
+                    continue;
 
+                if (sid.IsWellKnown(WellKnownSidType.CreatorOwnerSid))
                     return true;
-                }
 
                 if (!IsAdministrativeOrServiceSid(sid))
                     return true;

--- a/WireSockUI/Properties/Settings.Designer.cs
+++ b/WireSockUI/Properties/Settings.Designer.cs
@@ -136,5 +136,20 @@ namespace WireSockUI.Properties {
                 this["EnableKillSwitch"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool UpgradeRequired
+        {
+            get
+            {
+                return ((bool)(this["UpgradeRequired"]));
+            }
+            set
+            {
+                this["UpgradeRequired"] = value;
+            }
+        }
     }
 }

--- a/WireSockUI/Properties/Settings.settings
+++ b/WireSockUI/Properties/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="EnableKillSwitch" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="UpgradeRequired" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/WireSockUI/Resources/template.conf
+++ b/WireSockUI/Resources/template.conf
@@ -11,9 +11,6 @@ ListenPort = 49152
 DNS = 1.0.0.1, 1.1.1.1
 ; Optional: force this profile to use or not use virtual adapter mode
 #@ws:VirtualAdapterMode = false
-; Optional: exclude LAN traffic from the tunnel
-#@ws:BypassLanTraffic = false
-
 ; Peer Definition
 [Peer]
 PublicKey = 
@@ -22,7 +19,7 @@ PresharedKey =
 ; Peer IPv4, IPv6 or DNS endpoint with port
 Endpoint = myserver.dyndns.org:51820
 AllowedIPs = 0.0.0.0/0, ::/0
-; Optional: Send persistent keep alive packets every 5 minutes (900 sec)
+; Optional: Send persistent keep alive packets every 15 minutes (900 sec)
 PersistentKeepalive = 900
 
 ; WireSock extensions

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Management;
 using System.Runtime.InteropServices;
 using WireSockUI.Config;
+using WireSockUI.Native;
 using WireSockUI.Properties;
 using static WireSockUI.Native.WireguardBoosterExports;
 
@@ -41,6 +42,7 @@ namespace WireSockUI
         }
 
         private readonly LogPrinter _logPrinter;
+        private readonly IWireSockNativeApi _nativeApi;
 
         private const int MaxQueuedLogMessages = 1000;
         private readonly BlockingCollection<LogMessage> _logQueue;
@@ -61,7 +63,13 @@ namespace WireSockUI
         ///     <see cref="T:LogMessageCallback" />
         /// </param>
         public WireSockManager(LogMessageCallback logMessageCallback = null)
+            : this(new WireSockNativeApi(), logMessageCallback)
         {
+        }
+
+        internal WireSockManager(IWireSockNativeApi nativeApi, LogMessageCallback logMessageCallback = null)
+        {
+            _nativeApi = nativeApi ?? throw new ArgumentNullException(nameof(nativeApi));
             _logQueue = new BlockingCollection<LogMessage>(
                 new ConcurrentQueue<LogMessage>(),
                 MaxQueuedLogMessages);
@@ -101,34 +109,6 @@ namespace WireSockUI
                     if (_handle != IntPtr.Zero)
                         throw new InvalidOperationException(
                             "Adapter mode cannot be changed while a tunnel handle is still allocated. Disconnect and retry.");
-
-                    switch (value)
-                    {
-                        case Mode.VirtualAdapter:
-                            _getHandle = wgbp_get_handle;
-                            _setLogLevel = wgbp_set_log_level;
-                            _createTunnelFromFile = wgbp_create_tunnel_from_file_w;
-                            _startTunnel = wgbp_start_tunnel;
-                            _stopTunnel = wgbp_stop_tunnel;
-                            _dropTunnel = wgbp_drop_tunnel;
-                            _tunnelActive = wgbp_get_tunnel_active;
-                            _tunnelState = wgbp_get_tunnel_state;
-                            _setNetworkLockMode = wgbp_set_network_lock_mode;
-                            _getNetworkLockMode = wgbp_get_network_lock_mode;
-                            break;
-                        default:
-                            _getHandle = wgb_get_handle;
-                            _setLogLevel = wgb_set_log_level;
-                            _createTunnelFromFile = wgb_create_tunnel_from_file_w;
-                            _startTunnel = wgb_start_tunnel;
-                            _stopTunnel = wgb_stop_tunnel;
-                            _dropTunnel = wgb_drop_tunnel;
-                            _tunnelActive = wgb_get_tunnel_active;
-                            _tunnelState = wgb_get_tunnel_state;
-                            _setNetworkLockMode = wgb_set_network_lock_mode;
-                            _getNetworkLockMode = wgb_get_network_lock_mode;
-                            break;
-                    }
 
                     _adapterMode = value;
                 }
@@ -170,8 +150,8 @@ namespace WireSockUI
                     _logLevel = value;
 
                     // Update loglevel directly if instantiated
-                    if (_handle != IntPtr.Zero && _setLogLevel != null)
-                        _setLogLevel(_handle, value);
+                    if (_handle != IntPtr.Zero)
+                        _nativeApi.SetLogLevel(_adapterMode, _handle, value);
                 }
             }
         }
@@ -183,20 +163,32 @@ namespace WireSockUI
         {
             get
             {
-                lock (_syncRoot)
-                {
-                    if (_handle != IntPtr.Zero)
-                    {
-                        try
-                        {
-                            return _tunnelActive(_handle);
-                        }
-                        catch (Exception ex)
-                        {
-                            PrintLog($"Failed to query tunnel state: {ex.Message}");
-                        }
-                    }
+                if (TryGetConnected(out var connected, out var diagnostic))
+                    return connected;
 
+                PrintLog($"Failed to query tunnel state: {diagnostic}");
+                return false;
+            }
+        }
+
+        public bool TryGetConnected(out bool connected, out string diagnostic)
+        {
+            lock (_syncRoot)
+            {
+                connected = false;
+                diagnostic = null;
+
+                if (_handle == IntPtr.Zero)
+                    return true;
+
+                try
+                {
+                    return NativeCall.TryQuery(() => _nativeApi.GetTunnelActive(_adapterMode, _handle), value => !value, out connected,
+                        out diagnostic);
+                }
+                catch (Exception ex)
+                {
+                    diagnostic = ex.Message;
                     return false;
                 }
             }
@@ -263,21 +255,28 @@ namespace WireSockUI
                 if (_handle == IntPtr.Zero)
                     return true;
 
-                if (_getNetworkLockMode == null)
-                {
-                    enabled = false;
-                    return true;
-                }
-
                 try
                 {
-                    enabled = _getNetworkLockMode(_handle) == WgbNetworkLockMode.Enabled;
+                    if (!NativeCall.TryQuery(() => _nativeApi.GetNetworkLockMode(_adapterMode, _handle),
+                            value => value == WgbNetworkLockMode.Disabled, out var mode, out diagnostic))
+                    {
+                        PrintLog($"Failed to query kill switch network lock mode: {diagnostic}");
+                        return false;
+                    }
+
+                    if (mode != WgbNetworkLockMode.Disabled && mode != WgbNetworkLockMode.Enabled)
+                    {
+                        diagnostic = $"The native SDK returned an unsupported network lock mode value: {(int)mode}.";
+                        PrintLog($"Failed to query kill switch network lock mode: {diagnostic}");
+                        return false;
+                    }
+
+                    enabled = mode == WgbNetworkLockMode.Enabled;
                     return true;
                 }
-                catch (EntryPointNotFoundException)
+                catch (EntryPointNotFoundException ex)
                 {
-                    enabled = false;
-                    return true;
+                    diagnostic = $"The loaded wgbooster.dll does not expose network lock state support. {ex.Message}";
                 }
                 catch (Exception ex)
                 {
@@ -309,10 +308,14 @@ namespace WireSockUI
                 {
                     if (!Disconnect() && _handle != IntPtr.Zero)
                     {
-                        PrintLog("Forcing tunnel handle cleanup during disposal after native drop_tunnel failed.");
-                        DropCurrentHandle(true, true);
+                        PrintLog("Retrying tunnel handle cleanup during disposal after native drop_tunnel failed.");
+                        DropCurrentHandle(true);
                     }
                 }
+
+                if (disposing && _handle != IntPtr.Zero)
+                    PrintLog(
+                        "The native tunnel handle could not be released. Its logging callback will remain rooted until process exit.");
 
                 _disposed = true;
 
@@ -323,7 +326,7 @@ namespace WireSockUI
                         _logWorker.Dispose();
                 }
 
-                if (disposing && _logPrinterHandle.IsAllocated)
+                if (disposing && _handle == IntPtr.Zero && _logPrinterHandle.IsAllocated)
                     _logPrinterHandle.Free();
             }
         }
@@ -503,18 +506,22 @@ namespace WireSockUI
                             "A previous WireSock tunnel handle could not be released. Retry disconnect or restart WireSock UI before connecting again.");
 
                     if (_handle == IntPtr.Zero)
-                        _handle = _getHandle(_logPrinter, _logLevel, false);
+                    {
+                        NativeCall.ClearLastError();
+                        _handle = _nativeApi.GetHandle(_adapterMode, _logPrinter, _logLevel, false);
+                    }
 
                     if (_handle == IntPtr.Zero)
                         return ShowTunnelError(Resources.TunnelErrorManager);
 
                     if (Settings.Default.EnableKillSwitch && !SetNetworkLockMode(true))
                     {
-                        DropCurrentHandle(true, true);
+                        DropFailedConnectHandle();
                         return false;
                     }
 
-                    if (!_createTunnelFromFile(_handle, profilePath))
+                    NativeCall.ClearLastError();
+                    if (!_nativeApi.CreateTunnelFromFile(_adapterMode, _handle, profilePath))
                     {
                         ShowTunnelError(Resources.TunnelErrorCreate);
 
@@ -522,7 +529,8 @@ namespace WireSockUI
                         return false;
                     }
 
-                    if (!_startTunnel(_handle))
+                    NativeCall.ClearLastError();
+                    if (!_nativeApi.StartTunnel(_adapterMode, _handle))
                     {
                         ShowTunnelError(Resources.TunnelErrorStart);
 
@@ -589,12 +597,15 @@ namespace WireSockUI
         {
             lock (_syncRoot)
             {
+                LastError = null;
+
                 if (_handle == IntPtr.Zero)
                     return true;
 
                 try
                 {
-                    if (!_stopTunnel(_handle))
+                    NativeCall.ClearLastError();
+                    if (!_nativeApi.StopTunnel(_adapterMode, _handle))
                         PrintLog(
                             $"Failed to stop tunnel cleanly: {GetLastNativeErrorOrDefault("native stop_tunnel returned false.")}");
                 }
@@ -619,22 +630,43 @@ namespace WireSockUI
         /// </returns>
         public WgbStats GetState()
         {
+            if (TryGetState(out var state, out var diagnostic))
+                return state;
+
+            PrintLog($"Failed to read tunnel statistics: {diagnostic}");
+            return new WgbStats();
+        }
+
+        public bool TryGetState(out WgbStats state, out string diagnostic)
+        {
             lock (_syncRoot)
             {
-                if (_handle != IntPtr.Zero)
-                {
-                    try
-                    {
-                        return _tunnelState(_handle);
-                    }
-                    catch (Exception ex)
-                    {
-                        PrintLog($"Failed to read tunnel statistics: {ex.Message}");
-                    }
-                }
+                state = new WgbStats();
+                diagnostic = null;
 
-                return new WgbStats();
+                if (_handle == IntPtr.Zero)
+                    return true;
+
+                try
+                {
+                    return NativeCall.TryQuery(() => _nativeApi.GetTunnelState(_adapterMode, _handle), IsEmptyStats, out state,
+                        out diagnostic);
+                }
+                catch (Exception ex)
+                {
+                    diagnostic = ex.Message;
+                    return false;
+                }
             }
+        }
+
+        private static bool IsEmptyStats(WgbStats stats)
+        {
+            return stats.time_since_last_handshake == 0 &&
+                   stats.tx_bytes == 0 &&
+                   stats.rx_bytes == 0 &&
+                   Math.Abs(stats.estimated_loss) < float.Epsilon &&
+                   stats.estimated_rtt == 0;
         }
 
         /// <summary>
@@ -673,11 +705,7 @@ namespace WireSockUI
 
         private static string GetLastNativeError()
         {
-            var error = Marshal.GetLastWin32Error();
-            if (error == 0)
-                return null;
-
-            return $"Native error {error}: {new Win32Exception(error).Message}";
+            return NativeCall.GetLastErrorDiagnostic();
         }
 
         private static string GetLastNativeErrorOrDefault(string fallback)
@@ -696,12 +724,9 @@ namespace WireSockUI
         {
             try
             {
-                if (_setNetworkLockMode == null)
-                    return ShowTunnelError("Failed to update Kill Switch network lock mode.",
-                        "The loaded wgbooster.dll does not expose network lock support.");
-
                 var mode = enabled ? WgbNetworkLockMode.Enabled : WgbNetworkLockMode.Disabled;
-                if (_setNetworkLockMode(_handle, mode))
+                NativeCall.ClearLastError();
+                if (_nativeApi.SetNetworkLockMode(_adapterMode, _handle, mode))
                     return true;
 
                 return ShowTunnelError("Failed to update Kill Switch network lock mode.",
@@ -729,6 +754,7 @@ namespace WireSockUI
 
             try
             {
+                NativeCall.ClearLastError();
                 if (wg_reset_network_lock())
                     return true;
 
@@ -759,13 +785,13 @@ namespace WireSockUI
 
             try
             {
-                active = wg_is_network_lock_active();
-                return true;
+                return NativeCall.TryQuery(wg_is_network_lock_active, value => !value, out active,
+                    out diagnostic);
             }
-            catch (EntryPointNotFoundException)
+            catch (EntryPointNotFoundException ex)
             {
-                active = false;
-                return true;
+                diagnostic = $"The loaded wgbooster.dll does not expose network lock state support. {ex.Message}";
+                return false;
             }
             catch (Exception ex)
             {
@@ -779,11 +805,18 @@ namespace WireSockUI
             if (_handle == IntPtr.Zero)
                 return;
 
-            if (!DropCurrentHandle(true, true))
-                PrintLog("Discarding failed tunnel handle after cleanup failure. Restart WireSock UI if the next connection attempt fails.");
+            if (!DropCurrentHandle(true))
+            {
+                const string cleanupError =
+                    "The failed tunnel handle could not be released. New connections are blocked until cleanup succeeds or WireSock UI is restarted.";
+                PrintLog(cleanupError);
+                LastError = string.IsNullOrWhiteSpace(LastError)
+                    ? cleanupError
+                    : $"{LastError}{Environment.NewLine}{Environment.NewLine}{cleanupError}";
+            }
         }
 
-        private bool DropCurrentHandle(bool logFailure, bool clearOnFailure = false, bool preserveNetworkLock = false)
+        private bool DropCurrentHandle(bool logFailure, bool preserveNetworkLock = false)
         {
             if (_handle == IntPtr.Zero)
                 return true;
@@ -792,24 +825,25 @@ namespace WireSockUI
 
             try
             {
-                dropped = _dropTunnel(_handle, preserveNetworkLock);
+                NativeCall.ClearLastError();
+                dropped = _nativeApi.DropTunnel(_adapterMode, _handle, preserveNetworkLock);
                 if (!dropped && logFailure)
-                    PrintLog(
-                        $"Failed to release tunnel handle: {GetLastNativeErrorOrDefault("native drop_tunnel returned false.")}");
+                    RecordHandleReleaseFailure(
+                        GetLastNativeErrorOrDefault("native drop_tunnel returned false."));
             }
             catch (EntryPointNotFoundException ex)
             {
                 if (logFailure)
-                    PrintLog($"Failed to release tunnel handle: drop_tunnel export is unavailable. {ex.Message}");
+                    RecordHandleReleaseFailure($"drop_tunnel export is unavailable. {ex.Message}");
             }
             catch (Exception ex)
             {
                 if (logFailure)
-                    PrintLog($"Failed to release tunnel handle: {ex.Message}");
+                    RecordHandleReleaseFailure(ex.Message);
             }
             finally
             {
-                if (dropped || clearOnFailure)
+                if (dropped)
                 {
                     _handle = IntPtr.Zero;
                     ProfileName = null;
@@ -819,37 +853,15 @@ namespace WireSockUI
             return dropped;
         }
 
-        #region Wireguard Boost Library
-
-        private delegate IntPtr GetHandle(LogPrinter logPrinter, WgbLogLevel logLevel, bool enableTrafficCapture);
-
-        private delegate void SetLogLevel(IntPtr handle, WgbLogLevel logLevel);
-
-        private delegate bool CreateTunnelFromFile(IntPtr handle, string fileName);
-
-        private delegate bool TunnelAction(IntPtr handle);
-
-        private delegate bool DropTunnelAction(IntPtr handle, bool preserveNetworkLock);
-
-        private delegate WgbStats TunnelState(IntPtr handle);
-
-        private delegate bool SetNetworkLockModeAction(IntPtr handle, WgbNetworkLockMode mode);
-
-        private delegate WgbNetworkLockMode GetNetworkLockModeAction(IntPtr handle);
-
-        private GetHandle _getHandle;
-        private SetLogLevel _setLogLevel;
-        private CreateTunnelFromFile _createTunnelFromFile;
-        private TunnelAction _startTunnel;
-        private TunnelAction _stopTunnel;
-        private DropTunnelAction _dropTunnel;
-        private TunnelAction _tunnelActive;
-        private TunnelState _tunnelState;
-        private SetNetworkLockModeAction _setNetworkLockMode;
-        private GetNetworkLockModeAction _getNetworkLockMode;
+        private void RecordHandleReleaseFailure(string diagnostic)
+        {
+            var message = $"Failed to release tunnel handle: {diagnostic}";
+            PrintLog(message);
+            LastError = string.IsNullOrWhiteSpace(LastError)
+                ? message
+                : $"{LastError}{Environment.NewLine}{Environment.NewLine}{message}";
+        }
 
         private Mode _adapterMode;
-
-        #endregion
     }
 }

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -79,7 +79,7 @@ namespace WireSockUI
             TunnelMode = Mode.Transparent;
 
             // Create a new instance of the LogPrinter delegate
-            _logPrinter = PrintLog;
+            _logPrinter = PrintNativeLog;
 
             // Create a GCHandle to keep the delegate alive
             _logPrinterHandle = GCHandle.Alloc(_logPrinter);
@@ -328,6 +328,28 @@ namespace WireSockUI
 
                 if (disposing && _handle == IntPtr.Zero && _logPrinterHandle.IsAllocated)
                     _logPrinterHandle.Free();
+            }
+        }
+
+        /// <summary>
+        ///     Decodes a native UTF-8 log message without relying on callback parameter marshaling.
+        /// </summary>
+        private void PrintNativeLog(IntPtr message)
+        {
+            try
+            {
+                PrintLog(WireguardBoosterExports.DecodeLogMessage(message));
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    PrintLog($"Failed to decode a native wgbooster log message: {ex.Message}");
+                }
+                catch (Exception)
+                {
+                    // No managed exception may cross the native callback boundary.
+                }
             }
         }
 

--- a/WireSockUI/WireSockUI.csproj
+++ b/WireSockUI/WireSockUI.csproj
@@ -47,8 +47,8 @@
 
   <!-- Dependencies when targeting .NET Framework -->
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net472')) ">
-    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
-    <PackageReference Include="TaskScheduler" Version="2.10.1" />
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.9" />
+    <PackageReference Include="TaskScheduler" Version="2.12.2" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Design" />


### PR DESCRIPTION
## Summary

- align the direct wgbooster.dll ABI and lifecycle with the current Secure Connect SDK, including native error sentinels, UTF-8 logs, Kill Switch state, timeout cleanup, and recovery diagnostics
- match the current SDK configuration parser and validation rules, including exact #@ws: casing, duplicate-key projection, strict UTF-8, Amnezia 2.0 H1-H4 ranges, S1-S4 padding, and Id/Ip/Ib aliases
- harden elevated DLL/profile/autorun/notification trust boundaries, settings migration, dependencies, CI, and migration documentation

## Verification

- focused harness: 71/71 passed
- x64 Release and Release UWP builds passed with warnings treated as errors
- Release and Release UWP publish passed for AnyCPU, ARM64, and x64
- Roslyn formatter verification passed for every changed C# file
- NuGet audit found no vulnerable, deprecated, or outdated packages
- the installed Secure Connect Pro SDK directory passed trust validation and its wgbooster.dll loaded through the restricted search path

## Migration notes

Configuration names are now checked using the current SDK's exact casing and #@ws: prefix. Profiles must be UTF-8 without a BOM. Direct-DLL directives that the current parser does not apply (BypassLanTraffic, Table, I1-I5, and Socks5Username) are rejected with replacement guidance.

## Remaining runtime validation

The review did not start a real tunnel, so driver traffic flow, handshake, and live Kill Switch behavior still require validation on a test machine with the installed SDK and a disposable profile.