### PR TITLE
Harden SDK monitoring and compatibility validation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - wiresock-sdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           dotnet-version: '10.x'
 
       - name: Restore
-        run: dotnet restore WireSockUI.sln /p:Platform=x64
+        run: dotnet restore WireSockUI.sln /p:Platform=x64 -m:1
 
       - name: Verify formatting
         run: dotnet format WireSockUI.sln whitespace --verify-no-changes --no-restore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           dotnet-version: '10.x'
 
       - name: Restore
-        run: dotnet restore WireSockUI.sln -p:Platform=x64
+        run: dotnet restore WireSockUI.sln -p:Platform=x64 -m:1
 
       - name: Verify formatting
         run: dotnet format WireSockUI.sln whitespace --verify-no-changes --no-restore
@@ -31,8 +31,14 @@ jobs:
       - name: Test
         run: dotnet run --project WireSockUI.Tests/WireSockUI.Tests.csproj --configuration Release --framework net472-windows -p:Platform=x64 -p:UseSharedCompilation=false --no-restore
 
+  sdk-integration:
+    uses: ./.github/workflows/sdk-integration.yml
+    secrets: inherit
+
   build-and-package:
-    needs: test
+    needs:
+      - test
+      - sdk-integration
     strategy:
       matrix:
         platform: ['AnyCPU', 'x64', 'ARM64']

--- a/.github/workflows/sdk-contract-drift.yml
+++ b/.github/workflows/sdk-contract-drift.yml
@@ -1,0 +1,51 @@
+name: WireSock SDK Contract Drift
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  compare-upstream:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout WireSockUI
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          path: wiresockui
+
+      - name: Checkout current WireSock SDK
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: Wiresock-Foundation/wiresock-vpn-client
+          path: wiresock-sdk
+
+      - name: Verify current upstream contract
+        shell: pwsh
+        run: ./wiresockui/scripts/Verify-WgboosterContract.ps1 -SdkRoot ./wiresock-sdk
+
+      - name: Detect upstream SDK contract drift
+        shell: pwsh
+        run: |
+          $pinnedRevision = (Get-Content ./wiresockui/sdk-contract/SDK_REVISION)[1].Trim()
+          $upstreamRevision = (git -C ./wiresock-sdk rev-parse HEAD).Trim()
+          if ($pinnedRevision -ne $upstreamRevision) {
+            Write-Warning "WireSock SDK moved from pinned revision $pinnedRevision to $upstreamRevision."
+          }
+
+          git diff --no-index --ignore-all-space --exit-code `
+            ./wiresockui/sdk-contract/include/wgbooster.h `
+            ./wiresock-sdk/include/wgbooster.h
+          if ($LASTEXITCODE -ne 0) {
+            throw 'The upstream wgbooster.h differs from the pinned contract. Review and update sdk-contract explicitly.'
+          }
+
+          git diff --no-index --ignore-all-space --exit-code `
+            ./wiresockui/sdk-contract/wgbooster/wgbooster.def `
+            ./wiresock-sdk/wgbooster/wgbooster.def
+          if ($LASTEXITCODE -ne 0) {
+            throw 'The upstream wgbooster.def differs from the pinned contract. Review and update sdk-contract explicitly.'
+          }

--- a/.github/workflows/sdk-integration.yml
+++ b/.github/workflows/sdk-integration.yml
@@ -2,6 +2,7 @@ name: WireSock SDK Integration
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
@@ -31,7 +32,7 @@ jobs:
           dotnet-version: '10.x'
 
       - name: Restore
-        run: dotnet restore WireSockUI.sln /p:Platform=${{ matrix.platform }}
+        run: dotnet restore WireSockUI.sln /p:Platform=${{ matrix.platform }} -m:1
 
       - name: Run elevated real-SDK lifecycle smoke test
         env:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ WireSockUI does not talk to the newer WireSock Secure Connect service API. Keep 
 - `wgbooster.dll` available next to `WireSockUI.exe` or installed through the WireSock SDK/minimal installer.
 - The WireSock driver installed and usable by the current system.
 - Administrator privileges. Starting with WireSock Secure Connect v3, the driver interface is available only to elevated users, so WireSockUI now always starts elevated.
-- An administrator-owned installation directory. Before initializing settings or diagnostics, WireSockUI validates its executable, configuration, and every top-level DLL/EXE companion. Portable copies in user-writable locations are rejected because an elevated process must not load mutable application code.
+- An administrator-owned installation directory. Before initializing settings or diagnostics, WireSockUI recursively validates its executable, configuration, payload directories, and every DLL/EXE companion without following reparse points. Portable copies in user-writable locations are rejected because an elevated process must not load mutable application code.
 
 At startup WireSockUI looks for `wgbooster.dll` in this order:
 
@@ -70,6 +70,7 @@ Bounded diagnostic logs are written to `%ProgramData%\WireSockUI\Logs\WireSockUI
 ## Building
 
 ```powershell
+dotnet restore WireSockUI.sln -p:Platform=x64 -m:1
 dotnet run --project WireSockUI.Tests\WireSockUI.Tests.csproj --configuration Release --framework net472-windows
 dotnet build WireSockUI.sln --configuration Release -p:Platform=x64 -p:UseSharedCompilation=false -m:1
 dotnet build WireSockUI.sln --configuration "Release UWP" -p:Platform=x64 -p:UseSharedCompilation=false -m:1
@@ -77,7 +78,9 @@ dotnet build WireSockUI.sln --configuration "Release UWP" -p:Platform=x64 -p:Use
 
 The single-node `-m:1` solution build avoids a silent MSBuild failure that can happen when recent .NET SDKs schedule the WinForms app and the test project reference concurrently.
 
-CI checks the direct-driver ABI against the pinned SDK contract snapshot under `sdk-contract`. The snapshot currently comes from `Wiresock-Foundation/wiresock-vpn-client` revision `aa72bc6ab8dce8f8128f74b8a6e3167b8caaf11a`; update the header, export definition, and `SDK_REVISION` together when intentionally adopting a newer SDK revision. A manual `SDK Integration` workflow runs an additional handle lifecycle smoke test on administrator-controlled, elevated self-hosted Windows runners labeled `wiresock-sdk`. Protect the `wiresock-sdk` GitHub environment with required reviewers, then configure `WIRESOCKUI_WGBOOSTER_PATH_X64` and `WIRESOCKUI_WGBOOSTER_PATH_ARM64` repository variables with trusted installed DLL paths; `WIRESOCKUI_TEST_PROFILE` is optional and enables a full start/query/stop/drop smoke test with a non-production profile.
+CI checks both the native header/export ABI and the managed P/Invoke declarations against the pinned SDK contract snapshot under `sdk-contract`. The snapshot currently comes from `Wiresock-Foundation/wiresock-vpn-client` revision `aa72bc6ab8dce8f8128f74b8a6e3167b8caaf11a`; update the header, export definition, and `SDK_REVISION` together when intentionally adopting a newer SDK revision. A scheduled workflow compares the snapshot with current upstream contract files. The `SDK Integration` workflow runs a handle lifecycle smoke test on administrator-controlled, elevated self-hosted Windows runners labeled `wiresock-sdk`; it remains manually runnable and is also a required release job. Protect the `wiresock-sdk` GitHub environment with required reviewers, then configure `WIRESOCKUI_WGBOOSTER_PATH_X64` and `WIRESOCKUI_WGBOOSTER_PATH_ARM64` repository variables with trusted installed DLL paths; `WIRESOCKUI_TEST_PROFILE` is optional and enables a full start/query/stop/drop smoke test with a non-production profile.
+
+Native state and statistics polling use bounded asynchronous queries. If `wgbooster.dll` does not return before the query timeout, WireSockUI stops issuing additional native operations, records a recovery marker, and requires recovery or restart. Startup also compares the process and `wgbooster.dll` PE architectures so x64/ARM64 mismatches are reported directly.
 
 ## Releases
 
@@ -90,9 +93,10 @@ Release tags must use the `vMAJOR.MINOR.PATCH` form. The workflow uses the repos
 
 ## Remaining Runtime Risks
 
-- The ABI contract job does not prove that the installed driver and SDK DLL work together. Keep the manual real-SDK smoke workflow available on representative x64 and ARM64 hosts.
+- The ABI contract job does not prove that the installed driver and SDK DLL work together. Keep the release-gated real-SDK smoke runners available on representative x64 and ARM64 hosts.
 - Tunnel start/stop still depends on driver state and Windows networking permissions after elevation succeeds.
-- The `WireSockUI.Tests` harness covers parser/profile validation, native error-sentinel handling, lifecycle cleanup through a deterministic native facade, ACL checks, and reparse-point rejection. Real driver and `wgbooster.dll` validation remains environment-specific and is handled by the manual SDK Integration workflow.
+- The global `WiresockClientService` event is an SDK compatibility primitive shared with the direct C++ CLI. WireSockUI rejects unexpected owners and broad ACLs, but changing to a private authenticated namespace requires a coordinated SDK change.
+- The `WireSockUI.Tests` harness covers parser/profile validation, native error-sentinel handling, lifecycle cleanup and bounded monitoring through a deterministic native facade, ACL checks, architecture matching, transactional profile renames, and reparse-point rejection. Real driver and `wgbooster.dll` validation remains environment-specific and is handled by the SDK Integration workflow.
 
 ## License
 

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -122,6 +122,7 @@ namespace WireSockUI.Tests
                 { "Tunnel monitor stops after a bounded query timeout", TunnelMonitorStopsAfterBoundedQueryTimeout },
                 { "Tunnel monitor preserves statistics query timeouts", TunnelMonitorPreservesStatisticsQueryTimeouts },
                 { "Tunnel monitor suppresses canceled query updates", TunnelMonitorSuppressesCanceledQueryUpdates },
+                { "Tunnel monitor classifies unexpected statistics failures", TunnelMonitorClassifiesUnexpectedStatisticsFailures },
                 { "Diagnostic logging redacts credentials", DiagnosticLoggingRedactsCredentials },
                 { "Diagnostic logging bounds oversized records", DiagnosticLoggingBoundsOversizedRecords },
                 { "Native query distinguishes error sentinels", NativeQueryDistinguishesErrorSentinels },
@@ -2851,6 +2852,41 @@ namespace WireSockUI.Tests
             }
         }
 
+        private static void TunnelMonitorClassifiesUnexpectedStatisticsFailures()
+        {
+            var generation = 1;
+            var updateSource = new TaskCompletionSource<TunnelMonitorUpdate>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using (var monitor = new TunnelMonitor(
+                       _ => Task.FromResult(NativeOperationResult<bool>.Success(true)),
+                       _ => Task.FromException<NativeOperationResult<WireguardBoosterExports.WgbStats>>(
+                           new InvalidOperationException("simulated statistics failure")),
+                       () => generation,
+                       update =>
+                       {
+                           updateSource.TrySetResult(update);
+                           return Task.CompletedTask;
+                       },
+                       100,
+                       100,
+                       1,
+                       1))
+            {
+                monitor.StartConnected(generation);
+                AssertTrue(updateSource.Task.Wait(2000),
+                    "Expected the monitor to report the unexpected statistics failure.");
+
+                var update = updateSource.Task.GetAwaiter().GetResult();
+                AssertTrue(update.ConnectionQuery == null,
+                    "Expected a statistics failure not to be classified as a connection query failure.");
+                AssertTrue(update.StatisticsQuery?.Succeeded == false,
+                    "Expected the unexpected failure to retain statistics-query context.");
+                AssertTrue(update.StatisticsQuery.Diagnostic.Contains("simulated statistics failure"),
+                    "Expected the original statistics failure diagnostic to be preserved.");
+            }
+        }
+
         private static void WireSockManagerRollsBackFailedLogLevelChanges()
         {
             WithTemporaryConfigFolder(() =>
@@ -2908,9 +2944,9 @@ namespace WireSockUI.Tests
                 var missingTemporary = Path.Combine(directory, "missing.tmp");
                 File.WriteAllText(rollbackOriginal, "preserved");
 
-                AssertThrows<FileNotFoundException>(
+                AssertThrows<IOException>(
                     () => ProfileFileTransaction.Commit(missingTemporary, rollbackDestination, rollbackOriginal),
-                    string.Empty);
+                    "does not exist");
                 AssertEqual("preserved", File.ReadAllText(rollbackOriginal));
                 AssertFalse(File.Exists(rollbackDestination),
                     "Expected a failed replacement to restore the original profile name.");
@@ -2930,7 +2966,19 @@ namespace WireSockUI.Tests
 
                 AssertEqual("locked", File.ReadAllText(lockedOriginal));
                 AssertFalse(File.Exists(lockedDestination),
-                    "Expected a failed original deletion to remove the new profile copy.");
+                    "Expected a failed original deletion to remove the new profile destination.");
+                AssertEqual("replacement", File.ReadAllText(lockedTemporary));
+
+                var invalidTemporary = Path.Combine(directory, "invalid.tmp");
+                var invalidDestination = Path.Combine(directory, "invalid.conf");
+                Directory.CreateDirectory(invalidTemporary);
+                AssertThrows<IOException>(
+                    () => ProfileFileTransaction.Commit(invalidTemporary, invalidDestination),
+                    "directory");
+                AssertTrue(Directory.Exists(invalidTemporary),
+                    "Expected temporary-path validation to leave the invalid source untouched.");
+                AssertFalse(File.Exists(invalidDestination),
+                    "Expected temporary-path validation to run before mutating the destination.");
             }
             finally
             {

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -2803,6 +2803,17 @@ namespace WireSockUI.Tests
                 $"Expected attribute inspection diagnostics to escape embedded NULs, got '{diagnostic}'.");
             AssertTrue(diagnostic.Contains("\\0"),
                 $"Expected attribute inspection diagnostics to include the escaped NUL marker, got '{diagnostic}'.");
+
+            AssertFalse(WireSockUI.Program.TryValidateApplicationPayloadDirectory(
+                    malformedPath, out var payloadDiagnostic),
+                "Expected malformed application payload paths to fail validation.");
+            AssertTrue(payloadDiagnostic.IndexOf("Unable to inspect file system attributes",
+                           StringComparison.OrdinalIgnoreCase) >= 0,
+                $"Expected payload validation to preserve the attribute diagnostic, got '{payloadDiagnostic}'.");
+            AssertFalse(payloadDiagnostic.Contains("\0"),
+                $"Expected payload diagnostics to escape embedded NULs, got '{payloadDiagnostic}'.");
+            AssertTrue(payloadDiagnostic.Contains("\\0"),
+                $"Expected payload diagnostics to include the escaped NUL marker, got '{payloadDiagnostic}'.");
         }
 
         private static void TunnelMonitorPreservesStatisticsQueryTimeouts()
@@ -2909,9 +2920,23 @@ namespace WireSockUI.Tests
                     "Expected a statistics failure not to be classified as a connection query failure.");
                 AssertTrue(update.StatisticsQuery?.Succeeded == false,
                     "Expected the unexpected failure to retain statistics-query context.");
+                AssertTrue(update.StatisticsQuery.Diagnostic.Contains(nameof(InvalidOperationException)),
+                    "Expected the unexpected failure diagnostic to preserve the exception type.");
                 AssertTrue(update.StatisticsQuery.Diagnostic.Contains("simulated statistics failure"),
                     "Expected the original statistics failure diagnostic to be preserved.");
             }
+
+            var emptyMessageDiagnostic = TunnelMonitor.FormatUnexpectedFailureDiagnostic(
+                "Tunnel state monitor", new InvalidOperationException(string.Empty));
+            AssertEqual("Tunnel state monitor stopped unexpectedly (InvalidOperationException).",
+                emptyMessageDiagnostic);
+
+            var malformedMessageDiagnostic = TunnelMonitor.FormatUnexpectedFailureDiagnostic(
+                "Tunnel state monitor", new InvalidOperationException("invalid\0state"));
+            AssertFalse(malformedMessageDiagnostic.Contains("\0"),
+                "Expected unexpected monitor failure diagnostics to escape embedded NULs.");
+            AssertTrue(malformedMessageDiagnostic.Contains("invalid\\0state"),
+                "Expected unexpected monitor failure diagnostics to preserve the escaped message.");
         }
 
         private static void TunnelMonitorUiDispatchAwaitsMarshaledUpdates()

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -95,6 +95,7 @@ namespace WireSockUI.Tests
                 { "Program distinguishes x64 and ARM64 PE images", ProgramDistinguishesBinaryArchitectures },
                 { "Program rejects user-writable WireSock library directories", ProgramRejectsUserWritableWireSockLibraryDirectories },
                 { "Program detects user-writable WireSock library files", ProgramDetectsUserWritableWireSockLibraryFiles },
+                { "Program reports attribute inspection failures", ProgramReportsAttributeInspectionFailures },
                 { "Program rejects an untrusted WireSock crash handler", ProgramRejectsUntrustedWireSockCrashHandler },
                 { "Program distinguishes read-only and writable ACLs", ProgramDistinguishesReadOnlyAndWritableAcls },
                 { "Program recognizes administrative owner SIDs", ProgramRecognizesAdministrativeOwnerSids },
@@ -2776,6 +2777,31 @@ namespace WireSockUI.Tests
                 AssertEqual(1, Volatile.Read(ref queryCount));
                 pendingQuery.TrySetResult(NativeOperationResult<bool>.Failure("simulated completion"));
             }
+        }
+
+        private static void ProgramReportsAttributeInspectionFailures()
+        {
+            var missingPath = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", $"{Guid.NewGuid():N}.dll");
+            AssertFalse(WireSockUI.Program.TryGetExistingAttributes(
+                    missingPath, out _, out var missingDiagnostic),
+                "Expected missing attribute inspection targets to fail.");
+            AssertTrue(missingDiagnostic == null,
+                $"Expected missing attribute inspection targets to remain silent, got '{missingDiagnostic}'.");
+
+            var malformedPath = "invalid\0wgbooster.dll";
+
+            AssertFalse(WireSockUI.Program.TryGetExistingAttributes(
+                    malformedPath, out _, out var diagnostic),
+                "Expected malformed attribute inspection to fail.");
+            AssertTrue(!string.IsNullOrWhiteSpace(diagnostic),
+                "Expected unexpected attribute inspection failures to produce a diagnostic.");
+            AssertTrue(diagnostic.IndexOf("Unable to inspect file system attributes",
+                           StringComparison.OrdinalIgnoreCase) >= 0,
+                $"Expected an actionable attribute inspection diagnostic, got '{diagnostic}'.");
+            AssertFalse(diagnostic.Contains("\0"),
+                $"Expected attribute inspection diagnostics to escape embedded NULs, got '{diagnostic}'.");
+            AssertTrue(diagnostic.Contains("\\0"),
+                $"Expected attribute inspection diagnostics to include the escaped NUL marker, got '{diagnostic}'.");
         }
 
         private static void TunnelMonitorPreservesStatisticsQueryTimeouts()

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -91,6 +91,8 @@ namespace WireSockUI.Tests
                 { "Release version parser handles SemVer tags", ReleaseVersionParserHandlesSemVerTags },
                 { "Program path normalization preserves drive roots", ProgramPathNormalizationPreservesDriveRoots },
                 { "Program rejects untrusted application payloads", ProgramRejectsUntrustedApplicationPayloads },
+                { "Program enumerates nested application payloads", ProgramEnumeratesNestedApplicationPayloads },
+                { "Program distinguishes x64 and ARM64 PE images", ProgramDistinguishesBinaryArchitectures },
                 { "Program rejects user-writable WireSock library directories", ProgramRejectsUserWritableWireSockLibraryDirectories },
                 { "Program detects user-writable WireSock library files", ProgramDetectsUserWritableWireSockLibraryFiles },
                 { "Program rejects an untrusted WireSock crash handler", ProgramRejectsUntrustedWireSockCrashHandler },
@@ -117,6 +119,9 @@ namespace WireSockUI.Tests
                 { "Secure filesystem reads text through validated handles", SecureFileSystemReadsTextThroughValidatedHandles },
                 { "Secure filesystem rejects writable hard links", SecureFileSystemRejectsWritableHardLinks },
                 { "Tunnel session coordinator enforces recovery invariants", TunnelSessionCoordinatorEnforcesRecoveryInvariants },
+                { "Tunnel monitor stops after a bounded query timeout", TunnelMonitorStopsAfterBoundedQueryTimeout },
+                { "Tunnel monitor preserves statistics query timeouts", TunnelMonitorPreservesStatisticsQueryTimeouts },
+                { "Tunnel monitor suppresses canceled query updates", TunnelMonitorSuppressesCanceledQueryUpdates },
                 { "Diagnostic logging redacts credentials", DiagnosticLoggingRedactsCredentials },
                 { "Diagnostic logging bounds oversized records", DiagnosticLoggingBoundsOversizedRecords },
                 { "Native query distinguishes error sentinels", NativeQueryDistinguishesErrorSentinels },
@@ -139,6 +144,9 @@ namespace WireSockUI.Tests
                 { "WireSock manager retains handles when cleanup fails", WireSockManagerRetainsHandlesWhenCleanupFails },
                 { "WireSock manager retries release without dropping twice", WireSockManagerRetriesReleaseWithoutDroppingTwice },
                 { "WireSock manager quarantines dropped handles", WireSockManagerQuarantinesDroppedHandles },
+                { "WireSock manager rolls back failed log-level changes", WireSockManagerRollsBackFailedLogLevelChanges },
+                { "Profile rename commits and rolls back transactionally", ProfileRenameCommitsAndRollsBackTransactionally },
+                { "Single-instance event rejects broad access", SingleInstanceEventRejectsBroadAccess },
                 { "Network lock enum matches wgbooster ABI", NetworkLockEnumMatchesWgboosterAbi },
                 { "WireSock exports use restricted DLL search", WireSockExportsUseRestrictedDllSearch },
                 { "WireSock handle booleans match the C++ ABI", WireSockHandleBooleansMatchCppAbi },
@@ -1049,6 +1057,76 @@ namespace WireSockUI.Tests
             {
                 TryDeleteDirectory(directory, true);
             }
+        }
+
+        private static void ProgramEnumeratesNestedApplicationPayloads()
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+            var localeDirectory = Path.Combine(directory, "zh-Hant");
+            var resourceAssembly = Path.Combine(localeDirectory, "Microsoft.Win32.TaskScheduler.resources.dll");
+
+            try
+            {
+                Directory.CreateDirectory(localeDirectory);
+                File.WriteAllText(Path.Combine(directory, "WireSockUI.exe"), string.Empty);
+                File.WriteAllText(resourceAssembly, string.Empty);
+
+                AssertTrue(WireSockUI.Program.TryEnumerateApplicationPayloadEntries(
+                        directory, out var files, out var directories, out var diagnostic),
+                    diagnostic ?? "Expected nested application payload enumeration to succeed.");
+                AssertTrue(files.Contains(resourceAssembly, StringComparer.OrdinalIgnoreCase),
+                    "Expected nested resource assemblies to be included in payload validation.");
+                AssertTrue(directories.Contains(localeDirectory, StringComparer.OrdinalIgnoreCase),
+                    "Expected locale directories to be included in payload validation.");
+            }
+            finally
+            {
+                TryDeleteDirectory(directory, true);
+            }
+        }
+
+        private static void ProgramDistinguishesBinaryArchitectures()
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+            var x64Path = Path.Combine(directory, "x64.dll");
+            var arm64Path = Path.Combine(directory, "arm64.dll");
+
+            try
+            {
+                Directory.CreateDirectory(directory);
+                WriteMinimalPortableExecutable(x64Path, 0x8664);
+                WriteMinimalPortableExecutable(arm64Path, 0xaa64);
+
+                AssertTrue(WindowsBinaryArchitectureInfo.TryReadPortableExecutableArchitecture(
+                        x64Path, out var x64, out var x64Diagnostic),
+                    x64Diagnostic ?? "Expected the x64 image to parse.");
+                AssertTrue(WindowsBinaryArchitectureInfo.TryReadPortableExecutableArchitecture(
+                        arm64Path, out var arm64, out var arm64Diagnostic),
+                    arm64Diagnostic ?? "Expected the ARM64 image to parse.");
+
+                AssertEqual((int)WindowsBinaryArchitecture.X64, (int)x64);
+                AssertEqual((int)WindowsBinaryArchitecture.Arm64, (int)arm64);
+                AssertTrue(WindowsBinaryArchitectureInfo.AreCompatible(x64, x64),
+                    "Expected matching PE architectures to be compatible.");
+                AssertFalse(WindowsBinaryArchitectureInfo.AreCompatible(x64, arm64),
+                    "Expected x64 and ARM64 images to be rejected as incompatible.");
+            }
+            finally
+            {
+                TryDeleteDirectory(directory, true);
+            }
+        }
+
+        private static void WriteMinimalPortableExecutable(string path, ushort machine)
+        {
+            var image = new byte[70];
+            image[0] = (byte)'M';
+            image[1] = (byte)'Z';
+            BitConverter.GetBytes(64).CopyTo(image, 0x3c);
+            image[64] = (byte)'P';
+            image[65] = (byte)'E';
+            BitConverter.GetBytes(machine).CopyTo(image, 68);
+            File.WriteAllBytes(path, image);
         }
 
         private static void ProgramRejectsUserWritableWireSockLibraryDirectories()
@@ -2656,6 +2734,232 @@ namespace WireSockUI.Tests
             });
         }
 
+        private static void TunnelMonitorStopsAfterBoundedQueryTimeout()
+        {
+            var generation = 1;
+            var queryCount = 0;
+            var pendingQuery = new TaskCompletionSource<NativeOperationResult<bool>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var updateSource = new TaskCompletionSource<TunnelMonitorUpdate>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using (var monitor = new TunnelMonitor(
+                       _ =>
+                       {
+                           Interlocked.Increment(ref queryCount);
+                           return Task.FromResult(NativeOperationResult<bool>.Timeout(
+                               "simulated native query timeout", pendingQuery.Task));
+                       },
+                       _ => Task.FromResult(NativeOperationResult<WireguardBoosterExports.WgbStats>.Success(
+                           new WireguardBoosterExports.WgbStats())),
+                       () => generation,
+                       update =>
+                       {
+                           updateSource.TrySetResult(update);
+                           return Task.CompletedTask;
+                       },
+                       10,
+                       100,
+                       1,
+                       1))
+            {
+                monitor.StartConnected(generation);
+                AssertTrue(updateSource.Task.Wait(2000), "Expected the monitor to report the timed-out query.");
+
+                var update = updateSource.Task.GetAwaiter().GetResult();
+                AssertEqual((int)TunnelMonitorUpdateKind.QueryFailed, (int)update.Kind);
+                AssertTrue(update.ConnectionQuery?.TimedOut == true,
+                    "Expected the complete timeout result, including pending completion, to be preserved.");
+
+                Thread.Sleep(25);
+                AssertEqual(1, Volatile.Read(ref queryCount));
+                pendingQuery.TrySetResult(NativeOperationResult<bool>.Failure("simulated completion"));
+            }
+        }
+
+        private static void TunnelMonitorPreservesStatisticsQueryTimeouts()
+        {
+            var generation = 1;
+            var pendingQuery = new TaskCompletionSource<NativeOperationResult<WireguardBoosterExports.WgbStats>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var updateSource = new TaskCompletionSource<TunnelMonitorUpdate>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using (var monitor = new TunnelMonitor(
+                       _ => Task.FromResult(NativeOperationResult<bool>.Success(true)),
+                       _ => Task.FromResult(NativeOperationResult<WireguardBoosterExports.WgbStats>.Timeout(
+                           "simulated statistics timeout", pendingQuery.Task)),
+                       () => generation,
+                       update =>
+                       {
+                           updateSource.TrySetResult(update);
+                           return Task.CompletedTask;
+                       },
+                       10,
+                       100,
+                       1,
+                       1))
+            {
+                monitor.StartConnected(generation);
+                AssertTrue(updateSource.Task.Wait(2000),
+                    "Expected the monitor to report the timed-out statistics query.");
+
+                var update = updateSource.Task.GetAwaiter().GetResult();
+                AssertEqual((int)TunnelMonitorUpdateKind.QueryFailed, (int)update.Kind);
+                AssertTrue(update.StatisticsQuery?.TimedOut == true,
+                    "Expected the statistics timeout and pending completion to be preserved.");
+                pendingQuery.TrySetResult(
+                    NativeOperationResult<WireguardBoosterExports.WgbStats>.Failure("simulated completion"));
+            }
+        }
+
+        private static void TunnelMonitorSuppressesCanceledQueryUpdates()
+        {
+            var generation = 1;
+            var queryStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var queryCompletion = new TaskCompletionSource<NativeOperationResult<bool>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var updateCount = 0;
+
+            using (var monitor = new TunnelMonitor(
+                       _ =>
+                       {
+                           queryStarted.TrySetResult(true);
+                           return queryCompletion.Task;
+                       },
+                       _ => Task.FromResult(NativeOperationResult<WireguardBoosterExports.WgbStats>.Success(
+                           new WireguardBoosterExports.WgbStats())),
+                       () => generation,
+                       _ =>
+                       {
+                           Interlocked.Increment(ref updateCount);
+                           return Task.CompletedTask;
+                       },
+                       100,
+                       100,
+                       1,
+                       1))
+            {
+                monitor.StartConnected(generation);
+                AssertTrue(queryStarted.Task.Wait(2000), "Expected the native query to start.");
+
+                monitor.Cancel();
+                queryCompletion.TrySetResult(NativeOperationResult<bool>.Success(false));
+                Thread.Sleep(25);
+
+                AssertEqual(0, Volatile.Read(ref updateCount));
+            }
+        }
+
+        private static void WireSockManagerRollsBackFailedLogLevelChanges()
+        {
+            WithTemporaryConfigFolder(() =>
+            {
+                var originalKillSwitch = WireSockUI.Properties.Settings.Default.EnableKillSwitch;
+                var nativeApi = new FakeWireSockNativeApi();
+                using (var manager = new WireSockManager(nativeApi))
+                {
+                    try
+                    {
+                        WireSockUI.Properties.Settings.Default.EnableKillSwitch = false;
+                        File.WriteAllText(Profile.GetProfilePath("office"), ValidConfig());
+                        manager.LogLevel = WireguardBoosterExports.WgbLogLevel.Info;
+                        AssertTrue(manager.Connect("office"), "Expected the fake tunnel to connect.");
+
+                        nativeApi.SetLogLevelFailuresRemaining = 1;
+                        AssertThrows<InvalidOperationException>(
+                            () => manager.LogLevel = WireguardBoosterExports.WgbLogLevel.Debug,
+                            "Simulated set_log_level failure");
+                        AssertEqual((int)WireguardBoosterExports.WgbLogLevel.Info, (int)manager.LogLevel);
+
+                        AssertTrue(manager.Disconnect(), "Expected the fake tunnel to disconnect.");
+                        AssertTrue(manager.Connect("office"), "Expected the fake tunnel to reconnect.");
+                        AssertEqual((int)WireguardBoosterExports.WgbLogLevel.Info,
+                            (int)nativeApi.LastCreateLogLevel);
+                    }
+                    finally
+                    {
+                        WireSockUI.Properties.Settings.Default.EnableKillSwitch = originalKillSwitch;
+                    }
+                }
+            });
+        }
+
+        private static void ProfileRenameCommitsAndRollsBackTransactionally()
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "WireSockUI.Tests", Guid.NewGuid().ToString("N"));
+            var original = Path.Combine(directory, "original.conf");
+            var destination = Path.Combine(directory, "renamed.conf");
+            var temporary = Path.Combine(directory, "profile.tmp");
+
+            try
+            {
+                Directory.CreateDirectory(directory);
+                File.WriteAllText(original, "old");
+                File.WriteAllText(temporary, "new");
+
+                ProfileFileTransaction.Commit(temporary, destination, original);
+                AssertFalse(File.Exists(original), "Expected the old profile name to disappear after commit.");
+                AssertEqual("new", File.ReadAllText(destination));
+                AssertFalse(File.Exists(temporary), "Expected the temporary profile to be consumed.");
+
+                var rollbackOriginal = Path.Combine(directory, "rollback-original.conf");
+                var rollbackDestination = Path.Combine(directory, "rollback-renamed.conf");
+                var missingTemporary = Path.Combine(directory, "missing.tmp");
+                File.WriteAllText(rollbackOriginal, "preserved");
+
+                AssertThrows<FileNotFoundException>(
+                    () => ProfileFileTransaction.Commit(missingTemporary, rollbackDestination, rollbackOriginal),
+                    string.Empty);
+                AssertEqual("preserved", File.ReadAllText(rollbackOriginal));
+                AssertFalse(File.Exists(rollbackDestination),
+                    "Expected a failed replacement to restore the original profile name.");
+
+                var lockedOriginal = Path.Combine(directory, "locked-original.conf");
+                var lockedDestination = Path.Combine(directory, "locked-renamed.conf");
+                var lockedTemporary = Path.Combine(directory, "locked.tmp");
+                File.WriteAllText(lockedOriginal, "locked");
+                File.WriteAllText(lockedTemporary, "replacement");
+                using (new FileStream(lockedOriginal, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    AssertThrows<IOException>(
+                        () => ProfileFileTransaction.Commit(
+                            lockedTemporary, lockedDestination, lockedOriginal),
+                        string.Empty);
+                }
+
+                AssertEqual("locked", File.ReadAllText(lockedOriginal));
+                AssertFalse(File.Exists(lockedDestination),
+                    "Expected a failed original deletion to remove the new profile copy.");
+            }
+            finally
+            {
+                TryDeleteDirectory(directory, true);
+            }
+        }
+
+        private static void SingleInstanceEventRejectsBroadAccess()
+        {
+            var currentUser = WindowsIdentity.GetCurrent().User;
+            var administrators = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+            var everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            var security = new EventWaitHandleSecurity();
+            security.SetOwner(currentUser);
+            security.SetAccessRuleProtection(true, false);
+            security.AddAccessRule(new EventWaitHandleAccessRule(
+                administrators, EventWaitHandleRights.FullControl, AccessControlType.Allow));
+
+            AssertTrue(FrmMain.IsSingleInstanceEventSecurityTrusted(security, currentUser, out var diagnostic),
+                diagnostic ?? "Expected an administrator-only event ACL to be trusted.");
+
+            security.AddAccessRule(new EventWaitHandleAccessRule(
+                everyone, EventWaitHandleRights.Synchronize, AccessControlType.Allow));
+            AssertFalse(FrmMain.IsSingleInstanceEventSecurityTrusted(security, currentUser, out diagnostic),
+                "Expected a globally writable/openable ownership event to be rejected.");
+            AssertTrue(diagnostic?.IndexOf("untrusted identity", StringComparison.OrdinalIgnoreCase) >= 0,
+                $"Expected an actionable event ACL diagnostic, got '{diagnostic}'.");
+        }
+
         private static void NetworkLockEnumMatchesWgboosterAbi()
         {
             AssertEqual(0, (int)WireguardBoosterExports.WgbNetworkLockMode.Disabled);
@@ -2793,6 +3097,8 @@ namespace WireSockUI.Tests
             public int TunnelStateQueryCount { get; private set; }
             public int NetworkLockQueryCount { get; private set; }
             public int SetLogLevelCount { get; private set; }
+            public int SetLogLevelFailuresRemaining { get; set; }
+            public WireguardBoosterExports.WgbLogLevel LastCreateLogLevel { get; private set; }
             public int SetNetworkLockCount { get; private set; }
             public ManualResetEventSlim DropEntered { get; set; }
             public ManualResetEventSlim ContinueDrop { get; set; }
@@ -2803,6 +3109,7 @@ namespace WireSockUI.Tests
                 SetLastErrorForTest(0);
                 GetHandleCount++;
                 LastEnableAnalytics = enableAnalytics;
+                LastCreateLogLevel = logLevel;
                 return CreateHandleResult;
             }
 
@@ -2822,6 +3129,11 @@ namespace WireSockUI.Tests
             {
                 SetLastErrorForTest(0);
                 SetLogLevelCount++;
+                if (SetLogLevelFailuresRemaining > 0)
+                {
+                    SetLogLevelFailuresRemaining--;
+                    throw new InvalidOperationException("Simulated set_log_level failure.");
+                }
             }
 
             public bool CreateTunnelFromFile(WireSockManager.Mode mode, IntPtr handle, string fileName)

--- a/WireSockUI.Tests/Program.cs
+++ b/WireSockUI.Tests/Program.cs
@@ -124,6 +124,7 @@ namespace WireSockUI.Tests
                 { "Tunnel monitor preserves statistics query timeouts", TunnelMonitorPreservesStatisticsQueryTimeouts },
                 { "Tunnel monitor suppresses canceled query updates", TunnelMonitorSuppressesCanceledQueryUpdates },
                 { "Tunnel monitor classifies unexpected statistics failures", TunnelMonitorClassifiesUnexpectedStatisticsFailures },
+                { "Tunnel monitor UI dispatch awaits marshaled updates", TunnelMonitorUiDispatchAwaitsMarshaledUpdates },
                 { "Diagnostic logging redacts credentials", DiagnosticLoggingRedactsCredentials },
                 { "Diagnostic logging bounds oversized records", DiagnosticLoggingBoundsOversizedRecords },
                 { "Native query distinguishes error sentinels", NativeQueryDistinguishesErrorSentinels },
@@ -2913,6 +2914,37 @@ namespace WireSockUI.Tests
             }
         }
 
+        private static void TunnelMonitorUiDispatchAwaitsMarshaledUpdates()
+        {
+            var actionStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var actionRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var synchronizer = new QueuedSynchronizeInvoke();
+            try
+            {
+                var dispatchTask = FrmMain.InvokeOnUiThreadAsync(synchronizer, async () =>
+                {
+                    actionStarted.TrySetResult(true);
+                    await actionRelease.Task;
+                });
+
+                AssertFalse(actionStarted.Task.IsCompleted, "Expected the queued UI callback not to run early.");
+
+                synchronizer.RunCallback();
+                AssertTrue(actionStarted.Task.Wait(2000), "Expected the marshaled UI callback to start.");
+                AssertFalse(dispatchTask.IsCompleted,
+                    "Expected the dispatch task to wait for the asynchronous UI callback.");
+
+                actionRelease.TrySetResult(true);
+                AssertTrue(dispatchTask.Wait(2000),
+                    "Expected the dispatch task to complete with the UI callback.");
+            }
+            finally
+            {
+                actionRelease.TrySetResult(true);
+            }
+        }
+
         private static void WireSockManagerRollsBackFailedLogLevelChanges()
         {
             WithTemporaryConfigFolder(() =>
@@ -3299,6 +3331,44 @@ namespace WireSockUI.Tests
             public override void Post(SendOrPostCallback callback, object state)
             {
                 // Intentionally do not dispatch posted work. The timeout helper must not post here.
+            }
+        }
+
+        private sealed class QueuedSynchronizeInvoke : ISynchronizeInvoke
+        {
+            private object[] _arguments;
+            private Delegate _callback;
+
+            public bool InvokeRequired => true;
+
+            public IAsyncResult BeginInvoke(Delegate method, object[] args)
+            {
+                _callback = method;
+                _arguments = args;
+                return Task.CompletedTask;
+            }
+
+            public object EndInvoke(IAsyncResult result)
+            {
+                return null;
+            }
+
+            public object Invoke(Delegate method, object[] args)
+            {
+                return method.DynamicInvoke(args);
+            }
+
+            public void RunCallback()
+            {
+                var callback = _callback;
+                var arguments = _arguments;
+                _callback = null;
+                _arguments = null;
+
+                if (callback == null)
+                    throw new InvalidOperationException("No UI callback is queued.");
+
+                callback.DynamicInvoke(arguments);
             }
         }
 

--- a/WireSockUI/Config/ProfileFileTransaction.cs
+++ b/WireSockUI/Config/ProfileFileTransaction.cs
@@ -12,6 +12,8 @@ namespace WireSockUI.Config
             if (string.IsNullOrWhiteSpace(destinationPath))
                 throw new ArgumentException("A destination profile path is required.", nameof(destinationPath));
 
+            Profile.EnsureRegularProfileFile(temporaryPath);
+
             if (string.IsNullOrWhiteSpace(originalPath) ||
                 string.Equals(Path.GetFullPath(originalPath), Path.GetFullPath(destinationPath),
                     StringComparison.OrdinalIgnoreCase))
@@ -33,12 +35,12 @@ namespace WireSockUI.Config
             {
                 try
                 {
-                    File.Delete(destinationPath);
+                    File.Move(destinationPath, temporaryPath);
                 }
                 catch (Exception rollbackException)
                 {
                     throw new AggregateException(
-                        "The profile rename failed and the new profile copy could not be removed.",
+                        "The profile rename failed and the temporary profile could not be restored.",
                         commitException,
                         rollbackException);
                 }

--- a/WireSockUI/Config/ProfileFileTransaction.cs
+++ b/WireSockUI/Config/ProfileFileTransaction.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+
+namespace WireSockUI.Config
+{
+    internal static class ProfileFileTransaction
+    {
+        public static void Commit(string temporaryPath, string destinationPath, string originalPath = null)
+        {
+            if (string.IsNullOrWhiteSpace(temporaryPath))
+                throw new ArgumentException("A temporary profile path is required.", nameof(temporaryPath));
+            if (string.IsNullOrWhiteSpace(destinationPath))
+                throw new ArgumentException("A destination profile path is required.", nameof(destinationPath));
+
+            if (string.IsNullOrWhiteSpace(originalPath) ||
+                string.Equals(Path.GetFullPath(originalPath), Path.GetFullPath(destinationPath),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                CommitWithoutRename(temporaryPath, destinationPath);
+                return;
+            }
+
+            Profile.EnsureRegularProfileFile(originalPath);
+            if (Profile.ProfilePathExists(destinationPath))
+                throw new IOException($"The destination profile '{destinationPath}' already exists.");
+
+            File.Move(temporaryPath, destinationPath);
+            try
+            {
+                File.Delete(originalPath);
+            }
+            catch (Exception commitException)
+            {
+                try
+                {
+                    File.Delete(destinationPath);
+                }
+                catch (Exception rollbackException)
+                {
+                    throw new AggregateException(
+                        "The profile rename failed and the new profile copy could not be removed.",
+                        commitException,
+                        rollbackException);
+                }
+
+                throw;
+            }
+        }
+
+        private static void CommitWithoutRename(string temporaryPath, string destinationPath)
+        {
+            if (Profile.ProfilePathExists(destinationPath))
+            {
+                Profile.EnsureRegularProfileFile(destinationPath);
+                File.Replace(temporaryPath, destinationPath, null);
+                return;
+            }
+
+            File.Move(temporaryPath, destinationPath);
+        }
+    }
+}

--- a/WireSockUI/Forms/TunnelLifecycleController.cs
+++ b/WireSockUI/Forms/TunnelLifecycleController.cs
@@ -150,6 +150,16 @@ namespace WireSockUI.Forms
             }, timeoutMilliseconds, "The native tunnel-state query timed out.");
         }
 
+        public Task<NativeOperationResult<WgbStats>> GetStateAsync(int timeoutMilliseconds)
+        {
+            return RunWithTimeoutAsync(() =>
+            {
+                return _manager.TryGetState(out var state, out var diagnostic)
+                    ? NativeOperationResult<WgbStats>.Success(state)
+                    : NativeOperationResult<WgbStats>.Failure(diagnostic);
+            }, timeoutMilliseconds, "The native tunnel-statistics query timed out.");
+        }
+
         public Task<NativeOperationResult<bool>> ApplyKillSwitchAsync(bool enableKillSwitch,
             int timeoutMilliseconds)
         {
@@ -226,16 +236,6 @@ namespace WireSockUI.Forms
                         "The native tunnel handle remained allocated after shutdown cleanup returned.", false)
                     : NativeOperationResult<bool>.Success(true);
             }, timeoutMilliseconds, "The native shutdown cleanup timed out.");
-        }
-
-        public bool TryGetConnected(out bool connected, out string diagnostic)
-        {
-            return _manager.TryGetConnected(out connected, out diagnostic);
-        }
-
-        public bool TryGetState(out WgbStats state, out string diagnostic)
-        {
-            return _manager.TryGetState(out state, out diagnostic);
         }
 
         internal bool TryReleasePreservedNetworkLock(out string diagnostic)

--- a/WireSockUI/Forms/TunnelMonitor.cs
+++ b/WireSockUI/Forms/TunnelMonitor.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using static WireSockUI.Native.WireguardBoosterExports;
+
+namespace WireSockUI.Forms
+{
+    internal enum TunnelMonitorUpdateKind
+    {
+        Connected,
+        ConnectionTimedOut,
+        TunnelInactive,
+        Statistics,
+        QueryFailed
+    }
+
+    internal sealed class TunnelMonitorUpdate
+    {
+        private TunnelMonitorUpdate(int generation, TunnelMonitorUpdateKind kind)
+        {
+            Generation = generation;
+            Kind = kind;
+        }
+
+        public int Generation { get; }
+        public TunnelMonitorUpdateKind Kind { get; }
+        public NativeOperationResult<bool> ConnectionQuery { get; private set; }
+        public NativeOperationResult<WgbStats> StatisticsQuery { get; private set; }
+        public WgbStats Statistics { get; private set; }
+
+        public static TunnelMonitorUpdate Connected(int generation)
+        {
+            return new TunnelMonitorUpdate(generation, TunnelMonitorUpdateKind.Connected);
+        }
+
+        public static TunnelMonitorUpdate ConnectionTimedOut(int generation)
+        {
+            return new TunnelMonitorUpdate(generation, TunnelMonitorUpdateKind.ConnectionTimedOut);
+        }
+
+        public static TunnelMonitorUpdate TunnelInactive(int generation)
+        {
+            return new TunnelMonitorUpdate(generation, TunnelMonitorUpdateKind.TunnelInactive);
+        }
+
+        public static TunnelMonitorUpdate StatisticsChanged(int generation, WgbStats statistics)
+        {
+            return new TunnelMonitorUpdate(generation, TunnelMonitorUpdateKind.Statistics)
+            {
+                Statistics = statistics
+            };
+        }
+
+        public static TunnelMonitorUpdate ConnectionQueryFailed(int generation,
+            NativeOperationResult<bool> result)
+        {
+            return new TunnelMonitorUpdate(generation, TunnelMonitorUpdateKind.QueryFailed)
+            {
+                ConnectionQuery = result
+            };
+        }
+
+        public static TunnelMonitorUpdate StatisticsQueryFailed(int generation,
+            NativeOperationResult<WgbStats> result)
+        {
+            return new TunnelMonitorUpdate(generation, TunnelMonitorUpdateKind.QueryFailed)
+            {
+                StatisticsQuery = result
+            };
+        }
+    }
+
+    internal sealed class TunnelMonitor : IDisposable
+    {
+        private readonly int _connectedPollIntervalMilliseconds;
+        private readonly int _connectionPollIntervalMilliseconds;
+        private readonly int _connectionTimeoutMilliseconds;
+        private readonly Func<int> _currentGeneration;
+        private readonly Func<int, Task<NativeOperationResult<bool>>> _getConnectedAsync;
+        private readonly Func<int, Task<NativeOperationResult<WgbStats>>> _getStateAsync;
+        private readonly object _syncRoot = new object();
+        private readonly int _queryTimeoutMilliseconds;
+        private readonly Func<TunnelMonitorUpdate, Task> _updateHandler;
+        private CancellationTokenSource _cancellation;
+        private bool _disposed;
+        private Task _monitorTask = Task.CompletedTask;
+
+        public TunnelMonitor(
+            Func<int, Task<NativeOperationResult<bool>>> getConnectedAsync,
+            Func<int, Task<NativeOperationResult<WgbStats>>> getStateAsync,
+            Func<int> currentGeneration,
+            Func<TunnelMonitorUpdate, Task> updateHandler,
+            int queryTimeoutMilliseconds,
+            int connectionTimeoutMilliseconds,
+            int connectionPollIntervalMilliseconds = 500,
+            int connectedPollIntervalMilliseconds = 1000)
+        {
+            _getConnectedAsync = getConnectedAsync ?? throw new ArgumentNullException(nameof(getConnectedAsync));
+            _getStateAsync = getStateAsync ?? throw new ArgumentNullException(nameof(getStateAsync));
+            _currentGeneration = currentGeneration ?? throw new ArgumentNullException(nameof(currentGeneration));
+            _updateHandler = updateHandler ?? throw new ArgumentNullException(nameof(updateHandler));
+
+            if (queryTimeoutMilliseconds <= 0)
+                throw new ArgumentOutOfRangeException(nameof(queryTimeoutMilliseconds));
+            if (connectionTimeoutMilliseconds <= 0)
+                throw new ArgumentOutOfRangeException(nameof(connectionTimeoutMilliseconds));
+            if (connectionPollIntervalMilliseconds <= 0)
+                throw new ArgumentOutOfRangeException(nameof(connectionPollIntervalMilliseconds));
+            if (connectedPollIntervalMilliseconds <= 0)
+                throw new ArgumentOutOfRangeException(nameof(connectedPollIntervalMilliseconds));
+
+            _queryTimeoutMilliseconds = queryTimeoutMilliseconds;
+            _connectionTimeoutMilliseconds = connectionTimeoutMilliseconds;
+            _connectionPollIntervalMilliseconds = connectionPollIntervalMilliseconds;
+            _connectedPollIntervalMilliseconds = connectedPollIntervalMilliseconds;
+        }
+
+        public void StartConnecting(int generation)
+        {
+            Start(cancellationToken => MonitorConnectingAsync(generation, cancellationToken));
+        }
+
+        public void StartConnected(int generation)
+        {
+            Start(cancellationToken => MonitorConnectedAsync(generation, cancellationToken));
+        }
+
+        public void Cancel()
+        {
+            CancellationTokenSource cancellation;
+            Task task;
+
+            lock (_syncRoot)
+            {
+                cancellation = _cancellation;
+                task = _monitorTask;
+                _cancellation = null;
+                _monitorTask = Task.CompletedTask;
+            }
+
+            CancelAndDisposeWhenComplete(cancellation, task);
+        }
+
+        public void Dispose()
+        {
+            lock (_syncRoot)
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+            }
+
+            Cancel();
+        }
+
+        private void Start(Func<CancellationToken, Task> monitor)
+        {
+            CancellationTokenSource previousCancellation;
+            Task previousTask;
+
+            lock (_syncRoot)
+            {
+                if (_disposed)
+                    throw new ObjectDisposedException(nameof(TunnelMonitor));
+
+                previousCancellation = _cancellation;
+                previousTask = _monitorTask;
+                _cancellation = new CancellationTokenSource();
+                _monitorTask = monitor(_cancellation.Token);
+            }
+
+            CancelAndDisposeWhenComplete(previousCancellation, previousTask);
+        }
+
+        private async Task MonitorConnectingAsync(int generation, CancellationToken cancellationToken)
+        {
+            var elapsed = Stopwatch.StartNew();
+
+            try
+            {
+                while (generation == _currentGeneration())
+                {
+                    await Task.Delay(_connectionPollIntervalMilliseconds, cancellationToken);
+                    if (generation != _currentGeneration())
+                        return;
+
+                    var result = await _getConnectedAsync(_queryTimeoutMilliseconds);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (generation != _currentGeneration())
+                        return;
+
+                    if (!result.Succeeded)
+                    {
+                        await _updateHandler(TunnelMonitorUpdate.ConnectionQueryFailed(generation, result));
+                        return;
+                    }
+
+                    if (result.Value)
+                    {
+                        await _updateHandler(TunnelMonitorUpdate.Connected(generation));
+                        return;
+                    }
+
+                    if (elapsed.ElapsedMilliseconds >= _connectionTimeoutMilliseconds)
+                    {
+                        await _updateHandler(TunnelMonitorUpdate.ConnectionTimedOut(generation));
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (Exception ex)
+            {
+                await PublishUnexpectedFailureAsync(generation, "Tunnel connection monitor", ex, cancellationToken);
+            }
+        }
+
+        private async Task MonitorConnectedAsync(int generation, CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (generation == _currentGeneration())
+                {
+                    await Task.Delay(_connectedPollIntervalMilliseconds, cancellationToken);
+                    if (generation != _currentGeneration())
+                        return;
+
+                    var connectedResult = await _getConnectedAsync(_queryTimeoutMilliseconds);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (generation != _currentGeneration())
+                        return;
+
+                    if (!connectedResult.Succeeded)
+                    {
+                        await _updateHandler(
+                            TunnelMonitorUpdate.ConnectionQueryFailed(generation, connectedResult));
+                        return;
+                    }
+
+                    if (!connectedResult.Value)
+                    {
+                        await _updateHandler(TunnelMonitorUpdate.TunnelInactive(generation));
+                        return;
+                    }
+
+                    var stateResult = await _getStateAsync(_queryTimeoutMilliseconds);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (generation != _currentGeneration())
+                        return;
+
+                    if (!stateResult.Succeeded)
+                    {
+                        await _updateHandler(TunnelMonitorUpdate.StatisticsQueryFailed(generation, stateResult));
+                        return;
+                    }
+
+                    await _updateHandler(TunnelMonitorUpdate.StatisticsChanged(generation, stateResult.Value));
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (Exception ex)
+            {
+                await PublishUnexpectedFailureAsync(generation, "Tunnel state monitor", ex, cancellationToken);
+            }
+        }
+
+        private async Task PublishUnexpectedFailureAsync(int generation, string context, Exception exception,
+            CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested || generation != _currentGeneration())
+                return;
+
+            await _updateHandler(TunnelMonitorUpdate.ConnectionQueryFailed(
+                generation,
+                NativeOperationResult<bool>.Failure($"{context} stopped unexpectedly: {exception.Message}")));
+        }
+
+        private static void CancelAndDisposeWhenComplete(CancellationTokenSource cancellation, Task task)
+        {
+            if (cancellation == null)
+                return;
+
+            cancellation.Cancel();
+            (task ?? Task.CompletedTask).ContinueWith(
+                completedTask =>
+                {
+                    var ignored = completedTask.Exception;
+                    cancellation.Dispose();
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+    }
+}

--- a/WireSockUI/Forms/TunnelMonitor.cs
+++ b/WireSockUI/Forms/TunnelMonitor.cs
@@ -73,6 +73,12 @@ namespace WireSockUI.Forms
 
     internal sealed class TunnelMonitor : IDisposable
     {
+        private enum FailureSource
+        {
+            ConnectionQuery,
+            StatisticsQuery
+        }
+
         private readonly int _connectedPollIntervalMilliseconds;
         private readonly int _connectionPollIntervalMilliseconds;
         private readonly int _connectionTimeoutMilliseconds;
@@ -214,12 +220,15 @@ namespace WireSockUI.Forms
             }
             catch (Exception ex)
             {
-                await PublishUnexpectedFailureAsync(generation, "Tunnel connection monitor", ex, cancellationToken);
+                await PublishUnexpectedFailureAsync(
+                    generation, "Tunnel connection monitor", FailureSource.ConnectionQuery, ex, cancellationToken);
             }
         }
 
         private async Task MonitorConnectedAsync(int generation, CancellationToken cancellationToken)
         {
+            var failureSource = FailureSource.ConnectionQuery;
+
             try
             {
                 while (generation == _currentGeneration())
@@ -228,6 +237,7 @@ namespace WireSockUI.Forms
                     if (generation != _currentGeneration())
                         return;
 
+                    failureSource = FailureSource.ConnectionQuery;
                     var connectedResult = await _getConnectedAsync(_queryTimeoutMilliseconds);
                     cancellationToken.ThrowIfCancellationRequested();
                     if (generation != _currentGeneration())
@@ -246,6 +256,7 @@ namespace WireSockUI.Forms
                         return;
                     }
 
+                    failureSource = FailureSource.StatisticsQuery;
                     var stateResult = await _getStateAsync(_queryTimeoutMilliseconds);
                     cancellationToken.ThrowIfCancellationRequested();
                     if (generation != _currentGeneration())
@@ -265,19 +276,24 @@ namespace WireSockUI.Forms
             }
             catch (Exception ex)
             {
-                await PublishUnexpectedFailureAsync(generation, "Tunnel state monitor", ex, cancellationToken);
+                await PublishUnexpectedFailureAsync(
+                    generation, "Tunnel state monitor", failureSource, ex, cancellationToken);
             }
         }
 
-        private async Task PublishUnexpectedFailureAsync(int generation, string context, Exception exception,
-            CancellationToken cancellationToken)
+        private async Task PublishUnexpectedFailureAsync(int generation, string context, FailureSource failureSource,
+            Exception exception, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested || generation != _currentGeneration())
                 return;
 
-            await _updateHandler(TunnelMonitorUpdate.ConnectionQueryFailed(
-                generation,
-                NativeOperationResult<bool>.Failure($"{context} stopped unexpectedly: {exception.Message}")));
+            var diagnostic = $"{context} stopped unexpectedly: {exception.Message}";
+            var update = failureSource == FailureSource.StatisticsQuery
+                ? TunnelMonitorUpdate.StatisticsQueryFailed(
+                    generation, NativeOperationResult<WgbStats>.Failure(diagnostic))
+                : TunnelMonitorUpdate.ConnectionQueryFailed(
+                    generation, NativeOperationResult<bool>.Failure(diagnostic));
+            await _updateHandler(update);
         }
 
         private static void CancelAndDisposeWhenComplete(CancellationTokenSource cancellation, Task task)

--- a/WireSockUI/Forms/TunnelMonitor.cs
+++ b/WireSockUI/Forms/TunnelMonitor.cs
@@ -287,13 +287,25 @@ namespace WireSockUI.Forms
             if (cancellationToken.IsCancellationRequested || generation != _currentGeneration())
                 return;
 
-            var diagnostic = $"{context} stopped unexpectedly: {exception.Message}";
+            var diagnostic = FormatUnexpectedFailureDiagnostic(context, exception);
             var update = failureSource == FailureSource.StatisticsQuery
                 ? TunnelMonitorUpdate.StatisticsQueryFailed(
                     generation, NativeOperationResult<WgbStats>.Failure(diagnostic))
                 : TunnelMonitorUpdate.ConnectionQueryFailed(
                     generation, NativeOperationResult<bool>.Failure(diagnostic));
             await _updateHandler(update);
+        }
+
+        internal static string FormatUnexpectedFailureDiagnostic(string context, Exception exception)
+        {
+            if (exception == null)
+                throw new ArgumentNullException(nameof(exception));
+
+            var exceptionType = exception.GetType().Name;
+            var exceptionMessage = (exception.Message ?? string.Empty).Replace("\0", "\\0");
+            return string.IsNullOrWhiteSpace(exceptionMessage)
+                ? $"{context} stopped unexpectedly ({exceptionType})."
+                : $"{context} stopped unexpectedly ({exceptionType}): {exceptionMessage}";
         }
 
         private static void CancelAndDisposeWhenComplete(CancellationTokenSource cancellation, Task task)

--- a/WireSockUI/Forms/frmEdit.cs
+++ b/WireSockUI/Forms/frmEdit.cs
@@ -511,18 +511,9 @@ namespace WireSockUI.Forms
 
             try
             {
-                if (Profile.ProfilePathExists(profilePath))
-                {
-                    Profile.EnsureRegularProfileFile(profilePath);
-                    File.Replace(tmpProfile, profilePath, null);
-                }
-                else
-                {
-                    File.Move(tmpProfile, profilePath);
-                }
-
-                if (isRename)
-                    TryDeleteOriginalProfile(_originalProfileName, profilePath);
+                var originalProfilePath = isRename ? Profile.GetProfilePath(_originalProfileName) : null;
+                ProfileFileTransaction.Commit(tmpProfile, profilePath, originalProfilePath);
+                tmpProfile = null;
             }
             catch (Exception ex)
             {
@@ -545,25 +536,6 @@ namespace WireSockUI.Forms
 
             ApplySyntaxHighlighting();
             return btnSave.Enabled;
-        }
-
-        private static void TryDeleteOriginalProfile(string originalProfileName, string newProfilePath)
-        {
-            try
-            {
-                var originalProfilePath = Profile.GetProfilePath(originalProfileName);
-                if (!string.Equals(Path.GetFullPath(originalProfilePath), Path.GetFullPath(newProfilePath),
-                        StringComparison.OrdinalIgnoreCase) &&
-                    Profile.ProfilePathExists(originalProfilePath))
-                {
-                    Profile.EnsureRegularProfileFile(originalProfilePath);
-                    File.Delete(originalProfilePath);
-                }
-            }
-            catch (Exception ex)
-            {
-                Trace.TraceWarning($"Failed to delete renamed profile '{originalProfileName}': {ex.Message}");
-            }
         }
 
         private static void TryDeleteTemporaryProfile(string tmpProfile)

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
@@ -866,7 +867,67 @@ namespace WireSockUI.Forms
             return true;
         }
 
-        private async Task HandleTunnelMonitorUpdateAsync(TunnelMonitorUpdate update)
+        private Task HandleTunnelMonitorUpdateAsync(TunnelMonitorUpdate update)
+        {
+            if (_shutdownComplete || IsDisposed || Disposing || !IsHandleCreated)
+                return Task.CompletedTask;
+
+            return InvokeOnUiThreadAsync(this, () => HandleTunnelMonitorUpdateOnUiThreadAsync(update));
+        }
+
+        internal static Task InvokeOnUiThreadAsync(ISynchronizeInvoke synchronizer, Func<Task> action)
+        {
+            if (synchronizer == null)
+                throw new ArgumentNullException(nameof(synchronizer));
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            bool invokeRequired;
+            try
+            {
+                invokeRequired = synchronizer.InvokeRequired;
+            }
+            catch (ObjectDisposedException)
+            {
+                return Task.CompletedTask;
+            }
+            catch (InvalidOperationException)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (!invokeRequired)
+                return action();
+
+            var completion = new TaskCompletionSource<object>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            try
+            {
+                synchronizer.BeginInvoke(new Action(async () =>
+                {
+                    try
+                    {
+                        await action();
+                        completion.TrySetResult(null);
+                    }
+                    catch (Exception ex)
+                    {
+                        completion.TrySetException(ex);
+                    }
+                }), Array.Empty<object>());
+                return completion.Task;
+            }
+            catch (ObjectDisposedException)
+            {
+                return Task.CompletedTask;
+            }
+            catch (InvalidOperationException)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        private async Task HandleTunnelMonitorUpdateOnUiThreadAsync(TunnelMonitorUpdate update)
         {
             try
             {

--- a/WireSockUI/Forms/frmMain.cs
+++ b/WireSockUI/Forms/frmMain.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
@@ -31,8 +30,6 @@ namespace WireSockUI.Forms
             Indeterminate
         }
 
-        private readonly BackgroundWorker _tunnelConnectionWorker;
-        private readonly BackgroundWorker _tunnelStateWorker;
         private const int TunnelConnectionTimeoutMilliseconds = 30000;
         private const int TunnelDisconnectTimeoutMilliseconds = 10000;
         private const int NativeQueryTimeoutMilliseconds = 5000;
@@ -43,6 +40,7 @@ namespace WireSockUI.Forms
          * @brief The manager that handles the Wireguard connections.
          */
         private readonly TunnelLifecycleController _tunnelLifecycle;
+        private readonly TunnelMonitor _tunnelMonitor;
         private readonly TunnelSessionCoordinator _tunnelSession = new TunnelSessionCoordinator();
 
         private ConnectionState _currentState = ConnectionState.Disconnected;
@@ -51,22 +49,6 @@ namespace WireSockUI.Forms
         private Icon _ownedTrayIcon;
         private Image _inactiveStatusImage;
         private Image _connectedStatusImage;
-
-        private sealed class TunnelConnectionProgress
-        {
-            public int Generation { get; set; }
-            public bool Connected { get; set; }
-            public bool TimedOut { get; set; }
-            public string Diagnostic { get; set; }
-        }
-
-        private sealed class TunnelStateProgress
-        {
-            public int Generation { get; set; }
-            public WgbStats Stats { get; set; }
-            public string Diagnostic { get; set; }
-            public bool TunnelInactive { get; set; }
-        }
 
         /**
          * @brief Initializes a new instance of the Main class.
@@ -96,8 +78,14 @@ namespace WireSockUI.Forms
                 Environment.Exit(1);
             }
 
-            _tunnelConnectionWorker = InitializeTunnelConnectionWorker();
-            _tunnelStateWorker = InitTunnelStateWorker();
+            _tunnelLifecycle = new TunnelLifecycleController(OnWireSockLogMessage);
+            _tunnelMonitor = new TunnelMonitor(
+                _tunnelLifecycle.GetConnectedAsync,
+                _tunnelLifecycle.GetStateAsync,
+                CurrentTunnelGeneration,
+                HandleTunnelMonitorUpdateAsync,
+                NativeQueryTimeoutMilliseconds,
+                TunnelConnectionTimeoutMilliseconds);
 
             // Configure icons
             Icon = Resources.ico;
@@ -125,27 +113,8 @@ namespace WireSockUI.Forms
 
             OnLogWindowResize(lstLog, EventArgs.Empty);
 
-            _tunnelLifecycle = new TunnelLifecycleController(OnWireSockLogMessage);
-
             // Update the list of available configurations.
             LoadProfiles();
-        }
-
-        private static bool SleepUntilCancelled(BackgroundWorker worker, int milliseconds)
-        {
-            const int interval = 100;
-            var waited = 0;
-
-            while (waited < milliseconds)
-            {
-                if (worker.CancellationPending)
-                    return true;
-
-                Thread.Sleep(Math.Min(interval, milliseconds - waited));
-                waited += interval;
-            }
-
-            return worker.CancellationPending;
         }
 
         private static Bitmap GetWindowsIconBitmap(WindowsIcons.Icons icon, int size)
@@ -352,8 +321,7 @@ namespace WireSockUI.Forms
         private void CancelTunnelMonitoring()
         {
             AdvanceTunnelGeneration();
-            _tunnelConnectionWorker.CancelAsync();
-            _tunnelStateWorker.CancelAsync();
+            _tunnelMonitor.Cancel();
         }
 
         private bool TryBeginTunnelOperation(bool showBlockedMessage = true)
@@ -379,16 +347,14 @@ namespace WireSockUI.Forms
             _tunnelSession.EndOperation();
         }
 
-        private void StartTunnelConnectionWorker()
+        private void StartTunnelConnectionMonitor()
         {
-            if (!_tunnelConnectionWorker.IsBusy)
-                _tunnelConnectionWorker.RunWorkerAsync(CurrentTunnelGeneration());
+            _tunnelMonitor.StartConnecting(CurrentTunnelGeneration());
         }
 
-        private void StartTunnelStateWorker()
+        private void StartTunnelStateMonitor()
         {
-            if (!_tunnelStateWorker.IsBusy)
-                _tunnelStateWorker.RunWorkerAsync(CurrentTunnelGeneration());
+            _tunnelMonitor.StartConnected(CurrentTunnelGeneration());
         }
 
         private async Task<bool> DisconnectCurrentTunnelAsync(bool notify = true, bool preserveNetworkLock = false)
@@ -508,8 +474,7 @@ namespace WireSockUI.Forms
             _shutdownComplete = true;
             _currentState = ConnectionState.Disconnected;
 
-            _tunnelConnectionWorker.CancelAsync();
-            _tunnelStateWorker.CancelAsync();
+            _tunnelMonitor.Dispose();
 
             DisposeTunnelLifecycleWithTimeout();
 
@@ -809,6 +774,13 @@ namespace WireSockUI.Forms
 
                 if (createdNew) return false;
 
+                if (!TryValidateSingleInstanceEventSecurity(Global.AlreadyRunning, out var diagnostic))
+                {
+                    Global.AlreadyRunning.Dispose();
+                    Global.AlreadyRunning = null;
+                    throw new InvalidOperationException(diagnostic);
+                }
+
                 Global.AlreadyRunning.Dispose();
                 Global.AlreadyRunning = null;
                 return true;
@@ -840,145 +812,142 @@ namespace WireSockUI.Forms
             return security;
         }
 
-        /// <summary>
-        ///     Initialize a <see cref="T:BackgroundWorker" /> which retrieves tunnel connecting / connecting state and updates it
-        ///     in the UI
-        /// </summary>
-        /// <returns>
-        ///     <see cref="T:BackgroundWorker" />
-        /// </returns>
-        private BackgroundWorker InitializeTunnelConnectionWorker()
+        private static bool TryValidateSingleInstanceEventSecurity(EventWaitHandle waitHandle,
+            out string diagnostic)
         {
-            var worker = new BackgroundWorker
+            diagnostic = null;
+            try
             {
-                WorkerSupportsCancellation = true,
-                WorkerReportsProgress = true
-            };
-
-            worker.DoWork += (s, e) =>
+                return IsSingleInstanceEventSecurityTrusted(
+                    waitHandle.GetAccessControl(),
+                    WindowsIdentity.GetCurrent().User,
+                    out diagnostic);
+            }
+            catch (Exception ex)
             {
-                var generation = (int)e.Argument;
-                var connected = false;
-                var timeout = Stopwatch.StartNew();
+                diagnostic = $"Unable to validate the global WireSock ownership event: {ex.Message}";
+                return false;
+            }
+        }
 
-                do
+        internal static bool IsSingleInstanceEventSecurityTrusted(EventWaitHandleSecurity security,
+            SecurityIdentifier currentUser, out string diagnostic)
+        {
+            diagnostic = null;
+            if (security == null || currentUser == null)
+            {
+                diagnostic = "The global WireSock ownership event has no verifiable security descriptor.";
+                return false;
+            }
+
+            if (!(security.GetOwner(typeof(SecurityIdentifier)) is SecurityIdentifier owner) ||
+                (!owner.Equals(currentUser) && !Program.IsTrustedOwnerSid(owner)))
+            {
+                diagnostic = "The global WireSock ownership event is not owned by the current administrator, " +
+                             "the Administrators group, or LocalSystem.";
+                return false;
+            }
+
+            var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
+            foreach (EventWaitHandleAccessRule rule in rules)
+            {
+                if (rule.AccessControlType != AccessControlType.Allow ||
+                    !(rule.IdentityReference is SecurityIdentifier sid))
+                    continue;
+
+                if (sid.Equals(currentUser) || Program.IsTrustedAdministrativeSid(sid))
+                    continue;
+
+                diagnostic =
+                    $"The global WireSock ownership event grants access to an untrusted identity ({sid.Value}).";
+                return false;
+            }
+
+            return true;
+        }
+
+        private async Task HandleTunnelMonitorUpdateAsync(TunnelMonitorUpdate update)
+        {
+            try
+            {
+                if (update == null || _shutdownComplete || IsDisposed || Disposing ||
+                    update.Generation != CurrentTunnelGeneration())
+                    return;
+
+                switch (update.Kind)
                 {
-                    if (generation != CurrentTunnelGeneration())
-                    {
-                        e.Cancel = true;
+                    case TunnelMonitorUpdateKind.Connected:
+                        if (_currentState == ConnectionState.Connecting)
+                            UpdateState(ConnectionState.Connected);
                         return;
-                    }
-
-                    if (SleepUntilCancelled(worker, 500))
-                    {
-                        e.Cancel = true;
+                    case TunnelMonitorUpdateKind.ConnectionTimedOut:
+                        if (_currentState == ConnectionState.Connecting)
+                            await HandleTunnelConnectionTimeoutAsync(update.Generation);
                         return;
-                    }
-
-                    if (!_tunnelLifecycle.TryGetConnected(out connected, out var diagnostic))
-                    {
-                        worker.ReportProgress(0, new TunnelConnectionProgress
+                    case TunnelMonitorUpdateKind.TunnelInactive:
+                        if (_currentState == ConnectionState.Connected)
+                            await HandleTunnelInactiveAsync(update.Generation);
+                        return;
+                    case TunnelMonitorUpdateKind.Statistics:
+                        if (_currentState == ConnectionState.Connected)
+                            ApplyTunnelStatistics(update.Statistics);
+                        return;
+                    case TunnelMonitorUpdateKind.QueryFailed:
+                        if (update.ConnectionQuery != null)
                         {
-                            Generation = generation,
-                            Diagnostic = diagnostic ?? "Unable to query the native tunnel state."
-                        });
-                        e.Cancel = true;
-                        return;
-                    }
-
-                    if (!connected && timeout.ElapsedMilliseconds >= TunnelConnectionTimeoutMilliseconds)
-                    {
-                        worker.ReportProgress(0, new TunnelConnectionProgress
+                            await HandleTunnelMonitorQueryFailureAsync(
+                                update.Generation,
+                                update.ConnectionQuery,
+                                "tunnel active-state monitor");
+                        }
+                        else if (update.StatisticsQuery != null)
                         {
-                            Generation = generation,
-                            TimedOut = true
-                        });
-                        e.Cancel = true;
+                            await HandleTunnelMonitorQueryFailureAsync(
+                                update.Generation,
+                                update.StatisticsQuery,
+                                "tunnel statistics monitor");
+                        }
+
                         return;
-                    }
-
-                    worker.ReportProgress(0, new TunnelConnectionProgress
-                    {
-                        Generation = generation,
-                        Connected = connected
-                    });
-                } while (!worker.CancellationPending && generation == CurrentTunnelGeneration() && !connected);
-            };
-
-            worker.ProgressChanged += async (s, e) =>
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+            catch (Exception ex)
             {
-                try
-                {
-                    if (_shutdownComplete || !(e.UserState is TunnelConnectionProgress progress) ||
-                        progress.Generation != CurrentTunnelGeneration())
-                        return;
+                Trace.TraceError($"Tunnel monitor update handling failed unexpectedly: {ex.Message}");
+            }
+        }
 
-                    if (progress.TimedOut)
-                    {
-                        await HandleTunnelConnectionTimeoutAsync(progress.Generation);
-                        return;
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(progress.Diagnostic))
-                    {
-                        await HandleTunnelMonitorFailureAsync(progress.Generation, progress.Diagnostic);
-                        return;
-                    }
-
-                    if (_currentState == ConnectionState.Connecting && progress.Connected)
-                        UpdateState(ConnectionState.Connected);
-                }
-                catch (Exception ex)
-                {
-                    Trace.TraceError(
-                        $"Tunnel connection monitor progress handling failed unexpectedly: {ex.Message}");
-                }
-            };
-
-            worker.RunWorkerCompleted += async (s, e) =>
+        private async Task HandleTunnelMonitorQueryFailureAsync<T>(int generation,
+            NativeOperationResult<T> result, string context)
+        {
+            var diagnostic = result.Diagnostic ?? $"The native {context} query failed.";
+            if (result.TimedOut)
             {
-                try
-                {
-                    if (_shutdownComplete || IsDisposed || Disposing)
-                        return;
+                TrackTimedOutNativeOperation(result, context);
+                MarkNativeRecoveryRequired(_tunnelLifecycle.ProfileName, $"{context}: {diagnostic}");
+                return;
+            }
 
-                    if (e.Error != null)
-                    {
-                        await HandleTunnelMonitorFailureAsync(CurrentTunnelGeneration(),
-                            $"Tunnel connection monitor stopped unexpectedly: {e.Error.Message}");
-                        return;
-                    }
+            await HandleTunnelMonitorFailureAsync(generation, diagnostic);
+        }
 
-                    if (e.Cancelled)
-                        return;
+        private void ApplyTunnelStatistics(WgbStats stats)
+        {
+            if (layoutState.Controls["txtHandshake"] is TextBox txtHandshake)
+                txtHandshake.Text = stats.time_since_last_handshake.AsHandshakeAge();
 
-                    if (_currentState != ConnectionState.Connecting)
-                        return;
+            if (layoutState.Controls["txtTransfer"] is TextBox txtTransfer)
+                txtTransfer.Text = string.Format(Resources.StateTransferValue,
+                    stats.rx_bytes.AsHumanReadable(),
+                    stats.tx_bytes.AsHumanReadable());
 
-                    var generation = CurrentTunnelGeneration();
-                    var queryResult = await _tunnelLifecycle.GetConnectedAsync(NativeQueryTimeoutMilliseconds);
-                    if (_shutdownComplete || generation != CurrentTunnelGeneration() ||
-                        _currentState != ConnectionState.Connecting)
-                        return;
+            if (layoutState.Controls["txtRTT"] is TextBox txtRtt)
+                txtRtt.Text = string.Format(Resources.StateRTTValue, stats.estimated_rtt);
 
-                    if (!queryResult.Succeeded)
-                    {
-                        await HandleTunnelMonitorFailureAsync(generation,
-                            queryResult.Diagnostic ?? "Unable to query the native tunnel state.");
-                        return;
-                    }
-
-                    if (!queryResult.Value && !worker.IsBusy)
-                        worker.RunWorkerAsync(CurrentTunnelGeneration());
-                }
-                catch (Exception ex)
-                {
-                    await HandleTunnelMonitorFailureAsync(CurrentTunnelGeneration(),
-                        $"Tunnel connection monitor completion handling failed unexpectedly: {ex.Message}");
-                }
-            };
-
-            return worker;
+            if (layoutState.Controls["txtLoss"] is TextBox txtLoss)
+                txtLoss.Text = string.Format(Resources.StateLossValue, stats.estimated_loss * 100);
         }
 
         private async Task HandleTunnelMonitorFailureAsync(int generation, string diagnostic)
@@ -1209,167 +1178,6 @@ namespace WireSockUI.Forms
             });
         }
 
-        /// <summary>
-        ///     Initialize a <see cref="T:BackgroundWorker" /> which retrieves the connected tunnel state and updates it in the UI
-        /// </summary>
-        /// <returns>
-        ///     <see cref="T:BackgroundWorker" />
-        /// </returns>
-        private BackgroundWorker InitTunnelStateWorker()
-        {
-            var worker = new BackgroundWorker
-            {
-                WorkerSupportsCancellation = true,
-                WorkerReportsProgress = true
-            };
-
-            worker.DoWork += (s, e) =>
-            {
-                var generation = (int)e.Argument;
-
-                while (!worker.CancellationPending)
-                {
-                    if (generation != CurrentTunnelGeneration())
-                    {
-                        e.Cancel = true;
-                        return;
-                    }
-
-                    if (SleepUntilCancelled(worker, 1000))
-                    {
-                        e.Cancel = true;
-                        return;
-                    }
-
-                    if (!_tunnelLifecycle.TryGetConnected(out var connected, out var stateDiagnostic))
-                    {
-                        worker.ReportProgress(0, new TunnelStateProgress
-                        {
-                            Generation = generation,
-                            Diagnostic = stateDiagnostic ?? "Unable to query the native tunnel state."
-                        });
-                        e.Cancel = true;
-                        return;
-                    }
-
-                    if (!connected)
-                    {
-                        worker.ReportProgress(0, new TunnelStateProgress
-                        {
-                            Generation = generation,
-                            TunnelInactive = true
-                        });
-                        e.Cancel = true;
-                        return;
-                    }
-
-                    if (!_tunnelLifecycle.TryGetState(out var stats, out var statsDiagnostic))
-                    {
-                        worker.ReportProgress(0, new TunnelStateProgress
-                        {
-                            Generation = generation,
-                            Diagnostic = statsDiagnostic ?? "Unable to query native tunnel statistics."
-                        });
-                        e.Cancel = true;
-                        return;
-                    }
-
-                    worker.ReportProgress(0, new TunnelStateProgress
-                    {
-                        Generation = generation,
-                        Stats = stats
-                    });
-                }
-            };
-
-            worker.ProgressChanged += async (s, e) =>
-            {
-                try
-                {
-                    if (_shutdownComplete || !(e.UserState is TunnelStateProgress progress) ||
-                        progress.Generation != CurrentTunnelGeneration() || _currentState != ConnectionState.Connected)
-                        return;
-
-                    if (progress.TunnelInactive)
-                    {
-                        await HandleTunnelInactiveAsync(progress.Generation);
-                        return;
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(progress.Diagnostic))
-                    {
-                        await HandleTunnelMonitorFailureAsync(progress.Generation, progress.Diagnostic);
-                        return;
-                    }
-
-                    var stats = progress.Stats;
-
-                    if (layoutState.Controls["txtHandshake"] is TextBox txtHandshake)
-                        txtHandshake.Text = stats.time_since_last_handshake.AsHandshakeAge();
-
-                    if (layoutState.Controls["txtTransfer"] is TextBox txtTransfer)
-                        txtTransfer.Text = string.Format(Resources.StateTransferValue,
-                            stats.rx_bytes.AsHumanReadable(),
-                            stats.tx_bytes.AsHumanReadable());
-
-                    if (layoutState.Controls["txtRTT"] is TextBox txtRtt)
-                        txtRtt.Text = string.Format(Resources.StateRTTValue, stats.estimated_rtt);
-
-                    if (layoutState.Controls["txtLoss"] is TextBox txtLoss)
-                        txtLoss.Text = string.Format(Resources.StateLossValue, stats.estimated_loss * 100);
-                }
-                catch (Exception ex)
-                {
-                    Trace.TraceError($"Tunnel state monitor progress handling failed unexpectedly: {ex.Message}");
-                }
-            };
-
-            worker.RunWorkerCompleted += async (s, e) =>
-            {
-                try
-                {
-                    if (_shutdownComplete || IsDisposed || Disposing)
-                        return;
-
-                    if (e.Error != null)
-                    {
-                        await HandleTunnelMonitorFailureAsync(CurrentTunnelGeneration(),
-                            $"Tunnel state monitor stopped unexpectedly: {e.Error.Message}");
-                        return;
-                    }
-
-                    if (e.Cancelled)
-                        return;
-
-                    if (_currentState != ConnectionState.Connected)
-                        return;
-
-                    var generation = CurrentTunnelGeneration();
-                    var queryResult = await _tunnelLifecycle.GetConnectedAsync(NativeQueryTimeoutMilliseconds);
-                    if (_shutdownComplete || generation != CurrentTunnelGeneration() ||
-                        _currentState != ConnectionState.Connected)
-                        return;
-
-                    if (!queryResult.Succeeded)
-                    {
-                        await HandleTunnelMonitorFailureAsync(generation,
-                            queryResult.Diagnostic ?? "Unable to query the native tunnel state.");
-                        return;
-                    }
-
-                    if (queryResult.Value && !worker.IsBusy)
-                        worker.RunWorkerAsync(CurrentTunnelGeneration());
-                }
-                catch (Exception ex)
-                {
-                    await HandleTunnelMonitorFailureAsync(CurrentTunnelGeneration(),
-                        $"Tunnel state monitor completion handling failed unexpectedly: {ex.Message}");
-                }
-            };
-
-            return worker;
-        }
-
         private async Task HandleTunnelInactiveAsync(int generation)
         {
             while (!TryBeginTunnelOperation(false))
@@ -1500,7 +1308,7 @@ namespace WireSockUI.Forms
 
                     cmiResetKillSwitch.Enabled = false;
 
-                    StartTunnelConnectionWorker();
+                    StartTunnelConnectionMonitor();
                     break;
                 case ConnectionState.Connected:
                     if (btnActivate != null)
@@ -1548,7 +1356,7 @@ namespace WireSockUI.Forms
 
                     gbxState.Visible = true;
 
-                    StartTunnelStateWorker();
+                    StartTunnelStateMonitor();
 
 #if WIRESOCKUI_ENABLE_UWP
                     if (notify && Settings.Default.EnableNotifications)

--- a/WireSockUI/Native/WindowsBinaryArchitecture.cs
+++ b/WireSockUI/Native/WindowsBinaryArchitecture.cs
@@ -1,0 +1,149 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace WireSockUI.Native
+{
+    internal enum WindowsBinaryArchitecture
+    {
+        Unknown,
+        X86,
+        X64,
+        Arm64
+    }
+
+    internal static class WindowsBinaryArchitectureInfo
+    {
+        private const ushort ImageFileMachineUnknown = 0x0000;
+        private const ushort ImageFileMachineI386 = 0x014c;
+        private const ushort ImageFileMachineAmd64 = 0x8664;
+        private const ushort ImageFileMachineArm64 = 0xaa64;
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GetCurrentProcess();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool IsWow64Process2(IntPtr process, out ushort processMachine,
+            out ushort nativeMachine);
+
+        public static bool TryGetCurrentProcessArchitecture(out WindowsBinaryArchitecture architecture,
+            out string diagnostic)
+        {
+            architecture = WindowsBinaryArchitecture.Unknown;
+            diagnostic = null;
+
+            try
+            {
+                if (!IsWow64Process2(GetCurrentProcess(), out var processMachine, out var nativeMachine))
+                {
+                    diagnostic = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                    return false;
+                }
+
+                architecture = FromMachine(processMachine == ImageFileMachineUnknown ? nativeMachine : processMachine);
+                if (architecture != WindowsBinaryArchitecture.Unknown)
+                    return true;
+
+                diagnostic =
+                    $"Windows reported unsupported process machine 0x{(processMachine == ImageFileMachineUnknown ? nativeMachine : processMachine):x4}.";
+                return false;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                architecture = IntPtr.Size == 8
+                    ? WindowsBinaryArchitecture.X64
+                    : WindowsBinaryArchitecture.X86;
+                return true;
+            }
+        }
+
+        public static bool TryReadPortableExecutableArchitecture(string path,
+            out WindowsBinaryArchitecture architecture, out string diagnostic)
+        {
+            architecture = WindowsBinaryArchitecture.Unknown;
+            diagnostic = null;
+
+            try
+            {
+                using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read,
+                           4096, FileOptions.SequentialScan))
+                using (var reader = new BinaryReader(stream))
+                {
+                    if (stream.Length < 64 || reader.ReadUInt16() != 0x5a4d)
+                    {
+                        diagnostic = $"'{path}' is not a valid PE image.";
+                        return false;
+                    }
+
+                    stream.Position = 0x3c;
+                    var peOffset = reader.ReadInt32();
+                    if (peOffset < 0 || peOffset > stream.Length - 6)
+                    {
+                        diagnostic = $"'{path}' contains an invalid PE header offset.";
+                        return false;
+                    }
+
+                    stream.Position = peOffset;
+                    if (reader.ReadUInt32() != 0x00004550)
+                    {
+                        diagnostic = $"'{path}' does not contain a valid PE signature.";
+                        return false;
+                    }
+
+                    var machine = reader.ReadUInt16();
+                    architecture = FromMachine(machine);
+                    if (architecture != WindowsBinaryArchitecture.Unknown)
+                        return true;
+
+                    diagnostic = $"'{path}' uses unsupported PE machine 0x{machine:x4}.";
+                    return false;
+                }
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException ||
+                                       ex is ArgumentException || ex is NotSupportedException)
+            {
+                diagnostic = $"Unable to inspect '{path}': {ex.Message}";
+                return false;
+            }
+        }
+
+        public static bool AreCompatible(WindowsBinaryArchitecture processArchitecture,
+            WindowsBinaryArchitecture libraryArchitecture)
+        {
+            return processArchitecture != WindowsBinaryArchitecture.Unknown &&
+                   processArchitecture == libraryArchitecture;
+        }
+
+        public static string Format(WindowsBinaryArchitecture architecture)
+        {
+            switch (architecture)
+            {
+                case WindowsBinaryArchitecture.X86:
+                    return "x86";
+                case WindowsBinaryArchitecture.X64:
+                    return "x64";
+                case WindowsBinaryArchitecture.Arm64:
+                    return "ARM64";
+                default:
+                    return "unknown";
+            }
+        }
+
+        private static WindowsBinaryArchitecture FromMachine(ushort machine)
+        {
+            switch (machine)
+            {
+                case ImageFileMachineI386:
+                    return WindowsBinaryArchitecture.X86;
+                case ImageFileMachineAmd64:
+                    return WindowsBinaryArchitecture.X64;
+                case ImageFileMachineArm64:
+                    return WindowsBinaryArchitecture.Arm64;
+                default:
+                    return WindowsBinaryArchitecture.Unknown;
+            }
+        }
+    }
+}

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -418,9 +418,17 @@ namespace WireSockUI
             diagnostic = null;
 
             var fullDirectory = NormalizePathDirectory(directory);
-            if (fullDirectory == null ||
-                !TryGetExistingAttributes(fullDirectory, out var directoryAttributes) ||
-                (directoryAttributes & FileAttributes.Directory) == 0)
+            if (fullDirectory == null)
+                return false;
+
+            if (!TryGetExistingAttributes(fullDirectory, out var directoryAttributes, out diagnostic))
+            {
+                if (!string.IsNullOrWhiteSpace(diagnostic))
+                    Trace.TraceWarning(diagnostic);
+                return false;
+            }
+
+            if ((directoryAttributes & FileAttributes.Directory) == 0)
                 return false;
 
             if ((directoryAttributes & FileAttributes.ReparsePoint) != 0)
@@ -432,8 +440,12 @@ namespace WireSockUI
             }
 
             var libraryPath = Path.Combine(fullDirectory, "wgbooster.dll");
-            if (!TryGetExistingAttributes(libraryPath, out var libraryAttributes))
+            if (!TryGetExistingAttributes(libraryPath, out var libraryAttributes, out diagnostic))
+            {
+                if (!string.IsNullOrWhiteSpace(diagnostic))
+                    Trace.TraceWarning(diagnostic);
                 return false;
+            }
 
             if ((libraryAttributes & FileAttributes.Directory) != 0)
             {
@@ -742,7 +754,20 @@ namespace WireSockUI
         private static bool TryGetExistingAttributes(string path, out FileAttributes attributes,
             bool warnOnFailure = false)
         {
+            return TryGetExistingAttributesCore(path, out attributes, out _, warnOnFailure);
+        }
+
+        internal static bool TryGetExistingAttributes(string path, out FileAttributes attributes,
+            out string diagnostic)
+        {
+            return TryGetExistingAttributesCore(path, out attributes, out diagnostic, false);
+        }
+
+        private static bool TryGetExistingAttributesCore(string path, out FileAttributes attributes,
+            out string diagnostic, bool warnOnFailure)
+        {
             attributes = 0;
+            diagnostic = null;
 
             try
             {
@@ -759,11 +784,18 @@ namespace WireSockUI
             }
             catch (Exception ex)
             {
+                diagnostic =
+                    $"Unable to inspect file system attributes for '{EscapeDiagnosticText(path)}': {EscapeDiagnosticText(ex.Message)}";
                 if (warnOnFailure)
-                    Trace.TraceWarning($"Unable to inspect file system attributes for '{path}': {ex.Message}");
+                    Trace.TraceWarning(diagnostic);
 
                 return false;
             }
+        }
+
+        private static string EscapeDiagnosticText(string value)
+        {
+            return (value ?? string.Empty).Replace("\0", "\\0");
         }
 
         internal static bool IsPotentiallyUserWritableDirectory(string directory)

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -96,18 +96,15 @@ namespace WireSockUI
                     Resources.AppNoWireSockTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
 
-            if (!IsWireSockArchitectureSupported())
+            if (!IsWireSockInstalled(out var wireSockDiagnostic, out var installationCandidateFound))
             {
-                MessageBox.Show(Resources.AppUnsupportedArchMessage, Resources.AppNoWireSockTitle,
-                    MessageBoxButtons.OK, MessageBoxIcon.Error);
-                Environment.Exit(1);
-            }
-
-            if (!IsWireSockInstalled())
-            {
-                MessageBox.Show(Resources.AppNoWireSockMessage, Resources.AppNoWireSockTitle, MessageBoxButtons.OK,
-                    MessageBoxIcon.Information);
-                OpenBrowser(Resources.AppWireSockURL);
+                var message = string.IsNullOrWhiteSpace(wireSockDiagnostic)
+                    ? Resources.AppNoWireSockMessage
+                    : $"{Resources.AppNoWireSockMessage}{Environment.NewLine}{Environment.NewLine}{wireSockDiagnostic}";
+                MessageBox.Show(message, Resources.AppNoWireSockTitle, MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                if (!installationCandidateFound)
+                    OpenBrowser(Resources.AppWireSockURL);
 
                 Environment.Exit(1);
             }
@@ -135,16 +132,14 @@ namespace WireSockUI
                 return false;
 
             var applicationDirectory = Path.GetDirectoryName(normalizedExecutable);
-            string[] companionFiles;
-            try
-            {
-                companionFiles = Directory.GetFiles(applicationDirectory, "*", SearchOption.TopDirectoryOnly);
-            }
-            catch (Exception ex)
-            {
-                diagnostic =
-                    $"Unable to enumerate WireSock UI managed dependencies in '{applicationDirectory}': {ex.Message}";
+            if (!TryEnumerateApplicationPayloadEntries(applicationDirectory, out var companionFiles,
+                    out var payloadDirectories, out diagnostic))
                 return false;
+
+            foreach (var payloadDirectory in payloadDirectories)
+            {
+                if (!TryValidateApplicationPayloadDirectory(payloadDirectory, out diagnostic))
+                    return false;
             }
 
             foreach (var companionFile in companionFiles)
@@ -163,6 +158,87 @@ namespace WireSockUI
             }
 
             return true;
+        }
+
+        internal static bool TryEnumerateApplicationPayloadEntries(string applicationDirectory,
+            out string[] files, out string[] directories, out string diagnostic)
+        {
+            files = new string[0];
+            directories = new string[0];
+            diagnostic = null;
+
+            var normalizedDirectory = NormalizePathDirectoryCore(applicationDirectory, false);
+            if (normalizedDirectory == null)
+            {
+                diagnostic = "The WireSock UI application directory path is invalid.";
+                return false;
+            }
+
+            var pendingDirectories = new Stack<string>();
+            var discoveredDirectories = new List<string>();
+            var discoveredFiles = new List<string>();
+            pendingDirectories.Push(normalizedDirectory);
+
+            try
+            {
+                while (pendingDirectories.Count > 0)
+                {
+                    var currentDirectory = pendingDirectories.Pop();
+                    if (!TryGetExistingAttributes(currentDirectory, out var attributes) ||
+                        (attributes & FileAttributes.Directory) == 0)
+                    {
+                        diagnostic = $"Application payload path '{currentDirectory}' is not an accessible directory.";
+                        return false;
+                    }
+
+                    if ((attributes & FileAttributes.ReparsePoint) != 0)
+                    {
+                        diagnostic = $"Application payload directory '{currentDirectory}' is a reparse point.";
+                        return false;
+                    }
+
+                    discoveredDirectories.Add(currentDirectory);
+                    discoveredFiles.AddRange(Directory.GetFiles(currentDirectory, "*", SearchOption.TopDirectoryOnly));
+
+                    foreach (var childDirectory in Directory.GetDirectories(
+                                 currentDirectory, "*", SearchOption.TopDirectoryOnly))
+                        pendingDirectories.Push(childDirectory);
+                }
+            }
+            catch (Exception ex)
+            {
+                diagnostic =
+                    $"Unable to enumerate WireSock UI application payload in '{normalizedDirectory}': {ex.Message}";
+                return false;
+            }
+
+            files = discoveredFiles.ToArray();
+            directories = discoveredDirectories.ToArray();
+            return true;
+        }
+
+        private static bool TryValidateApplicationPayloadDirectory(string directory, out string diagnostic)
+        {
+            diagnostic = null;
+            if (!TryGetExistingAttributes(directory, out var attributes) ||
+                (attributes & FileAttributes.Directory) == 0)
+            {
+                diagnostic = $"Application payload path '{directory}' is not an accessible directory.";
+                return false;
+            }
+
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                diagnostic = $"Application payload directory '{directory}' is a reparse point.";
+                return false;
+            }
+
+            if (!IsPotentiallyUserWritableDirectoryCore(directory, false))
+                return true;
+
+            diagnostic =
+                $"Application payload directory '{directory}' is writable by or owned by non-administrative users.";
+            return false;
         }
 
         private static void RegisterUnhandledExceptionHandlers()
@@ -288,17 +364,34 @@ namespace WireSockUI
         ///     Determine if the WireSock library components are installed.
         /// </summary>
         /// <returns><c>true</c> if installed, otherwise <c>false</c></returns>
-        private static bool IsWireSockInstalled()
+        private static bool IsWireSockInstalled(out string diagnostic, out bool installationCandidateFound)
         {
+            var diagnostics = new List<string>();
             foreach (var candidate in EnumerateWireSockLibraryDirectoryCandidates())
             {
-                if (!TryValidateWireSockLibraryDirectory(candidate, out var libraryDirectory))
+                if (!TryValidateWireSockLibraryDirectory(candidate, out var libraryDirectory,
+                        out var candidateDiagnostic))
+                {
+                    if (!string.IsNullOrWhiteSpace(candidateDiagnostic))
+                        diagnostics.Add(candidateDiagnostic);
                     continue;
+                }
 
-                if (ConfigureWireSockLibraryDirectory(libraryDirectory))
+                if (ConfigureWireSockLibraryDirectory(libraryDirectory, out candidateDiagnostic))
+                {
+                    diagnostic = null;
+                    installationCandidateFound = true;
                     return true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(candidateDiagnostic))
+                    diagnostics.Add(candidateDiagnostic);
             }
 
+            installationCandidateFound = diagnostics.Count != 0;
+            diagnostic = !installationCandidateFound
+                ? "No trusted wgbooster.dll installation candidate was found."
+                : string.Join(Environment.NewLine, diagnostics);
             return false;
         }
 
@@ -315,7 +408,14 @@ namespace WireSockUI
 
         internal static bool TryValidateWireSockLibraryDirectory(string directory, out string libraryDirectory)
         {
+            return TryValidateWireSockLibraryDirectory(directory, out libraryDirectory, out _);
+        }
+
+        internal static bool TryValidateWireSockLibraryDirectory(string directory, out string libraryDirectory,
+            out string diagnostic)
+        {
             libraryDirectory = null;
+            diagnostic = null;
 
             var fullDirectory = NormalizePathDirectory(directory);
             if (fullDirectory == null ||
@@ -325,8 +425,9 @@ namespace WireSockUI
 
             if ((directoryAttributes & FileAttributes.ReparsePoint) != 0)
             {
-                Trace.TraceWarning(
-                    $"Skipping WireSock library directory '{fullDirectory}' because it is a reparse point.");
+                diagnostic =
+                    $"Skipping WireSock library directory '{fullDirectory}' because it is a reparse point.";
+                Trace.TraceWarning(diagnostic);
                 return false;
             }
 
@@ -336,27 +437,50 @@ namespace WireSockUI
 
             if ((libraryAttributes & FileAttributes.Directory) != 0)
             {
-                Trace.TraceWarning(
-                    $"Skipping WireSock library '{libraryPath}' because it is a directory.");
+                diagnostic = $"Skipping WireSock library '{libraryPath}' because it is a directory.";
+                Trace.TraceWarning(diagnostic);
                 return false;
             }
 
             if ((libraryAttributes & FileAttributes.ReparsePoint) != 0)
             {
-                Trace.TraceWarning(
-                    $"Skipping WireSock library '{libraryPath}' because it is a reparse point.");
+                diagnostic = $"Skipping WireSock library '{libraryPath}' because it is a reparse point.";
+                Trace.TraceWarning(diagnostic);
                 return false;
             }
 
-            if (!TryValidateTrustedFilePath(libraryPath, "WireSock library", out var trustDiagnostic))
+            if (!TryValidateTrustedFilePath(libraryPath, "WireSock library", out diagnostic))
             {
-                Trace.TraceWarning(trustDiagnostic);
+                Trace.TraceWarning(diagnostic);
                 return false;
             }
 
-            if (!TryValidateTrustedWireSockCompanionFiles(fullDirectory, libraryPath, out trustDiagnostic))
+            if (!TryValidateTrustedWireSockCompanionFiles(fullDirectory, libraryPath, out diagnostic))
             {
-                Trace.TraceWarning(trustDiagnostic);
+                Trace.TraceWarning(diagnostic);
+                return false;
+            }
+
+            if (!WindowsBinaryArchitectureInfo.TryGetCurrentProcessArchitecture(
+                    out var processArchitecture, out diagnostic))
+            {
+                diagnostic = $"Unable to determine the WireSock UI process architecture: {diagnostic}";
+                Trace.TraceWarning(diagnostic);
+                return false;
+            }
+
+            if (!WindowsBinaryArchitectureInfo.TryReadPortableExecutableArchitecture(
+                    libraryPath, out var libraryArchitecture, out diagnostic))
+            {
+                Trace.TraceWarning(diagnostic);
+                return false;
+            }
+
+            if (!WindowsBinaryArchitectureInfo.AreCompatible(processArchitecture, libraryArchitecture))
+            {
+                diagnostic =
+                    $"WireSock library '{libraryPath}' targets {WindowsBinaryArchitectureInfo.Format(libraryArchitecture)}, but WireSock UI is running as {WindowsBinaryArchitectureInfo.Format(processArchitecture)}.";
+                Trace.TraceWarning(diagnostic);
                 return false;
             }
 
@@ -476,28 +600,36 @@ namespace WireSockUI
             return locations.ToArray();
         }
 
-        private static bool ConfigureWireSockLibraryDirectory(string directory)
+        private static bool ConfigureWireSockLibraryDirectory(string directory, out string diagnostic)
         {
+            diagnostic = null;
             if (string.IsNullOrWhiteSpace(directory))
+            {
+                diagnostic = "The WireSock library directory path is empty.";
                 return false;
+            }
 
             var fullDirectory = NormalizePathDirectory(directory);
             if (fullDirectory == null)
+            {
+                diagnostic = $"The WireSock library directory '{directory}' is invalid.";
                 return false;
+            }
 
             var libraryPath = Path.Combine(fullDirectory, "wgbooster.dll");
 
             try
             {
-                if (TryConfigureRestrictedDllSearchPath(fullDirectory, libraryPath, out var diagnostic))
+                if (TryConfigureRestrictedDllSearchPath(fullDirectory, libraryPath, out diagnostic))
                     return true;
 
-                Trace.TraceWarning(
-                    $"Failed to configure WireSock library '{libraryPath}': {diagnostic}");
+                diagnostic = $"Failed to configure WireSock library '{libraryPath}': {diagnostic}";
+                Trace.TraceWarning(diagnostic);
             }
             catch (Exception ex)
             {
-                Trace.TraceWarning($"Failed to load WireSock library '{libraryPath}': {ex.Message}");
+                diagnostic = $"Failed to load WireSock library '{libraryPath}': {ex.Message}";
+                Trace.TraceWarning(diagnostic);
             }
 
             return false;
@@ -858,7 +990,7 @@ namespace WireSockUI
             return false;
         }
 
-        private static bool IsTrustedAdministrativeSid(SecurityIdentifier sid)
+        internal static bool IsTrustedAdministrativeSid(SecurityIdentifier sid)
         {
             return sid.IsWellKnown(WellKnownSidType.LocalSystemSid) ||
                    sid.IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid) ||
@@ -868,7 +1000,7 @@ namespace WireSockUI
                        StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool IsTrustedOwnerSid(SecurityIdentifier sid)
+        internal static bool IsTrustedOwnerSid(SecurityIdentifier sid)
         {
             if (IsTrustedAdministrativeSid(sid))
                 return true;
@@ -939,18 +1071,5 @@ namespace WireSockUI
             return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
 
-        /// <summary>
-        ///     Determine if running under a supported architecture.
-        /// </summary>
-        /// <remarks>
-        ///     WireSock VPN Client's wgbooster.dll currently forces us to match the operating system's architecture. Under
-        ///     normal circumstances this check always succeeds, but under a debugger AnyCPU builds may run as x86 or x64
-        ///     processes, disregarding the host OS bitness.
-        /// </remarks>
-        /// <returns><c>true</c> if supported, otherwise <c>false</c></returns>
-        private static bool IsWireSockArchitectureSupported()
-        {
-            return Environment.Is64BitOperatingSystem == Environment.Is64BitProcess;
-        }
     }
 }

--- a/WireSockUI/Program.cs
+++ b/WireSockUI/Program.cs
@@ -184,10 +184,18 @@ namespace WireSockUI
                 while (pendingDirectories.Count > 0)
                 {
                     var currentDirectory = pendingDirectories.Pop();
-                    if (!TryGetExistingAttributes(currentDirectory, out var attributes) ||
-                        (attributes & FileAttributes.Directory) == 0)
+                    if (!TryGetExistingAttributes(currentDirectory, out var attributes, out diagnostic))
                     {
-                        diagnostic = $"Application payload path '{currentDirectory}' is not an accessible directory.";
+                        if (string.IsNullOrWhiteSpace(diagnostic))
+                            diagnostic =
+                                $"Application payload path '{EscapeDiagnosticText(currentDirectory)}' is not an accessible directory.";
+                        return false;
+                    }
+
+                    if ((attributes & FileAttributes.Directory) == 0)
+                    {
+                        diagnostic =
+                            $"Application payload path '{EscapeDiagnosticText(currentDirectory)}' is not an accessible directory.";
                         return false;
                     }
 
@@ -208,7 +216,7 @@ namespace WireSockUI
             catch (Exception ex)
             {
                 diagnostic =
-                    $"Unable to enumerate WireSock UI application payload in '{normalizedDirectory}': {ex.Message}";
+                    $"Unable to enumerate WireSock UI application payload in '{EscapeDiagnosticText(normalizedDirectory)}': {EscapeDiagnosticText(ex.Message)}";
                 return false;
             }
 
@@ -217,13 +225,21 @@ namespace WireSockUI
             return true;
         }
 
-        private static bool TryValidateApplicationPayloadDirectory(string directory, out string diagnostic)
+        internal static bool TryValidateApplicationPayloadDirectory(string directory, out string diagnostic)
         {
             diagnostic = null;
-            if (!TryGetExistingAttributes(directory, out var attributes) ||
-                (attributes & FileAttributes.Directory) == 0)
+            if (!TryGetExistingAttributes(directory, out var attributes, out diagnostic))
             {
-                diagnostic = $"Application payload path '{directory}' is not an accessible directory.";
+                if (string.IsNullOrWhiteSpace(diagnostic))
+                    diagnostic =
+                        $"Application payload path '{EscapeDiagnosticText(directory)}' is not an accessible directory.";
+                return false;
+            }
+
+            if ((attributes & FileAttributes.Directory) == 0)
+            {
+                diagnostic =
+                    $"Application payload path '{EscapeDiagnosticText(directory)}' is not an accessible directory.";
                 return false;
             }
 
@@ -751,20 +767,8 @@ namespace WireSockUI
             }
         }
 
-        private static bool TryGetExistingAttributes(string path, out FileAttributes attributes,
-            bool warnOnFailure = false)
-        {
-            return TryGetExistingAttributesCore(path, out attributes, out _, warnOnFailure);
-        }
-
         internal static bool TryGetExistingAttributes(string path, out FileAttributes attributes,
             out string diagnostic)
-        {
-            return TryGetExistingAttributesCore(path, out attributes, out diagnostic, false);
-        }
-
-        private static bool TryGetExistingAttributesCore(string path, out FileAttributes attributes,
-            out string diagnostic, bool warnOnFailure)
         {
             attributes = 0;
             diagnostic = null;
@@ -786,9 +790,6 @@ namespace WireSockUI
             {
                 diagnostic =
                     $"Unable to inspect file system attributes for '{EscapeDiagnosticText(path)}': {EscapeDiagnosticText(ex.Message)}";
-                if (warnOnFailure)
-                    Trace.TraceWarning(diagnostic);
-
                 return false;
             }
         }
@@ -862,10 +863,16 @@ namespace WireSockUI
                 return false;
             }
 
-            if (!TryGetExistingAttributes(normalizedFile, out var fileAttributes) ||
-                (fileAttributes & FileAttributes.Directory) != 0)
+            if (!TryGetExistingAttributes(normalizedFile, out var fileAttributes, out diagnostic))
             {
-                diagnostic = $"{label} '{normalizedFile}' is not a regular file.";
+                if (string.IsNullOrWhiteSpace(diagnostic))
+                    diagnostic = $"{label} '{EscapeDiagnosticText(normalizedFile)}' is not a regular file.";
+                return false;
+            }
+
+            if ((fileAttributes & FileAttributes.Directory) != 0)
+            {
+                diagnostic = $"{label} '{EscapeDiagnosticText(normalizedFile)}' is not a regular file.";
                 return false;
             }
 
@@ -886,10 +893,18 @@ namespace WireSockUI
             var isContainingDirectory = true;
             while (!string.IsNullOrWhiteSpace(directory))
             {
-                if (!TryGetExistingAttributes(directory, out var directoryAttributes) ||
-                    (directoryAttributes & FileAttributes.Directory) == 0)
+                if (!TryGetExistingAttributes(directory, out var directoryAttributes, out diagnostic))
                 {
-                    diagnostic = $"{label} ancestor '{directory}' is not an accessible directory.";
+                    if (string.IsNullOrWhiteSpace(diagnostic))
+                        diagnostic =
+                            $"{label} ancestor '{EscapeDiagnosticText(directory)}' is not an accessible directory.";
+                    return false;
+                }
+
+                if ((directoryAttributes & FileAttributes.Directory) == 0)
+                {
+                    diagnostic =
+                        $"{label} ancestor '{EscapeDiagnosticText(directory)}' is not an accessible directory.";
                     return false;
                 }
 

--- a/WireSockUI/WireSockManager.cs
+++ b/WireSockUI/WireSockManager.cs
@@ -171,8 +171,6 @@ namespace WireSockUI
                     if (_handleTunnelDropped)
                         throw new InvalidOperationException(DroppedHandleDiagnostic);
 
-                    _logLevel = value;
-
                     // Update loglevel directly if instantiated
                     if (_handle != IntPtr.Zero)
                     {
@@ -181,6 +179,8 @@ namespace WireSockUI
                             _nativeApi.SetLogLevel(_adapterMode, _handle, value);
                         }
                     }
+
+                    _logLevel = value;
                 }
             }
         }

--- a/scripts/Verify-WgboosterContract.ps1
+++ b/scripts/Verify-WgboosterContract.ps1
@@ -7,12 +7,16 @@ $ErrorActionPreference = 'Stop'
 $sdkRootPath = (Resolve-Path -LiteralPath $SdkRoot).Path
 $headerPath = Join-Path $sdkRootPath 'include\wgbooster.h'
 $definitionPath = Join-Path $sdkRootPath 'wgbooster\wgbooster.def'
+$managedSourcePath = Join-Path $PSScriptRoot '..\WireSockUI\Native\WireguardBoosterExports.cs'
 
 if (-not (Test-Path -LiteralPath $headerPath -PathType Leaf)) {
     throw "WireSock SDK header was not found at '$headerPath'."
 }
 if (-not (Test-Path -LiteralPath $definitionPath -PathType Leaf)) {
     throw "WireSock SDK export definition was not found at '$definitionPath'."
+}
+if (-not (Test-Path -LiteralPath $managedSourcePath -PathType Leaf)) {
+    throw "WireSock UI managed SDK declarations were not found at '$managedSourcePath'."
 }
 
 $requiredExports = @(
@@ -44,6 +48,7 @@ $requiredExports = @(
 
 $definition = Get-Content -LiteralPath $definitionPath -Raw
 $header = Get-Content -LiteralPath $headerPath -Raw
+$managedSource = Get-Content -LiteralPath $managedSourcePath -Raw
 $missingExports = @($requiredExports | Where-Object {
     $definition -notmatch "(?m)^\s*$([regex]::Escape($_))(?:\s|$)"
 })
@@ -103,4 +108,25 @@ foreach ($check in $signatureChecks.GetEnumerator()) {
     }
 }
 
-Write-Host "WireSock SDK header/export contract is compatible with WireSock UI ($($requiredExports.Count) exports checked)."
+$missingManagedDeclarations = @($requiredExports | Where-Object {
+    $managedSource -notmatch "(?s)\[DllImport\(\s*`"wgbooster\.dll`"(?:(?!\)\]).)*CallingConvention\s*=\s*CallingConvention\.StdCall(?:(?!\)\]).)*\)\]\s*(?:\[return:\s*MarshalAs\([^]]+\)\]\s*)?public\s+static\s+extern\s+[^;]+\b$([regex]::Escape($_))\s*\("
+})
+if ($missingManagedDeclarations.Count -gt 0) {
+    throw "WireSock UI managed declarations are missing SDK exports: $($missingManagedDeclarations -join ', ')"
+}
+
+$managedChecks = [ordered]@{
+    'WgbLogLevel values' =
+        'enum\s+WgbLogLevel\s*\{[^}]*Error\s*=\s*0[^}]*Warning\s*=\s*1[^}]*Info\s*=\s*2[^}]*Debug\s*=\s*4[^}]*All\s*=\s*255[^}]*\}'
+    'WgbNetworkLockMode values' =
+        'enum\s+WgbNetworkLockMode\s*\{[^}]*Disabled\s*=\s*0[^}]*Enabled\s*=\s*1[^}]*\}'
+    'WgbStats packed layout' =
+        '\[StructLayout\(LayoutKind\.Sequential,\s*Pack\s*=\s*1\)\]\s*public\s+struct\s+WgbStats\s*\{\s*public\s+long\s+\w+\s*;\s*public\s+ulong\s+\w+\s*;\s*public\s+ulong\s+\w+\s*;\s*public\s+float\s+\w+\s*;\s*public\s+int\s+\w+\s*;[^}]*\}'
+}
+foreach ($check in $managedChecks.GetEnumerator()) {
+    if ($managedSource -notmatch $check.Value) {
+        throw "WireSock UI managed contract check failed for $($check.Key)."
+    }
+}
+
+Write-Host "WireSock SDK native and managed contracts are compatible with WireSock UI ($($requiredExports.Count) exports checked)."


### PR DESCRIPTION
## Summary
- replace blocking BackgroundWorker polling with cancellable, bounded native tunnel monitoring and recovery handling
- validate recursive application payload trust and process/DLL PE architecture compatibility before loading wgbooster.dll
- make profile renames transactional, preserve log-level state on native failure, and validate existing global event ACLs
- serialize CI restore, gate releases on real-SDK smoke tests, and add scheduled upstream SDK contract drift detection
- extend native/managed contract verification, focused regression coverage, and runtime documentation

## Verification
- full WireSockUI.Tests harness passed (one pre-existing symbolic-link test skipped because link creation is unavailable)
- Release x64 solution build passed with warnings treated as errors
- Release and Release UWP publishes passed for AnyCPU, x64, and ARM64
- dotnet format whitespace verification passed
- actionlint and YAML parsing passed for every workflow
- pinned and local upstream SDK contracts passed all 24 native/managed export checks at aa72bc6ab8dce8f8128f74b8a6e3167b8caaf11a
- NuGet vulnerability audit found no vulnerable packages

## Runtime note
The real wgbooster lifecycle smoke test was not run locally because this Codex process is not elevated. The release workflow now requires the protected elevated x64 and ARM64 SDK runner jobs before packaging.