### PR TITLE
ci: isolate hosted SDK cleanup exit code

### DIFF
--- a/scripts/Invoke-HostedSdkExperiment.ps1
+++ b/scripts/Invoke-HostedSdkExperiment.ps1
@@ -553,15 +553,24 @@ finally {
     Remove-HostedExperimentDirectory -Path $msiRoot
     if ($installedSdk) {
         try {
-            & $wingetPath uninstall `
-                --id $packageId `
-                --exact `
-                --source winget `
-                --silent `
-                --accept-source-agreements `
-                --disable-interactivity
-            if ($LASTEXITCODE -ne 0) {
-                Write-Warning "SDK cleanup failed with exit code $LASTEXITCODE; GitHub will discard the hosted VM."
+            $cleanupProcess = Start-Process `
+                -FilePath $wingetPath `
+                -ArgumentList @(
+                    'uninstall',
+                    '--id', $packageId,
+                    '--exact',
+                    '--source', 'winget',
+                    '--silent',
+                    '--accept-source-agreements',
+                    '--disable-interactivity'
+                ) `
+                -Wait `
+                -PassThru `
+                -NoNewWindow
+            if ($cleanupProcess.ExitCode -ne 0) {
+                Write-Warning (
+                    "SDK cleanup failed with exit code $($cleanupProcess.ExitCode); " +
+                    'GitHub will discard the hosted VM.')
             }
         }
         catch {


### PR DESCRIPTION
## Summary
- run best-effort hosted SDK package removal through `Start-Process`
- inspect the cleanup process's own exit code instead of leaking it through PowerShell's `$LASTEXITCODE`
- preserve the warning when WinGet cannot find an uninstall registration on the disposable VM

## Why
Hosted run https://github.com/wiresock/WireSockUI/actions/runs/31591854488 passed SDK installation, signature validation, WireSockUI MSI install/repair/uninstall, and all Transparent, VirtualAdapter, Kill Switch, and Amnezia lifecycle checks. The step was marked failed only after WinGet returned "No installed package found" during best-effort cleanup and left its exit code as the script's final native exit code.

## Validation
- PowerShell parser validation passed
- isolated nonzero child-process probe confirmed `Start-Process` preserves the preceding `$LASTEXITCODE`
- workflow security fixtures passed
- production workflow contracts passed
- `git diff --check` passed